### PR TITLE
LevelCode Cloud: managed-hosting backend + rename + money-path hardening

### DIFF
--- a/app/controllers/api/levelcode/v1/account_controller.rb
+++ b/app/controllers/api/levelcode/v1/account_controller.rb
@@ -1,0 +1,108 @@
+module Api
+  module Levelcode
+    module V1
+      # Account surface for the levelcode product (SPEC §3).
+      # Both actions require a valid editor access token or web session
+      # (authenticate_levelcode! is enforced by BaseController).
+      class AccountController < BaseController
+        PRODUCT = "levelcode".freeze
+
+        # GET /api/levelcode/v1/account/profile
+        def profile
+          render json: {
+            id: current_user.id,
+            email: current_user.email,
+            name: display_name,
+            plan: current_plan_name,
+            role: current_user.role
+          }, status: :ok
+        end
+
+        # GET /api/levelcode/v1/account/usage
+        def usage
+          wallet = current_wallet
+          # Show the LIVE per-period spend/usage (the same counters enforcement uses),
+          # not the async-lagged wallet columns.
+          in_used, out_used = wallet ? ::Levelcode::Metering.usage(wallet) : [ 0, 0 ]
+          spent = wallet ? ::Levelcode::Metering.spent_micros(wallet) : 0
+          budget = wallet&.budget_micros.to_i
+
+          render json: {
+            plan: current_plan_name,
+            model: ::Levelcode.gateway_model(wallet&.plan_key),
+            # Credits (M14): the DOLLAR budget is the enforced allowance; token fields are informational.
+            budget_micros: budget,
+            spent_micros: spent,
+            credits_remaining_micros: [ budget - spent, 0 ].max,
+            input_used: in_used,
+            input_cap: wallet&.input_cap.to_i,
+            output_used: out_used,
+            output_cap: wallet&.output_cap.to_i,
+            period_end: wallet&.period_end,
+            overage_policy: wallet&.overage_policy || "throttle"
+          }, status: :ok
+        end
+
+        # GET /api/levelcode/v1/account/models
+        # The plan's model roster for the editor picker + dashboard (M14 Phase 3): every entitled
+        # model with its credit multiplier, ≈ turns left on the current balance, and a `live` flag
+        # (confirmed-price models are selectable; staged ones are shown but not yet billable).
+        def models
+          wallet = current_wallet
+          budget = wallet&.budget_micros.to_i
+          spent = wallet ? ::Levelcode::Metering.spent_micros(wallet) : 0
+          remaining = [ budget - spent, 0 ].max
+
+          render json: {
+            plan: current_plan_name,
+            default_model: ::Levelcode.default_model(current_plan_key),
+            budget_micros: budget,
+            spent_micros: spent,
+            credits_remaining_micros: remaining,
+            models: ::Levelcode.roster_for(current_plan_key, remaining)
+          }, status: :ok
+        end
+
+        # GET /api/levelcode/v1/account/activity?year=YYYY
+        # GitHub-style contribution data: per-day editor usage + a per-model breakdown,
+        # from the durable usage_events ledger. `year` defaults to the current year.
+        def activity
+          year = (params[:year].presence || Time.current.year).to_i
+          render json: ::Levelcode::Activity.for_user(current_user, year: year), status: :ok
+        end
+
+        private
+
+        # Free-tier aware: a logged-in user with no paid plan gets (and sees) the
+        # FREE tier — FreeTier provisions/rolls a free wallet so the dashboard shows
+        # the free caps + gpt-oss engine instead of a blank "no plan".
+        def current_wallet
+          ::Levelcode::FreeTier.wallet_for(current_user)
+        end
+
+        def current_plan_key
+          current_wallet&.plan_key || "free"
+        end
+
+        # Friendly plan label for display (e.g. "Pro") — the Levelcode plan NAME, not the
+        # raw key ("orbits_pro"). "Free" when there's no active managed plan (BYOK).
+        def current_plan_name
+          key = current_wallet&.plan_key
+          return "Free" if key.blank? || key == "free"
+
+          ::Levelcode.plan(key)&.dig(:name) || key
+        end
+
+        # `name` is provided by the auth slice; fall back to the profile
+        # display name (every user has a profile) so this never 500s.
+        def display_name
+          if current_user.respond_to?(:name) && current_user.name.present?
+            current_user.name
+          else
+            current_user.profile&.display_name
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/levelcode/v1/admin_controller.rb
+++ b/app/controllers/api/levelcode/v1/admin_controller.rb
@@ -1,0 +1,37 @@
+module Api
+  module Levelcode
+    module V1
+      # Admin-only dashboard API. Gated on the user's `admin?` role (assigned from the Rails
+      # console: `user.update!(role: "admin")`). Authenticates like the rest of the namespace
+      # (editor bearer OR web session), then requires admin on top.
+      class AdminController < BaseController
+        before_action :require_admin!
+
+        # GET /api/levelcode/v1/admin/summary
+        def summary
+          render json: ::Levelcode::AdminReport.summary, status: :ok
+        end
+
+        # GET /api/levelcode/v1/admin/users?sort=&dir=&q=&plan=&limit=&offset=
+        def users
+          render json: ::Levelcode::AdminReport.users(
+            sort: params[:sort].presence || "input",
+            dir: params[:dir].presence || "desc",
+            q: params[:q].presence,
+            plan: params[:plan].presence,
+            limit: params.fetch(:limit, 100).to_i.clamp(1, 500),
+            offset: params[:offset].to_i.clamp(0, 1_000_000)
+          ), status: :ok
+        end
+
+        private
+
+        def require_admin!
+          return if current_levelcode_user&.admin?
+
+          render_levelcode_error("forbidden", "Admin access required", :forbidden)
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/levelcode/v1/ai_controller.rb
+++ b/app/controllers/api/levelcode/v1/ai_controller.rb
@@ -1,0 +1,283 @@
+module Api
+  module Levelcode
+    module V1
+      # POST /api/levelcode/v1/ai/chat — the gateway (SPEC §4/§5/§7).
+      #
+      # Transparent proxy of OpenRouter's OpenAI-compatible /chat/completions
+      # stream: each upstream chunk is re-emitted verbatim as an SSE `data:`
+      # line, terminated by `data: [DONE]`. The only thing we do beyond piping
+      # is (a) enforce caps before the request and (b) tee the final `usage`
+      # object into metering after the stream closes.
+      class AiController < BaseController
+        include ActionController::Live
+
+        before_action :authenticate_levelcode!
+        before_action :require_ai_scope!
+
+        PROVIDER = "openrouter".freeze
+
+        def chat
+          # Entitlement (M11): a PAID plan runs the flagship (Kimi K2.7 Code); ANY
+          # other logged-in editor user gets the FREE tier — the cheap open-weights
+          # engine (gpt-oss-120b) on a hard monthly cap. FreeTier provisions/rolls a
+          # free wallet as the metering anchor; it never touches a paid plan. (BYOK
+          # stays the free-and-private path and never reaches the gateway.)
+          wallet = ::Levelcode::FreeTier.wallet_for(current_levelcode_user)
+
+          decision = ::Levelcode::Metering.check!(wallet)
+          return render_cap_reached(wallet) if decision.blocked?
+
+          raw = chat_params
+          # Over-budget on a THROTTLE plan → fall back to the cheap open-weights engine so the user
+          # keeps working at near-zero marginal cost (M14). Otherwise honor the editor's requested
+          # model IF the plan is entitled to it (a Pro user may pick gpt-oss too), else the plan
+          # default. Entitlement stays server-side — free can never reach the flagship.
+          model =
+            if decision.throttle
+              ::Levelcode::FREE_MODEL
+            elsif raw["model"].to_s == ::Levelcode::AUTO_MODEL
+              ::Levelcode.auto_route(wallet.plan_key, raw) # cheap engine for trivial turns, else plan default
+            else
+              ::Levelcode.gateway_model(wallet.plan_key, raw["model"])
+            end
+          # Per-request output ceiling: the FREE ceiling when free OR throttled (running the cheap
+          # engine), else the higher paid ceiling — bounds a single request's spend so concurrent
+          # streams can't overshoot the dollar budget before their spend lands.
+          body = cap_output(raw, wallet, throttled: decision.throttle)
+
+          if streaming?(body)
+            stream_chat(body, wallet, model)
+          else
+            complete_chat(body, wallet, model)
+          end
+        end
+
+        private
+
+        # The editor token must carry an inference scope to use the gateway.
+        # Agent turns (tool-calling — the premium capability) require ai:agent;
+        # plain chat requires ai:chat. Whether the USER's plan may use agent is a
+        # separate entitlement check (plan-gating) — not the token scope.
+        def require_ai_scope!
+          needed = agent_turn? ? "ai:agent" : "ai:chat"
+          scopes = (levelcode_token_claims && levelcode_token_claims["scope"].to_s.split(/\s+/)) || []
+          return if scopes.include?(needed)
+
+          render_levelcode_error(
+            "insufficient_scope",
+            "This token cannot make #{agent_turn? ? 'agent' : 'chat'} requests (missing #{needed}).",
+            :forbidden
+          )
+        end
+
+        # An agent turn carries tool definitions (function calling); plain chat does not.
+        def agent_turn?
+          params[:tools].present?
+        end
+
+        # -- streaming (SSE) path -------------------------------------------
+
+        def stream_chat(body, wallet, model)
+          response.headers["Content-Type"] = "text/event-stream"
+          response.headers["Cache-Control"] = "no-cache"
+          response.headers["X-Accel-Buffering"] = "no" # disable proxy buffering
+          response.headers.delete("Content-Length")
+
+          request_id = current_request_id
+          @captured_usage = nil
+          @captured_model = nil
+
+          begin
+            result = ::Levelcode::AiRouter.call(
+              body,
+              model: model,
+              on_chunk: ->(payload) { capture_usage(payload); write_sse(payload) }
+            )
+            @captured_usage ||= result&.usage
+            @captured_model ||= result&.model
+            write_raw("data: [DONE]\n\n")
+          rescue ::Levelcode::OpenRouterAdapter::UpstreamError => e
+            Rails.logger.warn("[Api::Levelcode::V1::AiController] upstream #{e.status}: #{e.body.to_s[0, 800]}")
+            write_sse(upstream_error_json(e))
+          rescue IOError, ActionController::Live::ClientDisconnected
+            # Client hung up mid-stream; nothing more to write.
+            Rails.logger.info("[Api::Levelcode::V1::AiController] client disconnected mid-stream")
+          rescue => e
+            Rails.logger.error("[Api::Levelcode::V1::AiController] stream error: #{e.class}: #{e.message}")
+            begin
+              write_sse({ error: { message: "gateway_error", code: "gateway_error" } }.to_json)
+            rescue IOError
+              nil
+            end
+          ensure
+            # Meter whatever usage we captured — even on a mid-stream disconnect —
+            # so tokens already consumed upstream still count against caps + billing
+            # (SPEC §5). Runs exactly once (metering only records non-zero usage).
+            meter_captured!(wallet, request_id)
+            close_stream
+          end
+        end
+
+        # OpenRouter emits the final usage/model object as a chunk before [DONE].
+        # Capture it off the tee so metering survives a client disconnect.
+        def capture_usage(payload)
+          data = JSON.parse(payload)
+          @captured_usage = data["usage"] if data["usage"].present?
+          @captured_model = data["model"] if data["model"].present?
+        rescue JSON::ParserError
+          nil
+        end
+
+        def meter_captured!(wallet, request_id)
+          return if @captured_usage.blank?
+
+          meter!(
+            wallet,
+            ::Levelcode::OpenRouterAdapter::Result.new(usage: @captured_usage, model: @captured_model),
+            request_id
+          )
+        end
+
+        # -- non-streaming (JSON pass-through) path -------------------------
+
+        def complete_chat(body, wallet, model)
+          request_id = current_request_id
+          upstream = ::Levelcode::AiRouter.complete(body, model: model)
+          meter!(wallet, ::Levelcode::OpenRouterAdapter::Result.new(usage: upstream["usage"], model: upstream["model"]), request_id)
+          render json: upstream, status: :ok
+        rescue ::Levelcode::OpenRouterAdapter::UpstreamError => e
+          Rails.logger.warn("[Api::Levelcode::V1::AiController] upstream #{e.status}: #{e.body.to_s[0, 800]}")
+          render json: { error: { code: "upstream_error", message: upstream_message(e) } },
+                 status: :bad_gateway
+        end
+
+        # -- metering tee ----------------------------------------------------
+
+        def meter!(wallet, result, request_id)
+          usage = result&.usage
+          return if usage.blank?
+
+          input_tokens = (usage["prompt_tokens"] || usage[:prompt_tokens]).to_i
+          output_tokens = (usage["completion_tokens"] || usage[:completion_tokens]).to_i
+          cached = cached_tokens(usage)
+          model = result.model
+          cost_micros = ::Levelcode.cost_micros(model, input_tokens, output_tokens, cached)
+
+          # Burn the DOLLAR budget by this request's cost (M14) + keep the token counters for display.
+          ::Levelcode::Metering.record(wallet, input_tokens, output_tokens, cost_micros)
+
+          RecordUsageJob.perform_async(
+            current_levelcode_user.id,
+            request_id,
+            model,
+            PROVIDER,
+            input_tokens,
+            output_tokens,
+            cached,
+            cost_micros,
+            wallet.period_end.to_i # period at enqueue — scopes the durable counter to the right period
+          )
+        rescue => e
+          Rails.logger.error("[Api::Levelcode::V1::AiController] metering tee failed: #{e.class}: #{e.message}")
+        end
+
+        def cached_tokens(usage)
+          details = usage["prompt_tokens_details"] || usage[:prompt_tokens_details] || {}
+          (details["cached_tokens"] || details[:cached_tokens]).to_i
+        end
+
+        # -- helpers ---------------------------------------------------------
+
+        def streaming?(body)
+          val = body["stream"]
+          val = body[:stream] if val.nil?
+          ActiveModel::Type::Boolean.new.cast(val)
+        end
+
+        def write_sse(payload)
+          write_raw("data: #{payload}\n\n")
+        end
+
+        def write_raw(data)
+          response.stream.write(data)
+        end
+
+        def close_stream
+          response.stream.close
+        rescue IOError
+          nil
+        end
+
+        def render_cap_reached(wallet)
+          free = wallet.plan_key.to_s == ::Levelcode::FREE_PLAN_KEY
+          render json: {
+            error: {
+              code: "cap_reached",
+              message: free ?
+                "You've hit your free monthly limit. Upgrade to Pro for Kimi K2.7 Code and higher caps." :
+                "Usage cap reached for the current billing period.",
+              # The editor surfaces this as an "Upgrade" CTA on the free tier.
+              upgrade_url: (free ? "#{site_origin}/ai/pricing" : nil),
+              topup_url: topup_url_for(wallet)
+            }
+          }, status: :payment_required
+        end
+
+        def topup_url_for(wallet)
+          return nil unless wallet.overage_policy == "topup"
+
+          "#{site_origin}/ai/account"
+        end
+
+        def site_origin
+          ENV["SITE_ORIGIN"].presence || "https://levelcode.ai"
+        end
+
+        def upstream_error_json(error)
+          { error: { code: "upstream_error", status: error.status, message: upstream_message(error) } }.to_json
+        end
+
+        # Surface the REAL upstream reason (the OpenRouter error message) instead of
+        # a generic label — e.g. "moonshotai/kimi-k2.6 is not a valid model ID" or
+        # "No auth credentials found" — so failures are diagnosable in the editor.
+        def upstream_message(error)
+          parsed = JSON.parse(error.body.to_s)
+          msg = parsed.dig("error", "message") || parsed["message"]
+          msg.presence || "Upstream returned #{error.status}"
+        rescue JSON::ParserError, TypeError
+          "Upstream returned #{error.status}"
+        end
+
+        def current_request_id
+          request.request_id || SecureRandom.uuid
+        end
+
+        # Passes the OpenAI chat body through untouched. We permit the whole
+        # payload because this is a transparent proxy — we must not drop fields
+        # the editor/upstream rely on.
+        def chat_params
+          params.permit!.to_h.except("controller", "action", "ai", "format")
+        end
+
+        # Per-request output ceiling (M14). Enforcement is per-request-start, so without a per-request
+        # bound a burst of concurrent streams could overshoot the dollar budget before their spend
+        # lands. Clamps an over-large client value AND sets a default when omitted. The FREE ceiling
+        # applies to free wallets OR the throttle path (both run the cheap engine); paid requests get
+        # the higher paid ceiling.
+        def cap_output(body, wallet, throttled: false)
+          free_ceiling = throttled || wallet.plan_key.to_s == ::Levelcode::FREE_PLAN_KEY
+          limit = free_ceiling ? ::Levelcode::FREE_MAX_TOKENS : ::Levelcode::PAID_MAX_TOKENS
+
+          out = body.dup
+          fields = %w[max_tokens max_completion_tokens].select { |f| out[f].present? }
+          if fields.empty?
+            out["max_tokens"] = limit
+          else
+            fields.each { |f| out[f] = [ out[f].to_i, limit ].min }
+          end
+          out
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/levelcode/v1/ai_controller.rb
+++ b/app/controllers/api/levelcode/v1/ai_controller.rb
@@ -45,10 +45,26 @@ module Api
           # streams can't overshoot the dollar budget before their spend lands.
           body = cap_output(raw, wallet, throttled: decision.throttle)
 
+          # Reserve this request's worst-case cost against the dollar budget BEFORE it runs, so a burst
+          # of concurrent streams can't collectively overshoot the budget in the window before their
+          # spend lands (spend is only recorded after each stream closes). Skip on the throttle path —
+          # it runs the near-free open-weights engine intentionally and isn't budget-metered. A
+          # reservation that would exceed the budget → 402 (same surface as a cap hit).
+          reservation = 0
+          estimate = 0
+          unless decision.throttle
+            free_tier = wallet.plan_key.to_s == ::Levelcode::FREE_PLAN_KEY
+            estimate = ::Levelcode.estimate_cost_micros(model, body, free_tier: free_tier)
+            res = ::Levelcode::Metering.reserve!(wallet, estimate)
+            return render_cap_reached(wallet) unless res.ok
+
+            reservation = res.amount
+          end
+
           if streaming?(body)
-            stream_chat(body, wallet, model)
+            stream_chat(body, wallet, model, reservation, estimate)
           else
-            complete_chat(body, wallet, model)
+            complete_chat(body, wallet, model, reservation)
           end
         end
 
@@ -77,7 +93,7 @@ module Api
 
         # -- streaming (SSE) path -------------------------------------------
 
-        def stream_chat(body, wallet, model)
+        def stream_chat(body, wallet, model, reservation, estimate)
           response.headers["Content-Type"] = "text/event-stream"
           response.headers["Cache-Control"] = "no-cache"
           response.headers["X-Accel-Buffering"] = "no" # disable proxy buffering
@@ -86,6 +102,7 @@ module Api
           request_id = current_request_id
           @captured_usage = nil
           @captured_model = nil
+          @streamed_content = false
 
           begin
             result = ::Levelcode::AiRouter.call(
@@ -110,66 +127,124 @@ module Api
               nil
             end
           ensure
-            # Meter whatever usage we captured — even on a mid-stream disconnect —
-            # so tokens already consumed upstream still count against caps + billing
-            # (SPEC §5). Runs exactly once (metering only records non-zero usage).
-            meter_captured!(wallet, request_id)
+            # Settle the reservation + meter the turn exactly once, even on a mid-stream disconnect
+            # (SPEC §5), so tokens already consumed upstream still count and the reservation is never
+            # stranded.
+            finalize_stream!(wallet, request_id, reservation, model, estimate)
             close_stream
           end
         end
 
-        # OpenRouter emits the final usage/model object as a chunk before [DONE].
-        # Capture it off the tee so metering survives a client disconnect.
+        # OpenRouter emits the final usage/model object as a chunk before [DONE]. Capture it off the tee
+        # so metering survives a client disconnect, and note whether any CONTENT was streamed (so a
+        # hang-up before the final usage chunk can be charged rather than billed $0).
         def capture_usage(payload)
           data = JSON.parse(payload)
           @captured_usage = data["usage"] if data["usage"].present?
           @captured_model = data["model"] if data["model"].present?
+          @streamed_content = true if streamed_content?(data)
         rescue JSON::ParserError
           nil
         end
 
-        def meter_captured!(wallet, request_id)
-          return if @captured_usage.blank?
+        def streamed_content?(data)
+          Array(data["choices"]).any? do |c|
+            c.is_a?(Hash) && (c.dig("delta", "content").to_s != "" || c.dig("message", "content").to_s != "")
+          end
+        end
 
-          meter!(
-            wallet,
-            ::Levelcode::OpenRouterAdapter::Result.new(usage: @captured_usage, model: @captured_model),
-            request_id
+        # Settle the reservation + meter the turn exactly once, whatever happened to the stream:
+        #  • usage captured  → bill the REAL cost (and release the over-reserved remainder).
+        #  • no usage but content WAS streamed (client hung up before the final usage chunk) → tokens
+        #    were produced upstream, so don't zero-bill: charge the reserved estimate + write a
+        #    synthetic ledger row so the durable column matches the hot counter.
+        #  • no usage and nothing streamed (pure upstream error / instant disconnect) → release it.
+        def finalize_stream!(wallet, request_id, reservation, model, estimate)
+          if @captured_usage.present?
+            meter!(
+              wallet,
+              ::Levelcode::OpenRouterAdapter::Result.new(usage: @captured_usage, model: @captured_model),
+              request_id, reservation, model
+            )
+          elsif @streamed_content
+            # Tokens were produced upstream but the usage chunk never arrived (client hung up). Charge
+            # the reserved estimate; if the reservation failed OPEN (amount 0 on a Redis blip at
+            # admission), fall back to a fresh estimate so a disconnect-after-output is never billed $0.
+            charge = reservation.to_i.positive? ? reservation.to_i : estimate.to_i
+            if charge.positive?
+              charge_reservation!(wallet, request_id, reservation, charge, model)
+            else
+              ::Levelcode::Metering.settle!(wallet, reservation, 0, 0, 0)
+            end
+          else
+            ::Levelcode::Metering.settle!(wallet, reservation, 0, 0, 0) # release the reservation
+          end
+        rescue => e
+          Rails.logger.error("[Api::Levelcode::V1::AiController] finalize failed: #{e.class}: #{e.message}")
+        end
+
+        # Client disconnected mid-stream after tokens were produced but before the usage chunk: bill
+        # `charge` (the standing reservation, or a fresh estimate if the reservation failed open) and
+        # write a synthetic ledger row so durable spend matches the hot counter. `reservation` is what's
+        # already on the hot counter, so settle! reconciles it to `charge` (delta = charge − reservation).
+        def charge_reservation!(wallet, request_id, reservation, charge, billing_model)
+          ::Levelcode::Metering.settle!(wallet, reservation, 0, 0, charge)
+          RecordUsageJob.perform_async(
+            current_levelcode_user.id, request_id, billing_model, PROVIDER,
+            0, 0, 0, charge.to_i, wallet.period_end.to_i
           )
         end
 
         # -- non-streaming (JSON pass-through) path -------------------------
 
-        def complete_chat(body, wallet, model)
+        def complete_chat(body, wallet, model, reservation)
           request_id = current_request_id
+          settled = false
           upstream = ::Levelcode::AiRouter.complete(body, model: model)
-          meter!(wallet, ::Levelcode::OpenRouterAdapter::Result.new(usage: upstream["usage"], model: upstream["model"]), request_id)
+          meter!(wallet, ::Levelcode::OpenRouterAdapter::Result.new(usage: upstream["usage"], model: upstream["model"]), request_id, reservation, model)
+          settled = true # meter! has reconciled/released the reservation; don't touch it again below
           render json: upstream, status: :ok
         rescue ::Levelcode::OpenRouterAdapter::UpstreamError => e
+          ::Levelcode::Metering.settle!(wallet, reservation, 0, 0, 0) unless settled # no generation → release
           Rails.logger.warn("[Api::Levelcode::V1::AiController] upstream #{e.status}: #{e.body.to_s[0, 800]}")
           render json: { error: { code: "upstream_error", message: upstream_message(e) } },
                  status: :bad_gateway
+        rescue => e
+          # Any OTHER failure (timeout, connection reset, malformed upstream JSON) before meter! settled
+          # would STRAND the reservation (spend over-counted) — release it. `settled` guards against a
+          # double-release if the failure happened after meter! already reconciled.
+          ::Levelcode::Metering.settle!(wallet, reservation, 0, 0, 0) unless settled
+          Rails.logger.error("[Api::Levelcode::V1::AiController] complete error: #{e.class}: #{e.message}")
+          render json: { error: { code: "gateway_error", message: "gateway_error" } }, status: :bad_gateway
         end
 
         # -- metering tee ----------------------------------------------------
 
-        def meter!(wallet, result, request_id)
+        # Reconcile the reservation to the real spend + write the durable ledger row. `billing_model` is
+        # the ROUTED catalog model (what we price/entitle), NOT result.model — the upstream string is
+        # often a dated snapshot ("…-20260528") that's absent from the catalog and would fall back to
+        # the cheapest rate, under-billing pricier models. The ledger still RECORDS the served id.
+        def meter!(wallet, result, request_id, reservation, billing_model)
           usage = result&.usage
-          return if usage.blank?
+          usage = nil unless usage.is_a?(Hash) # a non-Hash usage (malformed upstream) must not raise below
+          if usage.blank?
+            ::Levelcode::Metering.settle!(wallet, reservation, 0, 0, 0) # nothing to bill → release
+            return
+          end
 
           input_tokens = (usage["prompt_tokens"] || usage[:prompt_tokens]).to_i
           output_tokens = (usage["completion_tokens"] || usage[:completion_tokens]).to_i
           cached = cached_tokens(usage)
-          model = result.model
-          cost_micros = ::Levelcode.cost_micros(model, input_tokens, output_tokens, cached)
+          cost_micros = ::Levelcode.cost_micros(billing_model, input_tokens, output_tokens, cached)
+          ledger_model = result.model.presence || billing_model
 
-          # Burn the DOLLAR budget by this request's cost (M14) + keep the token counters for display.
-          ::Levelcode::Metering.record(wallet, input_tokens, output_tokens, cost_micros)
+          # Reconcile the up-front reservation to the actual cost (M14) + keep the token counters.
+          ::Levelcode::Metering.settle!(wallet, reservation, input_tokens, output_tokens, cost_micros)
 
           RecordUsageJob.perform_async(
             current_levelcode_user.id,
             request_id,
-            model,
+            ledger_model,
             PROVIDER,
             input_tokens,
             output_tokens,
@@ -248,8 +323,12 @@ module Api
           "Upstream returned #{error.status}"
         end
 
+        # Mint a fresh SERVER-side idempotency/billing id per turn. Deriving it from request.request_id
+        # would trust the client-controlled X-Request-Id header — a client could reuse one id across
+        # turns and collapse them onto a single durable ledger row (spend under-counts, a real bypass
+        # once Redis is cold). request.request_id stays for log correlation only.
         def current_request_id
-          request.request_id || SecureRandom.uuid
+          SecureRandom.uuid
         end
 
         # Passes the OpenAI chat body through untouched. We permit the whole

--- a/app/controllers/api/levelcode/v1/auth_controller.rb
+++ b/app/controllers/api/levelcode/v1/auth_controller.rb
@@ -1,0 +1,315 @@
+# frozen_string_literal: true
+
+require "uri"
+require "cgi"
+
+module Api
+  module Levelcode
+    module V1
+      # Auth surface for the LevelCode editor + levelcode.ai site (SPEC §2, §3).
+      #
+      # Browser flows (`oauth`, `login`, `signup`) authenticate the user and then,
+      # when an editor `redirect_uri` is present, 302 back to it. Default hardened
+      # path carries `?code=<one_time_code>` (PKCE S256, TTL 60s, single-use); a
+      # `?token=<access>&refresh=…` fallback is also built (SPEC §2.1 — "both paths
+      # built, code is default").
+      #
+      # Machine flows (`exchange`, `refresh`, `signout`) return JSON tokens.
+      class AuthController < BaseController
+        # These are all public / self-authenticating except signout + web_handoff
+        # (both require a valid editor token).
+        skip_before_action :authenticate_levelcode!, except: [ :signout, :web_handoff ]
+        skip_before_action :enforce_abuse_caps!
+
+        # POST /api/levelcode/v1/auth/callback  (levelcode.ai server -> backend)
+        # Service-token authed. The site has completed the provider `authorize`
+        # step and forwards the provider `code` (+ its own PKCE verifier + the
+        # exact redirect_uri it used for authorize, so the token exchange matches).
+        # We exchange the code, find/create the user, and return either a one-time
+        # editor `code` (mode:"editor") or access/refresh + session (mode:"web").
+        # Body: { provider, code, verifier, redirect_uri, mode, code_challenge? }
+        def callback
+          return unless verify_service_token!
+
+          user =
+            case params[:provider].to_s
+            when "github"
+              ::Levelcode::ProviderOAuth.github_user(code: params[:code], redirect_uri: params[:redirect_uri])
+            when "google"
+              ::Levelcode::ProviderOAuth.google_user(
+                code: params[:code],
+                redirect_uri: params[:redirect_uri],
+                verifier: params[:verifier]
+              )
+            else
+              return render_levelcode_error("invalid_provider", "Unknown provider", :bad_request)
+            end
+
+          unless user&.persisted?
+            return render_levelcode_error("unauthorized", "OAuth authentication failed", :unauthorized)
+          end
+
+          render_mint_result(user)
+        end
+
+        # POST /api/levelcode/v1/auth/email/request  (levelcode.ai server -> backend)
+        # Passwordless sign-in, step 1: email a 6-digit code. Always returns 200
+        # (never reveals whether the address exists — any email can sign up on
+        # verify). Service-token authed; the site adds a per-IP cap on top.
+        def email_request
+          return unless verify_service_token!
+
+          email = params[:email].to_s.strip.downcase
+          unless valid_email?(email)
+            return render_levelcode_error("invalid_email", "A valid email is required", :unprocessable_content)
+          end
+
+          begin
+            code = ::Levelcode::EmailCode.issue(email)
+            # deliver_now (not _later): send immediately and keep the plaintext code
+            # out of the Sidekiq/Redis job queue. raise_delivery_errors surfaces SMTP failures.
+            LevelcodeAuthMailer.login_code(email, code).deliver_now
+          rescue ::Levelcode::EmailCode::RateLimited
+            # A code was just sent and is still valid — succeed silently (no resend spam).
+            Rails.logger.info("[Levelcode email OTP] resend throttled")
+          rescue StandardError => e
+            # Delivery failed: drop the just-issued code + resend throttle so the
+            # user can request another immediately (they never got this one).
+            ::Levelcode::EmailCode.clear(email)
+            Rails.logger.error("[Levelcode email OTP] issue failed: #{e.class}: #{e.message}")
+            return render_levelcode_error("email_failed", "Could not send the code. Please try again.", :bad_gateway)
+          end
+
+          render json: { sent: true }, status: :ok
+        end
+
+        # POST /api/levelcode/v1/auth/email/verify  (levelcode.ai server -> backend)
+        # Passwordless sign-in, step 2. Body: { email, code, redirect_uri?, mode?, code_challenge? }.
+        def email_verify
+          return unless verify_service_token!
+
+          email = params[:email].to_s.strip.downcase
+          unless ::Levelcode::EmailCode.verify(email, params[:code])
+            return render_levelcode_error("invalid_code", "That code is invalid or has expired", :unauthorized)
+          end
+
+          user = user_from_email(email)
+          unless user&.persisted?
+            return render_levelcode_error("account_error", "Could not sign you in", :unprocessable_content)
+          end
+
+          render_mint_result(user)
+        end
+
+        # GET/POST /api/levelcode/v1/auth/login  (browser)
+        def login
+          user = User.find_for_database_authentication(email: login_params[:email].to_s.downcase)
+
+          unless user&.valid_password?(login_params[:password])
+            log_auth(kind: "login", outcome: "failure", email: login_params[:email], reason: "invalid_credentials")
+            return render_levelcode_error("invalid_credentials", "Invalid email or password", :unauthorized)
+          end
+
+          log_auth(kind: "login", outcome: "success", user: user)
+          touch_access!(user)
+          deliver_browser_result(user)
+        end
+
+        # POST /api/levelcode/v1/auth/signup  (browser)
+        def signup
+          user = User.new(
+            email: signup_params[:email].to_s.downcase,
+            password: signup_params[:password],
+            terms_accepted: ActiveModel::Type::Boolean.new.cast(signup_params[:terms])
+          )
+
+          if user.save
+            deliver_browser_result(user)
+          else
+            render_levelcode_error(
+              "signup_failed",
+              user.errors.full_messages.to_sentence.presence || "Could not create account",
+              :unprocessable_content
+            )
+          end
+        end
+
+        # POST /api/levelcode/v1/auth/exchange  (editor, hardened PKCE)
+        # Body: { code, verifier } -> { access, refresh, profile }
+        def exchange
+          user = ::Levelcode::OneTimeCode.redeem(params[:code], params[:verifier])
+          log_auth(kind: "exchange", outcome: "success", user: user)
+          touch_access!(user)
+          render json: token_bundle(user).merge(profile: profile_for(user)), status: :ok
+        rescue ::Levelcode::OneTimeCode::InvalidVerifier => e
+          log_auth(kind: "exchange", outcome: "failure", reason: "invalid_verifier")
+          render_levelcode_error("invalid_verifier", e.message, :unauthorized)
+        rescue ::Levelcode::OneTimeCode::Error => e
+          log_auth(kind: "exchange", outcome: "failure", reason: "invalid_code")
+          render_levelcode_error("invalid_code", e.message, :unauthorized)
+        end
+
+        # POST /api/levelcode/v1/auth/refresh  (editor)
+        # Body: { refresh } -> { access }
+        def refresh
+          claims = ::Levelcode::EditorToken.verify(params[:refresh], scope: "refresh")
+          user = User.find_by(id: claims["sub"])
+          return render_levelcode_error("unauthorized", "User not found", :unauthorized) unless user
+
+          render json: { access: ::Levelcode::EditorToken.mint_access(user) }, status: :ok
+        rescue ::Levelcode::EditorToken::InvalidToken => e
+          render_levelcode_error("invalid_refresh", e.message, :unauthorized)
+        end
+
+        # POST /api/levelcode/v1/auth/signout  (editor, bearer)
+        # Revokes the presented access token's jti.
+        def signout
+          claims = levelcode_token_claims
+          ::Levelcode::EditorToken.revoke!(claims["jti"]) if claims
+
+          render json: { ok: true }, status: :ok
+        end
+
+        # POST /api/levelcode/v1/auth/web_handoff  (editor, bearer)
+        # Hand the editor's authenticated identity to the browser: mint a single-use,
+        # 60s one-time code and return the URL that redeems it into a Devise web session
+        # and lands on /ai/account — so "Manage account" from the editor doesn't force a
+        # second browser sign-in. Only a holder of THIS user's editor token can mint it
+        # (the action is authed); the code is unbound (redeemed server-side at
+        # /ai/auth/handoff), single-use, and short-lived.
+        def web_handoff
+          code = ::Levelcode::OneTimeCode.issue(current_levelcode_user)
+          render json: { url: "#{request.base_url}/ai/auth/handoff?code=#{CGI.escape(code)}" }, status: :ok
+        end
+
+        private
+
+        # --- Browser result delivery (SPEC §2.1) --------------------------------
+
+        # If the caller supplied an editor `redirect_uri`, 302 to it carrying
+        # either a one-time `code` (default, hardened) or the `token`/`refresh`
+        # pair (fallback). Otherwise return the token bundle + profile as JSON.
+        def deliver_browser_result(user)
+          uri = safe_redirect_uri(params[:redirect_uri])
+
+          if uri
+            redirect_to build_callback_url(uri, user), allow_other_host: true
+          else
+            render json: token_bundle(user).merge(profile: profile_for(user)), status: :ok
+          end
+        end
+
+        def build_callback_url(uri, user)
+          query = existing_query(uri)
+          # Always hand back a single-use code (never raw tokens in the URL, which
+          # leak into browser history / Referer / proxy logs). The editor redeems
+          # it at /auth/exchange. (SPEC §2.1; the client-selectable token_fallback
+          # was removed — see the review's auth findings.)
+          query["code"] = ::Levelcode::OneTimeCode.issue(user, params[:code_challenge])
+          uri.query = URI.encode_www_form(query)
+          uri.to_s
+        end
+
+        def existing_query(uri)
+          uri.query.present? ? Hash[URI.decode_www_form(uri.query)] : {}
+        end
+
+        # Allow ONLY the frozen editor deep-link callback or the levelcode.ai origin.
+        # A bare scheme check is an open redirect: build_callback_url appends the
+        # one-time code (and, previously, raw tokens) to the query, so any allowed
+        # host receives credentials. Pin exact host+path.
+        def safe_redirect_uri(raw)
+          return nil if raw.blank?
+
+          uri = URI.parse(raw)
+          if uri.scheme == "atom-plus-plus" && uri.host == "levelcode.atom-ai" && uri.path == "/auth/callback"
+            return uri
+          end
+
+          site_host = URI(ENV["SITE_ORIGIN"].presence || "https://levelcode.ai").host
+          return uri if uri.scheme == "https" && uri.host == site_host
+
+          nil
+        rescue URI::InvalidURIError
+          nil
+        end
+
+        # --- Token / profile shaping -------------------------------------------
+
+        # Shared editor-vs-web result for the mint endpoints (callback, email_verify).
+        # Editor gets a one-time handoff code (redeemed at /auth/exchange, bound to
+        # the editor's PKCE challenge); web gets access/refresh + a session token.
+        def render_mint_result(user)
+          if params[:mode].to_s == "editor"
+            code = ::Levelcode::OneTimeCode.issue(user, params[:code_challenge])
+            render json: { code: code, profile: profile_for(user) }, status: :ok
+          else
+            # Web session: a long-lived, account-scoped token for the levelcode.ai
+            # cookie. Do NOT hand the web the editor's gateway (ai:*) access token.
+            render json: { session: ::Levelcode::EditorToken.mint_session(user), profile: profile_for(user) }, status: :ok
+          end
+        end
+
+        # Passwordless find-or-create (email OTP). New users get a random password
+        # (Devise validatable requires one; it is never used — sign-in is OTP-only).
+        def user_from_email(email)
+          User.find_by(email: email) || User.create(
+            email: email,
+            password: Devise.friendly_token[0, 32],
+            terms_accepted: true
+          )
+        end
+
+        def valid_email?(email)
+          email.present? && email.match?(URI::MailTo::EMAIL_REGEXP)
+        end
+
+        def token_bundle(user)
+          {
+            access: ::Levelcode::EditorToken.mint_access(user),
+            refresh: ::Levelcode::EditorToken.mint_refresh(user)
+          }
+        end
+
+        def profile_for(user)
+          {
+            name: user_display_name(user),
+            email: user.email,
+            plan: user_plan_key(user)
+          }
+        end
+
+        def user_display_name(user)
+          return user.name if user.respond_to?(:name) && user.name.present?
+
+          user.email.to_s.split("@").first
+        end
+
+        # The LevelCode Cloud (Levelcode) plan for the editor profile — e.g. "Pro" — read
+        # from the levelcode CreditWallet, NOT user.plan (the link-shortener
+        # subscription, e.g. "Influencer", which is a different product entirely).
+        def user_plan_key(user)
+          key = CreditWallet.find_by(user: user, product: "levelcode")&.plan_key
+          return nil if key.blank? || key == "free"
+
+          ::Levelcode.plan(key)&.dig(:name) || key
+        end
+
+        # GitHub + Google server-side OAuth code-exchange (and the verified-email /
+        # id_token security posture) now live in ::Levelcode::ProviderOAuth so the
+        # Rails-served web account surface shares one hardened implementation.
+        # `callback` delegates to ProviderOAuth.{github,google}_user directly.
+
+        # --- Strong params ------------------------------------------------------
+
+        def login_params
+          params.permit(:email, :password)
+        end
+
+        def signup_params
+          params.permit(:email, :password, :terms)
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/levelcode/v1/auth_controller.rb
+++ b/app/controllers/api/levelcode/v1/auth_controller.rb
@@ -222,7 +222,10 @@ module Api
           return nil if raw.blank?
 
           uri = URI.parse(raw)
-          if uri.scheme == "atom-plus-plus" && uri.host == "levelcode.atom-ai" && uri.path == "/auth/callback"
+          # Editor deep-link: host = extension id (levelcode.levelcode-ai), path pinned. Accept the
+          # current `levelcode` scheme and the legacy `atom-plus-plus` (pre-rename builds) during the
+          # transition; host + path stay pinned so this can't become an open redirect.
+          if %w[levelcode atom-plus-plus].include?(uri.scheme) && uri.host == "levelcode.levelcode-ai" && uri.path == "/auth/callback"
             return uri
           end
 

--- a/app/controllers/api/levelcode/v1/base_controller.rb
+++ b/app/controllers/api/levelcode/v1/base_controller.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+module Api
+  module Levelcode
+    module V1
+      # Base controller for the isolated LevelCode Cloud API (SPEC §3). Separate from
+      # the link-shortener `Api::V1::*` stack: pure JSON, no CSRF/session cookies of
+      # its own, HS256 editor tokens instead of the browser devise-jwt.
+      #
+      # `authenticate_levelcode!` accepts EITHER:
+      #   - `Authorization: Bearer <editor access JWT>` — verified via
+      #     ::Levelcode::EditorToken (sig + exp + scope + jti-not-revoked), OR
+      #   - the levelcode.ai web session cookie — i.e. an already-signed-in Devise
+      #     user (warden), used by `/account` and `/pricing` server calls.
+      class BaseController < ActionController::API
+        include ActionController::Cookies
+        include Devise::Controllers::Helpers
+        include AccessTracking
+
+        before_action :authenticate_levelcode!
+        before_action :enforce_abuse_caps!
+
+        rescue_from ::Levelcode::EditorToken::InvalidToken do |e|
+          render_levelcode_error("unauthorized", e.message, :unauthorized)
+        end
+
+        # The authenticated user for this request, resolved from either the editor
+        # bearer token or the web session. Memoized.
+        def current_levelcode_user
+          @current_levelcode_user
+        end
+
+        # Alias so controllers written against the app-wide `current_user`
+        # convention (the billing/account controllers mirror Api::V1) resolve the
+        # levelcode-authenticated user. Overrides Devise's helper within this
+        # namespace, which is intentional (this API is token-first, not session).
+        def current_user
+          current_levelcode_user
+        end
+
+        private
+
+        # Verify the levelcode.ai server->backend service token (SPEC §1, §2). Used by
+        # the trusted mint endpoint (auth#callback), which runs before any user
+        # exists. Constant-time compare; renders 403 and returns false on mismatch.
+        def verify_service_token!
+          expected = ENV["LEVELCODE_SITE_SERVICE_TOKEN"].to_s
+          presented = request.headers["X-Levelcode-Service-Token"].to_s
+          if expected.present? && ActiveSupport::SecurityUtils.secure_compare(presented, expected)
+            return true
+          end
+
+          render_levelcode_error("forbidden", "Invalid service token", :forbidden)
+          false
+        end
+
+        # Primary gate. Sets @current_levelcode_user or renders 401.
+        def authenticate_levelcode!
+          @current_levelcode_user = user_from_bearer || user_from_session
+
+          if @current_levelcode_user
+            touch_access!(@current_levelcode_user) # denormalize last country/seen (throttled)
+            return
+          end
+
+          render_levelcode_error("unauthorized", "Authentication required", :unauthorized)
+        end
+
+        # --- Bearer (editor access token) ---------------------------------------
+
+        def user_from_bearer
+          token = bearer_token
+          return nil if token.blank?
+
+          claims = ::Levelcode::EditorToken.verify(token, scope: "account:read")
+          User.find_by(id: claims["sub"])
+        end
+
+        def bearer_token
+          header = request.headers["Authorization"].to_s
+          return nil unless header.start_with?("Bearer ")
+
+          header.split(" ", 2).last&.strip
+        end
+
+        # Expose the verified claims (scope checks, jti for signout) to actions.
+        def levelcode_token_claims
+          return @levelcode_token_claims if defined?(@levelcode_token_claims)
+
+          token = bearer_token
+          @levelcode_token_claims = token.present? ? ::Levelcode::EditorToken.verify(token) : nil
+        rescue ::Levelcode::EditorToken::InvalidToken
+          @levelcode_token_claims = nil
+        end
+
+        # --- Web session cookie -------------------------------------------------
+
+        def user_from_session
+          # warden is populated by Devise's middleware from the session cookie.
+          warden = request.env["warden"]
+          warden&.authenticate(scope: :user)
+        end
+
+        # --- Abuse caps (SPEC §5) ----------------------------------------------
+
+        # Thin stub: per-user RPM / daily token caps via Redis. Full enforcement
+        # (concurrency, configurable limits, StatsD) lands with the metering slice;
+        # this hook keeps the wiring and fails open when Redis is unavailable.
+        def enforce_abuse_caps!
+          return unless current_levelcode_user
+          return unless abuse_redis
+
+          user_id = current_levelcode_user.id
+          rpm_key = "levelcode:rpm:#{user_id}:#{Time.now.to_i / 60}"
+          count = abuse_redis.incr(rpm_key)
+          abuse_redis.expire(rpm_key, 60) if count == 1
+
+          if count > abuse_rpm_limit
+            render_levelcode_error(
+              "rate_limited",
+              "Too many requests. Please slow down.",
+              :too_many_requests
+            )
+          end
+        rescue StandardError => e
+          # Fail open: never let a Redis hiccup take the API down.
+          Rails.logger.warn("Levelcode abuse-cap check failed: #{e.message}")
+          nil
+        end
+
+        def abuse_rpm_limit
+          (ENV["LEVELCODE_RPM_LIMIT"].presence || 120).to_i
+        end
+
+        def abuse_redis
+          defined?($redis) ? $redis : nil
+        end
+
+        # --- Error helper (SPEC §3 envelope) -----------------------------------
+
+        def render_levelcode_error(code, message, status)
+          render json: { error: { code: code, message: message } }, status: status
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/levelcode/v1/billings_controller.rb
+++ b/app/controllers/api/levelcode/v1/billings_controller.rb
@@ -1,0 +1,30 @@
+module Api
+  module Levelcode
+    module V1
+      # Stripe billing portal for the levelcode product.
+      # Mirrors Api::V1::BillingsController, but returns the customer to the
+      # site account page (SITE_ORIGIN/account) after they manage billing.
+      class BillingsController < BaseController
+        # POST /api/levelcode/v1/billings
+        def create
+          begin
+            session = Stripe::BillingPortal::Session.create({
+              customer: current_user.stripe_id,
+              return_url: "#{site_origin}/account"
+            })
+          rescue => e
+            return render json: { error: { code: "stripe_error", message: e.message } }, status: :bad_request
+          end
+
+          render json: { url: session.url }, status: :ok
+        end
+
+        private
+
+        def site_origin
+          ENV["SITE_ORIGIN"] || "https://levelcode.ai"
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/levelcode/v1/checkouts_controller.rb
+++ b/app/controllers/api/levelcode/v1/checkouts_controller.rb
@@ -1,0 +1,105 @@
+module Api
+  module Levelcode
+    module V1
+      # Stripe Checkout / plan-change for the `levelcode` product.
+      # Mirrors Api::V1::CheckoutsController's checkout + proration pattern, but
+      # scoped to the levelcode product subscription and redirecting to the site
+      # account page (SITE_ORIGIN/account) rather than the link-shortener routes.
+      class CheckoutsController < BaseController
+        PRODUCT = "levelcode".freeze
+
+        # POST /api/levelcode/v1/checkouts
+        def create
+          lookup_key = params["lookup_key"]
+          prices = Stripe::Price.list(
+            lookup_keys: [ lookup_key ],
+            expand: [ "data.product" ]
+          )
+
+          new_price = prices.data[0]
+          return render json: { error: { code: "plan_not_found", message: "Plan not found for lookup key: #{lookup_key}" } }, status: :not_found unless new_price
+
+          subscription = current_user.subscriptions.find_by(product: PRODUCT)
+          active_stripe_sub = subscription&.subscription_id
+
+          # ── User already has an active levelcode subscription → upgrade / downgrade ──
+          if active_stripe_sub.present? && subscription&.status&.in?(%w[active trialing past_due])
+            handle_plan_change(subscription, active_stripe_sub, new_price)
+          else
+            # ── First purchase: create a Checkout Session ──
+            create_checkout_session(new_price)
+          end
+        rescue Stripe::StripeError => e
+          render json: { error: { code: "stripe_error", message: e.message } }, status: :bad_request
+        end
+
+        private
+
+        def handle_plan_change(subscription, active_stripe_sub, new_price)
+          stripe_sub = Stripe::Subscription.retrieve(active_stripe_sub)
+          current_price_id = stripe_sub.items.data[0].price.id
+
+          # ── Block same-plan purchase ──
+          if current_price_id == new_price.id
+            return render json: { error: { code: "already_subscribed", message: "You are already subscribed to this plan" } }, status: :unprocessable_content
+          end
+
+          # Determine if this is an upgrade or downgrade by comparing unit amounts
+          current_amount = stripe_sub.items.data[0].price.unit_amount
+          new_amount = new_price.unit_amount
+          upgrading =
+            if current_amount.nil? || new_amount.nil?
+              # If either price has no unit_amount, avoid treating this as an upgrade based on a bogus comparison.
+              false
+            else
+              new_amount > current_amount
+            end
+
+          # ── Upgrade: prorate immediately, Stripe auto-charges the payment method on file.
+          #    If 3DS is needed, Stripe sends the customer an email to confirm.
+          #    The webhook (customer.subscription.updated / invoice.paid) handles all state changes.
+          # ── Downgrade: apply at end of current period so the customer keeps
+          #    their higher-tier access until the period they already paid for ends.
+          Stripe::Subscription.update(
+            active_stripe_sub,
+            items: [ {
+              id: stripe_sub.items.data[0].id,
+              price: new_price.id
+            } ],
+            proration_behavior: upgrading ? "create_prorations" : "none",
+            payment_behavior: "allow_incomplete"
+          )
+
+          change_type = upgrading ? "upgraded" : "downgraded"
+          render json: {
+            status: "plan_changed",
+            change_type: change_type,
+            message: upgrading ?
+              "Your plan has been upgraded. New limits are effective immediately." :
+              "Your plan has been downgraded. Changes take effect at the end of the current billing period."
+          }, status: :ok
+        end
+
+        def create_checkout_session(price)
+          session = Stripe::Checkout::Session.create(
+            customer: current_user.stripe_id,
+            mode: "subscription",
+            client_reference_id: current_user.id,
+            line_items: [ {
+              quantity: 1,
+              price: price.id
+            } ],
+            success_url: "#{site_origin}/account?checkout=success",
+            cancel_url: "#{site_origin}/account?checkout=cancel"
+          )
+
+          render json: { url: session.url }, status: :ok
+        end
+
+        def site_origin
+          ENV["SITE_ORIGIN"] || "https://levelcode.ai"
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/levelcode/v1/feedback_controller.rb
+++ b/app/controllers/api/levelcode/v1/feedback_controller.rb
@@ -1,0 +1,27 @@
+module Api
+  module Levelcode
+    module V1
+      # POST /api/levelcode/v1/feedback — record a thumbs up/down the editor sends when a
+      # user reacts to an assistant turn on the metered gateway. Bearer-authed; BYOK
+      # never reaches here (it stays local + private). Keeps the per-user RPM cap
+      # (enforce_abuse_caps!) so a client can't loop unbounded INSERTs into the table.
+      class FeedbackController < BaseController
+        def create
+          rating = params[:rating].to_s
+          unless UsageFeedback::RATINGS.include?(rating)
+            return render_levelcode_error("invalid_rating", "rating must be 'up' or 'down'", :unprocessable_content)
+          end
+
+          UsageFeedback.create!(
+            user: current_levelcode_user,
+            model: params[:model].to_s.presence,
+            rating: rating,
+            request_id: params[:request_id].to_s.presence,
+            created_at: Time.current
+          )
+          render json: { ok: true }, status: :ok
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/levelcode/v1/pricing_controller.rb
+++ b/app/controllers/api/levelcode/v1/pricing_controller.rb
@@ -1,0 +1,34 @@
+module Api
+  module Levelcode
+    module V1
+      # Public pricing endpoint — server-side truth for the 4 Levelcode tiers.
+      # The site (levelcode.ai/pricing) and editor render whatever this returns;
+      # prices/caps are never hard-coded on the frontend (SPEC §3, §6, D10).
+      class PricingController < BaseController
+        skip_before_action :authenticate_levelcode!, only: %i[index]
+
+        # GET /api/levelcode/v1/pricing
+        def index
+          render json: { tiers: serialized_tiers }, status: :ok
+        end
+
+        private
+
+        def serialized_tiers
+          ::Levelcode::PLANS.map do |plan|
+            {
+              key: plan[:key],
+              name: plan[:name],
+              price_cents: plan[:price_cents],
+              interval: plan[:interval] || "month",
+              input_cap: plan[:input_cap],
+              output_cap: plan[:output_cap],
+              turns: plan[:turns],
+              features: plan[:features] || []
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/webhooks_controller.rb
+++ b/app/controllers/api/v1/webhooks_controller.rb
@@ -29,6 +29,13 @@ class Api::V1::WebhooksController < ApplicationController
 
     handle_event(event)
     head :ok
+  rescue Levelcode::WebhookSync::SyncError => e
+    # The money-critical wallet sync failed AFTER we claimed idempotency — release the claim so Stripe's
+    # retry re-runs it (a non-2xx triggers the retry; bounded by Stripe's ~3-day retry window). Without
+    # this, a stranded teardown would leave a canceled wallet fully funded.
+    ProcessedStripeEvent.where(stripe_event_id: event&.id).delete_all
+    Rails.logger.error("[Stripe Webhook] Wallet sync failed; released idempotency for retry: #{event&.id} (#{e.message})")
+    head :internal_server_error
   rescue => e
     Rails.logger.error("[Stripe Webhook] Unhandled error processing #{event&.type}: #{e.message}")
     Rails.logger.error(e.backtrace&.first(10)&.join("\n"))
@@ -50,6 +57,10 @@ class Api::V1::WebhooksController < ApplicationController
       Levelcode::WebhookSync.call(event)
     rescue StandardError => e
       Rails.logger.error("[Stripe Webhook] Levelcode::WebhookSync failed: #{e.message}")
+      # Money-critical: re-raise so create() releases idempotency and Stripe retries, rather than
+      # silently stranding a teardown/provision. (WebhookSync swallows its own Stripe API errors, so
+      # what reaches here is a durable failure — DB/etc. — worth retrying.)
+      raise Levelcode::WebhookSync::SyncError, e.message
     end
 
     case event.type

--- a/app/controllers/api/v1/webhooks_controller.rb
+++ b/app/controllers/api/v1/webhooks_controller.rb
@@ -42,6 +42,16 @@ class Api::V1::WebhooksController < ApplicationController
   def handle_event(event)
     obj = event.data.object
 
+    # LevelCode Cloud (Levelcode): provision/reset the CreditWallet from subscription
+    # events. Self-filters to product 'levelcode' by Stripe price lookup_key and
+    # no-ops for link-shortener subscriptions, so it is safe to call for every
+    # event (SPEC §3.7 / DECISIONS D11). Never let it break the primary webhook.
+    begin
+      Levelcode::WebhookSync.call(event)
+    rescue StandardError => e
+      Rails.logger.error("[Stripe Webhook] Levelcode::WebhookSync failed: #{e.message}")
+    end
+
     case event.type
 
     # ── Checkout Session Events ──────────────────────────────────

--- a/app/controllers/concerns/access_tracking.rb
+++ b/app/controllers/concerns/access_tracking.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+# Shared geo + access/auth capture for the admin dashboard. Country comes from the CDN edge
+# header (Cloudflare / CloudFront) — the same source the shortener uses; nil in dev (no CDN).
+# Everything here is best-effort: it must never break the request it's attached to.
+module AccessTracking
+  extend ActiveSupport::Concern
+
+  # Two-letter country from the CDN edge; nil when not behind a CDN (local/dev).
+  def request_country
+    (request.headers["CF-IPCountry"].presence ||
+     request.headers["CloudFront-Viewer-Country"].presence).to_s.strip.upcase.presence
+  end
+
+  # Denormalize "last seen where/when" onto the user, THROTTLED to ~once / 15 min so it's a rare
+  # write instead of one per request. update_columns → no callbacks / validations / updated_at churn.
+  def touch_access!(user)
+    return unless user
+
+    now = Time.current
+    return if user.last_seen_at.present? && user.last_seen_at > now - 15.minutes
+
+    attrs = { last_seen_at: now }
+    country = request_country
+    attrs[:last_country] = country if country.present?
+    user.update_columns(attrs)
+  rescue StandardError => e
+    Rails.logger.warn("[AccessTracking] touch failed: #{e.class}: #{e.message}")
+  end
+
+  # Record one authentication attempt (success or failure) for the admin auth-health view.
+  def log_auth(kind:, outcome:, email: nil, user: nil, provider: nil, reason: nil)
+    AuthEvent.create!(
+      user: user,
+      email: (email || user&.email).to_s.strip.downcase.presence,
+      kind: kind.to_s,
+      provider: provider.presence,
+      outcome: outcome.to_s,
+      reason: reason.presence,
+      ip: request.remote_ip,
+      country: request_country,
+      created_at: Time.current
+    )
+  rescue StandardError => e
+    Rails.logger.warn("[AccessTracking] auth log failed: #{e.class}: #{e.message}")
+  end
+end

--- a/app/controllers/levelcode/web_controller.rb
+++ b/app/controllers/levelcode/web_controller.rb
@@ -15,7 +15,7 @@ module Levelcode
   # CSRF — the SPA sends the token from the shell's <meta name="csrf-token">.
   #
   # Sign-in delivers TWO ways (SHARED CONTRACT):
-  #   - editor: an `atom-plus-plus://…/auth/callback` redirect_uri is present ->
+  #   - editor: an `levelcode://…/auth/callback` redirect_uri is present ->
   #     mint a single-use Levelcode::OneTimeCode bound to the editor's PKCE
   #     code_challenge and hand back `<redirect_uri>?code=<code>` (never tokens).
   #   - web: Devise sign_in(user) -> destination /ai/account.
@@ -29,8 +29,13 @@ module Levelcode
 
     before_action :authenticate_user!, only: %i[checkout billing authorize_editor]
 
-    # The frozen editor deep-link callback (SHARED CONTRACT).
-    EDITOR_CALLBACK = "atom-plus-plus://levelcode.atom-ai/auth/callback"
+    # The frozen editor deep-link callback (SHARED CONTRACT). Host = the extension id
+    # <publisher>.<name> = levelcode.levelcode-ai; path = /auth/callback.
+    EDITOR_CALLBACK = "levelcode://levelcode.levelcode-ai/auth/callback"
+    # Accepted url schemes for the editor deep-link. `levelcode` is the current product urlProtocol;
+    # `atom-plus-plus` is the pre-rename scheme, still emitted by editor builds not yet rebuilt —
+    # accepted during the transition. The security-relevant host + path stay strictly pinned.
+    EDITOR_SCHEMES = %w[levelcode atom-plus-plus].freeze
 
     # Per-IP OTP-send cap. The recipient is caller-chosen, so EmailCode's per-email
     # resend window alone can be fanned out across many addresses — bound by source IP.
@@ -279,7 +284,7 @@ module Levelcode
 
       u = URI.parse(uri_str.to_s)
       e = URI.parse(EDITOR_CALLBACK)
-      u.scheme == e.scheme && u.host == e.host && u.path == e.path
+      EDITOR_SCHEMES.include?(u.scheme) && u.host == e.host && u.path == e.path
     rescue URI::InvalidURIError
       false
     end

--- a/app/controllers/levelcode/web_controller.rb
+++ b/app/controllers/levelcode/web_controller.rb
@@ -1,0 +1,362 @@
+# frozen_string_literal: true
+
+require "uri"
+require "cgi"
+
+module Levelcode
+  # Server-side auth/session/billing flows for the LevelCode Cloud account app
+  # (the onetime SPA served at /ai/*). The SPA renders the pages and reads data
+  # from the JSON API (Api::Levelcode::V1::* — pricing, account/profile+usage); this
+  # controller owns only the flows that MUST run server-side:
+  #   - OAuth authorize + callback (client-secret code exchange), and
+  #   - the session-establishing / Stripe WRITES (CSRF-protected, cookie session).
+  #
+  # It uses the standard Devise web session (sign_in / current_user) and Rails
+  # CSRF — the SPA sends the token from the shell's <meta name="csrf-token">.
+  #
+  # Sign-in delivers TWO ways (SHARED CONTRACT):
+  #   - editor: an `atom-plus-plus://…/auth/callback` redirect_uri is present ->
+  #     mint a single-use Levelcode::OneTimeCode bound to the editor's PKCE
+  #     code_challenge and hand back `<redirect_uri>?code=<code>` (never tokens).
+  #   - web: Devise sign_in(user) -> destination /ai/account.
+  class WebController < ApplicationController
+    include AccessTracking
+
+    # Browser/session surface — restore real CSRF (ApplicationController defaults
+    # to :null_session for the token-first API). The SPA's state-changing POSTs
+    # carry X-CSRF-Token from the shell meta; OAuth start/callback are GETs.
+    protect_from_forgery with: :exception
+
+    before_action :authenticate_user!, only: %i[checkout billing authorize_editor]
+
+    # The frozen editor deep-link callback (SHARED CONTRACT).
+    EDITOR_CALLBACK = "atom-plus-plus://levelcode.atom-ai/auth/callback"
+
+    # Per-IP OTP-send cap. The recipient is caller-chosen, so EmailCode's per-email
+    # resend window alone can be fanned out across many addresses — bound by source IP.
+    EMAIL_SEND_WINDOW = 1.hour.to_i
+    EMAIL_SEND_MAX = 20
+
+    # POST /ai/auth/email  (JSON) — passwordless step 1: email a 6-digit code.
+    def email_request
+      email = params[:email].to_s.strip.downcase
+      return render_error("invalid_email", "Enter a valid email address.", :unprocessable_content) unless valid_email?(email)
+      return render_error("rate_limited", "Too many sign-in attempts from your network. Please wait a bit and try again.", :too_many_requests) unless email_send_allowed?
+
+      begin
+        code = Levelcode::EmailCode.issue(email)
+        # deliver_now: send immediately + keep the plaintext code out of the job queue.
+        LevelcodeAuthMailer.login_code(email, code).deliver_now
+      rescue Levelcode::EmailCode::RateLimited
+        # A live code was just sent — succeed silently (no resend spam).
+        Rails.logger.info("[Levelcode web OTP] resend throttled")
+      rescue StandardError => e
+        Levelcode::EmailCode.clear(email)
+        Rails.logger.error("[Levelcode web OTP] issue failed: #{e.class}: #{e.message}")
+        return render_error("email_failed", "Could not send the code. Please try again.", :bad_gateway)
+      end
+
+      render json: { sent: true }
+    end
+
+    # POST /ai/auth/verify  (JSON) — step 2. Body: { email, code, redirect_uri?, code_challenge? }.
+    # The editor threads redirect_uri + code_challenge as params (there is no
+    # server-rendered login page to stash them in session first).
+    def email_verify
+      @redirect_uri = editor_redirect_uri(params[:redirect_uri])
+      @code_challenge = editor_code_challenge(params[:code_challenge])
+      email = params[:email].to_s.strip.downcase
+
+      unless Levelcode::EmailCode.verify(email, params[:code])
+        log_auth(kind: "email", outcome: "failure", email: email, reason: "invalid_code")
+        return render_error("invalid_code", "That code is invalid or has expired.", :unauthorized)
+      end
+
+      user = find_or_create_email_user(email)
+      unless user&.persisted?
+        log_auth(kind: "email", outcome: "failure", email: email, reason: "account_error")
+        return render_error("account_error", "Could not sign you in. Please try again.", :unprocessable_content)
+      end
+
+      log_auth(kind: "email", outcome: "success", user: user)
+      touch_access!(user)
+      dest = deliver_signed_in(user)
+      return render_error("link_expired", "Your sign-in link expired. Please start again from the editor.", :unprocessable_content) unless dest
+
+      render json: { redirect: dest }
+    end
+
+    # GET /ai/auth/oauth/:provider  — full-page nav from the SPA. Persist an
+    # anti-CSRF `state` (+ carry the editor context) in the session, 302 to the
+    # provider. The provider redirect_uri is always OUR fixed web callback.
+    def oauth_start
+      provider = params[:provider].to_s
+      (redirect_to("/ai/login") and return) unless %w[github google].include?(provider)
+
+      stash_editor_context(safe_redirect_uri(params[:redirect_uri]), params[:code_challenge].presence)
+
+      state = SecureRandom.urlsafe_base64(24)
+      session[:levelcode_oauth_state] = state
+      session[:levelcode_oauth_provider] = provider
+
+      url = Levelcode::ProviderOAuth.authorize_url(provider: provider, redirect_uri: oauth_callback_uri, state: state)
+      redirect_to url, allow_other_host: true
+    end
+
+    # GET /ai/auth/callback  — OAuth return: verify session `state`, exchange the
+    # code server-side, then either 302 to the editor deep-link (with a one-time
+    # code) or sign in and 302 to /ai/account.
+    def oauth_callback
+      provider = session.delete(:levelcode_oauth_provider).to_s
+      expected_state = session.delete(:levelcode_oauth_state).to_s
+
+      if expected_state.blank? || params[:state].to_s != expected_state
+        log_auth(kind: "oauth", outcome: "failure", provider: provider, reason: "session_expired")
+        return redirect_to("/ai/login?error=session_expired")
+      end
+
+      user =
+        case provider
+        when "github" then Levelcode::ProviderOAuth.github_user(code: params[:code], redirect_uri: oauth_callback_uri)
+        when "google" then Levelcode::ProviderOAuth.google_user(code: params[:code], redirect_uri: oauth_callback_uri)
+        end
+
+      unless user&.persisted?
+        log_auth(kind: "oauth", outcome: "failure", provider: provider, reason: "oauth_failed")
+        return redirect_to("/ai/login?error=oauth_failed")
+      end
+
+      log_auth(kind: "oauth", outcome: "success", user: user, provider: provider)
+      touch_access!(user)
+      @redirect_uri = editor_redirect_uri
+      @code_challenge = editor_code_challenge
+      dest = deliver_signed_in(user)
+      redirect_to(dest || "/ai/login?error=link_expired", allow_other_host: true)
+    end
+
+    # GET /ai/auth/handoff?code=…  — the editor->browser direction of the shared
+    # contract. Redeem a single-use code minted by /api/levelcode/v1/auth/web_handoff
+    # (issuable only by a holder of the user's editor token) and sign the SAME user
+    # into a Devise web session, then land on /ai/account — so "Manage account" from
+    # the editor doesn't force a second sign-in. Invalid/expired/Redis-down → /ai/login.
+    def handoff
+      user = Levelcode::OneTimeCode.redeem(params[:code])
+      sign_in(user)
+      redirect_to("/ai/account")
+    rescue Levelcode::OneTimeCode::Error
+      redirect_to("/ai/login?error=link_expired")
+    end
+
+    # POST /ai/authorize_editor  (JSON, authenticate_user!) — the "Open IDE" completion step.
+    # The EDITOR initiates its normal PKCE sign-in (it holds the verifier) and opens /ai/login
+    # with its `redirect_uri` + `code_challenge`; when the browser already has a session, the SPA
+    # calls this to mint a PKCE-BOUND one-time code and hand back the editor deep-link — so no
+    # second login. FAILS CLOSED without a valid editor deep-link + challenge: an UNBOUND code
+    # would be interceptable via the custom scheme and redeemable at /auth/exchange for full
+    # editor tokens (the exact posture deliver_signed_in enforces). Binding the code to the
+    # editor-held verifier means an intercepted code is useless without it.
+    def authorize_editor
+      redirect_uri = safe_redirect_uri(params[:redirect_uri])
+      challenge = editor_code_challenge(params[:code_challenge])
+      if redirect_uri.blank? || challenge.blank?
+        return render_error("invalid_request", "Not a valid editor sign-in request.", :unprocessable_content)
+      end
+
+      code = Levelcode::OneTimeCode.issue(current_user, challenge)
+      render json: { redirect: editor_callback_with_code(redirect_uri, code) }
+    end
+
+    # POST /ai/checkout  (JSON, authenticate_user!) — Stripe Checkout session.
+    def checkout
+      lookup_key = params[:lookup_key].to_s
+      prices = Stripe::Price.list(lookup_keys: [ lookup_key ], expand: [ "data.product" ])
+      price = prices.data[0]
+      return render_error("plan_unavailable", "That plan is unavailable.", :unprocessable_content) unless price
+
+      session_obj = Stripe::Checkout::Session.create(
+        customer: current_user.stripe_id,
+        mode: "subscription",
+        client_reference_id: current_user.id,
+        line_items: [ { quantity: 1, price: price.id } ],
+        success_url: absolute_url("/ai/account"),
+        cancel_url: absolute_url("/ai/pricing")
+      )
+      render json: { url: session_obj.url }
+    rescue Stripe::StripeError => e
+      Rails.logger.error("[Levelcode web checkout] #{e.class}: #{e.message}")
+      render_error("stripe_error", "Could not start checkout. Please try again.", :bad_gateway)
+    end
+
+    # POST /ai/billing  (JSON, authenticate_user!) — Stripe billing portal.
+    def billing
+      session_obj = Stripe::BillingPortal::Session.create(
+        customer: current_user.stripe_id,
+        return_url: absolute_url("/ai/account")
+      )
+      render json: { url: session_obj.url }
+    rescue Stripe::StripeError => e
+      Rails.logger.error("[Levelcode web billing] #{e.class}: #{e.message}")
+      render_error("stripe_error", "Could not open billing. Please try again.", :bad_gateway)
+    end
+
+    # POST/DELETE /ai/signout  (JSON) — the SPA navigates to /ai/login after.
+    def signout
+      sign_out(current_user) if current_user
+      render json: { ok: true }
+    end
+
+    # GET /ai/csrf  (JSON) — same-origin CSRF token for the SPA in dev. The prod
+    # shell embeds this via <meta name="csrf-token">; the Vite dev shell can't,
+    # so `api.ts` fetches one here. Same-origin only — CORS prevents cross-origin
+    # reads, so this exposes nothing the prod meta tag doesn't already.
+    def csrf
+      render json: { token: form_authenticity_token }
+    end
+
+    private
+
+    # --- Delivery (SHARED CONTRACT: editor deep-link vs web session) ----------
+
+    # Returns the post-sign-in destination URL (editor deep-link carrying a
+    # one-time code, or the web account path) and establishes the Devise session
+    # for the web path. Returns nil to FAIL CLOSED (editor deep-link with no PKCE
+    # challenge — an unbound one-time code would be interceptable).
+    def deliver_signed_in(user)
+      clear_editor_context
+
+      if editor_deep_link?(@redirect_uri)
+        return nil if @code_challenge.blank?
+
+        code = Levelcode::OneTimeCode.issue(user, @code_challenge)
+        editor_callback_with_code(@redirect_uri, code)
+      else
+        sign_in(user)
+        "/ai/account"
+      end
+    end
+
+    def editor_callback_with_code(uri_str, code)
+      uri = URI.parse(uri_str)
+      query = uri.query.present? ? Hash[URI.decode_www_form(uri.query)] : {}
+      query["code"] = code
+      uri.query = URI.encode_www_form(query)
+      uri.to_s
+    end
+
+    # --- redirect_uri validation (no open redirect, never tokens in a URL) ----
+    #
+    # Accept ONLY the editor deep-link, pinned by scheme + host + path. We must
+    # tolerate a query string (VS Code's asExternalUri appends ?windowId=N to route
+    # the callback to the right editor window) and percent-encoding (the value can
+    # arrive single- OR double-encoded through the login → OAuth hops), but NOTHING
+    # else — no https, no other host/path — so this stays closed to open-redirect
+    # abuse (D36). Returns the DECODED deep-link WITH its query so the caller can
+    # append the one-time code without dropping the window routing.
+    def safe_redirect_uri(raw)
+      return nil if raw.blank?
+
+      candidate = decode_deep_link(raw)
+      editor_deep_link?(candidate) ? candidate : nil
+    end
+
+    # Decode until stable — handles single- or double-encoded values; capped.
+    def decode_deep_link(raw)
+      s = raw.to_s
+      3.times do
+        break unless s.include?("%")
+        decoded = CGI.unescape(s)
+        break if decoded == s
+        s = decoded
+      end
+      s
+    end
+
+    # True when uri_str is the editor callback deep-link. Scheme + host + path are
+    # pinned to EDITOR_CALLBACK; any query (e.g. ?windowId=N) is allowed and gets
+    # preserved by editor_callback_with_code.
+    def editor_deep_link?(uri_str)
+      return false if uri_str.blank?
+
+      u = URI.parse(uri_str.to_s)
+      e = URI.parse(EDITOR_CALLBACK)
+      u.scheme == e.scheme && u.host == e.host && u.path == e.path
+    rescue URI::InvalidURIError
+      false
+    end
+
+    # --- Session-stashed editor context (OAuth round-trip) --------------------
+
+    def stash_editor_context(redirect_uri, code_challenge)
+      if redirect_uri.present?
+        session[:levelcode_editor_redirect_uri] = redirect_uri
+        # Never DOWNGRADE an already-bound flow: only (re)write the challenge when
+        # one is actually supplied (a re-link that omits it must not null it out,
+        # which would make the minted one-time code PKCE-unbound).
+        session[:levelcode_editor_code_challenge] = code_challenge if code_challenge.present?
+      else
+        clear_editor_context
+      end
+    end
+
+    def clear_editor_context
+      session.delete(:levelcode_editor_redirect_uri)
+      session.delete(:levelcode_editor_code_challenge)
+    end
+
+    # Resolve the editor redirect_uri from an explicit param (re-validated) or the
+    # session stash; nil means the web session path. Email verify passes params;
+    # OAuth reads the session stashed at oauth_start.
+    def editor_redirect_uri(param = nil)
+      safe_redirect_uri(param) || session[:levelcode_editor_redirect_uri].presence
+    end
+
+    def editor_code_challenge(param = nil)
+      param.presence || session[:levelcode_editor_code_challenge].presence
+    end
+
+    # --- Helpers --------------------------------------------------------------
+
+    # Passwordless find-or-create; a random password satisfies Devise validatable
+    # and is never used (sign-in is OTP/OAuth only).
+    def find_or_create_email_user(email)
+      User.find_by(email: email) || User.create(
+        email: email,
+        password: Devise.friendly_token[0, 32],
+        terms_accepted: true
+      )
+    end
+
+    def valid_email?(email)
+      email.present? && email.match?(URI::MailTo::EMAIL_REGEXP)
+    end
+
+    # Per-IP OTP-send throttle (EMAIL_SEND_MAX per EMAIL_SEND_WINDOW). Best-effort:
+    # allows the send if Redis is unavailable rather than locking users out.
+    def email_send_allowed?
+      r = defined?($redis) && $redis
+      return true unless r
+
+      key = "levelcode:web:emailsend:#{request.remote_ip}"
+      count = r.incr(key)
+      r.expire(key, EMAIL_SEND_WINDOW) if count == 1
+      count <= EMAIL_SEND_MAX
+    rescue StandardError => e
+      Rails.logger.warn("[Levelcode web OTP] throttle check failed: #{e.class}: #{e.message}")
+      true
+    end
+
+    # Our fixed web OAuth callback (absolute, host-derived) — the provider
+    # redirect_uri for BOTH authorize and the token exchange.
+    def oauth_callback_uri
+      absolute_url("/ai/auth/callback")
+    end
+
+    def absolute_url(path)
+      "#{request.base_url}#{path}"
+    end
+
+    def render_error(code, message, status)
+      render json: { error: { code: code, message: message } }, status: status
+    end
+  end
+end

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -1,5 +1,22 @@
 class StaticController < ApplicationController
+  # Hosts that serve the LevelCode Cloud account app (levelcode.html shell) instead of
+  # the thin.ly shortener SPA. The account app always lives under /ai/* on every
+  # host (the /ai prefix never collides with the 7-char shortcode lookup), so the
+  # brand switch is PATH-based; these hosts additionally funnel bare HTML paths
+  # into /ai so levelcode.ai/pricing → /ai/pricing. (Non-HTML bare paths 404, which
+  # is correct — the account app has no non-HTML bare endpoints; the JSON API is
+  # under /api/levelcode/v1/*.)
+  LEVELCODE_HOSTS = %w[levelcode.ai www.levelcode.ai].freeze
+
   def ui
+    # On an LevelCode host, redirect bare (non-/ai) paths into the /ai-mounted app.
+    if levelcode_host? && !ai_path?
+      dest = request.path == "/" ? "/ai" : "/ai#{request.path}"
+      dest += "?#{request.query_string}" if request.query_string.present?
+      return redirect_to(dest)
+    end
+
+    render(ai_path? ? "static/ui_levelcode" : "static/ui", layout: false)
   end
 
   def unsafe_link
@@ -15,5 +32,15 @@ class StaticController < ApplicationController
   def not_found
     response.set_header("X-Robots-Tag", "noindex, nofollow")
     render file: Rails.root.join("public", "404.html"), status: :not_found, layout: false
+  end
+
+  private
+
+  def levelcode_host?
+    LEVELCODE_HOSTS.include?(request.host)
+  end
+
+  def ai_path?
+    request.path == "/ai" || request.path.start_with?("/ai/")
   end
 end

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -9,7 +9,7 @@ class StaticController < ApplicationController
   LEVELCODE_HOSTS = %w[levelcode.ai www.levelcode.ai].freeze
 
   def ui
-    # On an LevelCode host, redirect bare (non-/ai) paths into the /ai-mounted app.
+    # On a LevelCode host, redirect bare (non-/ai) paths into the /ai-mounted app.
     if levelcode_host? && !ai_path?
       dest = request.path == "/" ? "/ai" : "/ai#{request.path}"
       dest += "?#{request.query_string}" if request.query_string.present?

--- a/app/jobs/record_usage_job.rb
+++ b/app/jobs/record_usage_job.rb
@@ -36,9 +36,14 @@ class RecordUsageJob
     # and only against the wallet still in the SAME period as when this was enqueued.
     return unless event.previously_new_record?
 
+    # FLOOR both sides so the match survives a fractional-second period_end. The enqueue passes
+    # `wallet.period_end.to_i` (Ruby Time#to_i TRUNCATES to whole seconds), but a bare
+    # `EXTRACT(EPOCH FROM period_end)::bigint` ROUNDS to nearest — so a period_end stored with ≥ .5µs
+    # rounds UP and never equals the truncated arg, silently matching 0 rows (the durable columns then
+    # freeze at 0 while only the Redis counter — which floors on both sides — stays correct).
     CreditWallet
       .where(user_id: user_id, product: Levelcode::PRODUCT)
-      .where("period_end IS NOT NULL AND EXTRACT(EPOCH FROM period_end)::bigint = ?", period_end_epoch.to_i)
+      .where("period_end IS NOT NULL AND FLOOR(EXTRACT(EPOCH FROM period_end))::bigint = ?", period_end_epoch.to_i)
       .update_all([
         "input_used = input_used + ?, output_used = output_used + ?, spent_micros = spent_micros + ?, updated_at = ?",
         input_tokens.to_i, output_tokens.to_i, cost_micros.to_i, Time.current

--- a/app/jobs/record_usage_job.rb
+++ b/app/jobs/record_usage_job.rb
@@ -1,0 +1,47 @@
+require "sidekiq"
+
+# Writes the durable usage ledger row (usage_events) off the request path AND
+# keeps the per-period CreditWallet counter in sync (SPEC §5).
+#
+# Idempotent + period-safe:
+#   - `request_id` is unique (partial unique index), so a Sidekiq retry or a
+#     duplicate enqueue neither inserts a second ledger row nor double-increments
+#     the wallet counters (the bump runs only on the first insert).
+#   - The wallet increment is scoped to the billing period captured at ENQUEUE
+#     time (`period_end_epoch`), so a late job for an already-rolled period no-ops
+#     instead of corrupting the new period's totals.
+#
+# Enqueued as: RecordUsageJob.perform_async(user_id, request_id, model, provider,
+#   input_tokens, output_tokens, cached_input_tokens, cost_micros, period_end_epoch).
+class RecordUsageJob
+  include Sidekiq::Job
+  queue_as :default
+
+  def perform(user_id, request_id, model, provider, input_tokens, output_tokens, cached_input_tokens, cost_micros, period_end_epoch = nil)
+    request_id = SecureRandom.uuid if request_id.blank? # never collapse blanks onto one row
+
+    event = UsageEvent.create_or_find_by!(request_id: request_id) do |e|
+      e.assign_attributes(
+        user_id: user_id,
+        model: model,
+        provider: provider,
+        input_tokens: input_tokens.to_i,
+        output_tokens: output_tokens.to_i,
+        cached_input_tokens: cached_input_tokens.to_i,
+        cost_micros: cost_micros.to_i
+      )
+    end
+
+    # Only bump the durable per-period counter on the FIRST (unique) ledger insert,
+    # and only against the wallet still in the SAME period as when this was enqueued.
+    return unless event.previously_new_record?
+
+    CreditWallet
+      .where(user_id: user_id, product: Levelcode::PRODUCT)
+      .where("period_end IS NOT NULL AND EXTRACT(EPOCH FROM period_end)::bigint = ?", period_end_epoch.to_i)
+      .update_all([
+        "input_used = input_used + ?, output_used = output_used + ?, spent_micros = spent_micros + ?, updated_at = ?",
+        input_tokens.to_i, output_tokens.to_i, cost_micros.to_i, Time.current
+      ])
+  end
+end

--- a/app/mailers/levelcode_auth_mailer.rb
+++ b/app/mailers/levelcode_auth_mailer.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# LevelCode Cloud passwordless sign-in email. Kept separate from the link-shortener
+# mailers so its branding/from-address are independent (Levelcode::EmailCode).
+class LevelcodeAuthMailer < ApplicationMailer
+  def login_code(email, code)
+    @code = code
+    @ttl_minutes = (Levelcode::EmailCode::TTL / 60).to_i
+    mail(
+      to: email,
+      from: ENV["LEVELCODE_MAIL_FROM"].presence || "LevelCode <notifications@thin.ly>",
+      subject: "#{code} is your LevelCode sign-in code"
+    )
+  end
+end

--- a/app/models/auth_event.rb
+++ b/app/models/auth_event.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: auth_events
+#
+#  id         :bigint           not null, primary key
+#  country    :string
+#  email      :string
+#  ip         :string
+#  kind       :string           not null
+#  outcome    :string           not null
+#  provider   :string
+#  reason     :string
+#  created_at :datetime         not null
+#  user_id    :bigint
+#
+# Indexes
+#
+#  index_auth_events_on_created_at  (created_at)
+#  index_auth_events_on_email       (email)
+#  index_auth_events_on_outcome     (outcome)
+#  index_auth_events_on_user_id     (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
+class AuthEvent < ApplicationRecord
+  belongs_to :user, optional: true
+
+  KINDS    = %w[email oauth exchange login refresh].freeze
+  OUTCOMES = %w[success failure].freeze
+
+  validates :kind, inclusion: { in: KINDS }
+  validates :outcome, inclusion: { in: OUTCOMES }
+
+  scope :failures, -> { where(outcome: "failure") }
+  scope :successes, -> { where(outcome: "success") }
+end

--- a/app/models/credit_wallet.rb
+++ b/app/models/credit_wallet.rb
@@ -1,0 +1,93 @@
+# == Schema Information
+#
+# Table name: credit_wallets
+#
+#  id             :bigint           not null, primary key
+#  budget_micros  :bigint           default(0), not null
+#  input_cap      :bigint           not null
+#  input_used     :bigint           default(0), not null
+#  output_cap     :bigint           not null
+#  output_used    :bigint           default(0), not null
+#  overage_policy :string           default("throttle"), not null
+#  period_end     :datetime
+#  period_start   :datetime
+#  plan_key       :string           not null
+#  product        :string           default("levelcode"), not null
+#  spent_micros   :bigint           default(0), not null
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  user_id        :bigint           not null
+#
+# Indexes
+#
+#  index_credit_wallets_on_user_id              (user_id)
+#  index_credit_wallets_on_user_id_and_product  (user_id,product) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
+class CreditWallet < ApplicationRecord
+  belongs_to :user
+
+  # Past-cap behaviour (SPEC §5).
+  OVERAGE_POLICIES = %w[throttle topup stop].freeze
+
+  validates :product, :plan_key, presence: true
+  validates :input_cap, :output_cap, presence: true
+  validates :overage_policy, inclusion: { in: OVERAGE_POLICIES }
+
+  # Find-or-provision the wallet for a user + product, seeding caps/policy from
+  # the plan definition in Levelcode::PLANS. Idempotent per [user, product].
+  def self.for(user, product: Levelcode::PRODUCT, plan_key: Levelcode::PLANS.first[:key])
+    wallet = find_or_initialize_by(user: user, product: product)
+    return wallet if wallet.persisted?
+
+    plan = Levelcode.plan(plan_key) || Levelcode::PLANS.first
+    wallet.plan_key = plan[:key]
+    wallet.input_cap = plan[:input_cap]
+    wallet.output_cap = plan[:output_cap]
+    wallet.save!
+    wallet
+  end
+
+  # True once either dimension has reached its cap for the current period.
+  def cap_reached?
+    input_cap_reached? || output_cap_reached?
+  end
+
+  def input_cap_reached?
+    input_used >= input_cap
+  end
+
+  def output_cap_reached?
+    output_used >= output_cap
+  end
+
+  # Tokens still available before the cap on each dimension (never negative).
+  def input_remaining
+    [ input_cap - input_used, 0 ].max
+  end
+
+  def output_remaining
+    [ output_cap - output_used, 0 ].max
+  end
+
+  # Whether the wallet is currently over cap on either dimension — i.e. this
+  # request would be served past the subsidized ceiling.
+  def overage?
+    input_used > input_cap || output_used > output_cap
+  end
+
+  def throttle?
+    overage_policy == "throttle"
+  end
+
+  def topup?
+    overage_policy == "topup"
+  end
+
+  def stop?
+    overage_policy == "stop"
+  end
+end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -7,6 +7,7 @@
 #  current_period_end   :datetime
 #  current_period_start :datetime
 #  interval             :string
+#  product              :string           default("linkly"), not null
 #  status               :string
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
@@ -17,7 +18,8 @@
 #
 # Indexes
 #
-#  index_subscriptions_on_user_id  (user_id)
+#  index_subscriptions_on_user_id              (user_id)
+#  index_subscriptions_on_user_id_and_product  (user_id,product)
 #
 # Foreign Keys
 #
@@ -26,6 +28,9 @@
 class Subscription < ApplicationRecord
   belongs_to :user
   has_many :plans, dependent: :destroy
+
+  # Product-scoped lookup (SPEC §6). Default product is the link-shortener.
+  scope :for_product, ->(product) { where(product: product) }
 
   after_commit :create_default_plan, on: :create
 

--- a/app/models/usage_event.rb
+++ b/app/models/usage_event.rb
@@ -1,0 +1,41 @@
+# == Schema Information
+#
+# Table name: usage_events
+#
+#  id                  :bigint           not null, primary key
+#  cached_input_tokens :bigint           default(0), not null
+#  cost_micros         :bigint           default(0), not null
+#  input_tokens        :bigint           default(0), not null
+#  model               :string
+#  output_tokens       :bigint           default(0), not null
+#  provider            :string
+#  created_at          :datetime         not null
+#  request_id          :string
+#  user_id             :bigint           not null
+#
+# Indexes
+#
+#  index_usage_events_on_request_id_unique       (request_id) UNIQUE WHERE (request_id IS NOT NULL)
+#  index_usage_events_on_user_id                 (user_id)
+#  index_usage_events_on_user_id_and_created_at  (user_id,created_at)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
+class UsageEvent < ApplicationRecord
+  belongs_to :user
+
+  validates :input_tokens, :output_tokens, :cached_input_tokens, :cost_micros,
+            numericality: { greater_than_or_equal_to: 0 }
+
+  # Total input tokens including the cached subset (mirrors upstream usage).
+  def total_input_tokens
+    input_tokens
+  end
+
+  # Cost expressed in whole dollars (micros → dollars) for display/analytics.
+  def cost_dollars
+    cost_micros / 1_000_000.0
+  end
+end

--- a/app/models/usage_feedback.rb
+++ b/app/models/usage_feedback.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: usage_feedbacks
+#
+#  id         :bigint           not null, primary key
+#  model      :string
+#  rating     :string           not null
+#  created_at :datetime         not null
+#  request_id :string
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_usage_feedbacks_on_user_id                 (user_id)
+#  index_usage_feedbacks_on_user_id_and_created_at  (user_id,created_at)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
+class UsageFeedback < ApplicationRecord
+  belongs_to :user
+
+  RATINGS = %w[up down].freeze
+
+  validates :rating, inclusion: { in: RATINGS }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,10 +7,13 @@
 #  email                  :string           default(""), not null
 #  encrypted_password     :string           default(""), not null
 #  jti                    :string           not null
+#  last_country           :string
+#  last_seen_at           :datetime
 #  provider               :string
 #  remember_created_at    :datetime
 #  reset_password_sent_at :datetime
 #  reset_password_token   :string
+#  role                   :string           default("member"), not null
 #  terms_accepted         :boolean          default(FALSE), not null
 #  terms_accepted_at      :datetime
 #  terms_accepted_version :string
@@ -23,6 +26,7 @@
 #
 #  index_users_on_email                 (email) UNIQUE
 #  index_users_on_jti                   (jti) UNIQUE
+#  index_users_on_last_seen_at          (last_seen_at)
 #  index_users_on_provider_and_uid      (provider,uid) UNIQUE
 #  index_users_on_reset_password_token  (reset_password_token) UNIQUE
 #
@@ -41,6 +45,8 @@ class User < ApplicationRecord
   has_many :subscriptions, dependent: :destroy
   has_many :plans, through: :subscriptions
   has_many :brand_pages, dependent: :destroy
+  has_many :credit_wallets, dependent: :destroy
+  has_many :usage_events, dependent: :destroy
   has_one :profile, dependent: :destroy
 
   mount_uploader :avatar, AvatarUploader
@@ -87,6 +93,18 @@ class User < ApplicationRecord
         terms_accepted: ActiveModel::Type::Boolean.new.cast(terms_accepted) || false
       )
     end
+  end
+
+  # Application roles. `member` is the default; `admin` unlocks staff-only
+  # surfaces (SPEC §6 — replaces the hard-coded jbuilder role).
+  ROLES = %w[member admin].freeze
+
+  def admin?
+    role == "admin"
+  end
+
+  def member?
+    role == "member"
   end
 
   def retrieve_stripe_customer

--- a/app/services/levelcode/activity.rb
+++ b/app/services/levelcode/activity.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+module Levelcode
+  # GitHub-style contribution activity for the account dashboard: per-day usage of the
+  # editor (request counts + tokens + cost) with a per-model breakdown, aggregated from
+  # the durable usage_events ledger. Days are bucketed by DATE(created_at) in the app
+  # timezone-naive DB time (UTC) — a single grouped query, folded in Ruby.
+  module Activity
+    module_function
+
+    # @return [Hash] { year:, total:, days: { "YYYY-MM-DD" => {count,input,output,cost_micros,models:[…]} },
+    #                  models: [{model,count,input,output,cost_micros,up,down}, …], years: [Int,…] }
+    def for_user(user, year:)
+      year = year.to_i
+      range = Time.zone.local(year, 1, 1).all_year
+
+      rows = UsageEvent.where(user_id: user.id, created_at: range)
+                       .group(Arel.sql("DATE(created_at)"), :model)
+                       .pluck(
+                         Arel.sql("DATE(created_at)"),
+                         :model,
+                         Arel.sql("COUNT(*)"),
+                         Arel.sql("COALESCE(SUM(input_tokens), 0)"),
+                         Arel.sql("COALESCE(SUM(output_tokens), 0)"),
+                         Arel.sql("COALESCE(SUM(cost_micros), 0)")
+                       )
+
+      days = {}
+      model_totals = Hash.new { |h, k| h[k] = { count: 0, input: 0, output: 0, cost_micros: 0 } }
+
+      rows.each do |date, model, count, inp, out, cost|
+        m = canonical_model(model)
+        count = count.to_i; inp = inp.to_i; out = out.to_i; cost = cost.to_i
+
+        day = days[date.to_s] ||= { count: 0, input: 0, output: 0, cost_micros: 0, models: {} }
+        day[:count] += count; day[:input] += inp; day[:output] += out; day[:cost_micros] += cost
+        dm = day[:models][m] ||= { count: 0, input: 0, output: 0, cost_micros: 0 }
+        dm[:count] += count; dm[:input] += inp; dm[:output] += out; dm[:cost_micros] += cost
+
+        t = model_totals[m]
+        t[:count] += count; t[:input] += inp; t[:output] += out; t[:cost_micros] += cost
+      end
+      # Fold each day's per-model map into a count-sorted array.
+      days.each_value { |d| d[:models] = d[:models].map { |mm, v| v.merge(model: mm) }.sort_by { |x| -x[:count] } }
+
+      fb = feedback_by_model(user, range)
+      models = model_totals.map { |m, v| v.merge(model: m, up: fb.dig(m, "up").to_i, down: fb.dig(m, "down").to_i) }
+                           .sort_by { |m| -m[:count] }
+
+      {
+        year: year,
+        total: days.values.sum { |d| d[:count] },
+        days: days,
+        models: models,
+        years: available_years(user)
+      }
+    end
+
+    # Collapse a dated model snapshot to its base id (strip a trailing "-YYYYMMDD"/"-YYMMDD"),
+    # so metering — which records the UPSTREAM-resolved model (e.g. "moonshotai/kimi-k2.7-code-20260612")
+    # — and feedback — recorded against the REQUESTED id ("moonshotai/kimi-k2.7-code") — aggregate to the
+    # same row. Non-dated ids (e.g. "openai/gpt-oss-120b") pass through unchanged.
+    def canonical_model(model)
+      (model.presence || "unknown").sub(/-\d{6,8}\z/, "")
+    end
+
+    # { canonical_model => { "up" => n, "down" => n } } — summed across raw model strings that
+    # canonicalize to the same id.
+    def feedback_by_model(user, range)
+      UsageFeedback.where(user_id: user.id, created_at: range)
+                   .group(:model, :rating)
+                   .count
+                   .each_with_object(Hash.new { |h, k| h[k] = Hash.new(0) }) do |((model, rating), n), acc|
+        acc[canonical_model(model)][rating] += n
+      end
+    end
+
+    # Descending list of years the user has any usage in (for the year picker); always
+    # includes the current year so a brand-new user still sees a grid.
+    def available_years(user)
+      years = UsageEvent.where(user_id: user.id)
+                        .distinct
+                        .pluck(Arel.sql("EXTRACT(YEAR FROM created_at)::int"))
+                        .map(&:to_i)
+      (years + [ Time.current.year ]).uniq.sort.reverse
+    end
+
+    private_class_method :canonical_model, :feedback_by_model, :available_years
+  end
+end

--- a/app/services/levelcode/admin_report.rb
+++ b/app/services/levelcode/admin_report.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+module Levelcode
+  # Aggregations for the admin dashboard (admin-only). System-wide token/request totals and a
+  # per-user roll-up (tokens burned, requests, plan, country, auth attempts) that the admin can
+  # sort/filter to find the heaviest users and spot login problems. Each metric is one grouped
+  # query; the per-user list is assembled in Ruby (fine at current scale — revisit with pagination
+  # pushed into SQL if the user table grows large).
+  module AdminReport
+    module_function
+
+    PRODUCT = "levelcode"
+    SORTS = %w[input output requests cost last_seen auth_attempts auth_failures email plan created].freeze
+    # Postgres FILTER aggregate — count only the failed attempts in the same pass.
+    FAIL_FILTER = Arel.sql("COUNT(*) FILTER (WHERE outcome = 'failure')")
+
+    # System-wide totals + plan/country/auth breakdowns for the summary cards.
+    def summary
+      u = UsageEvent.pick(
+        Arel.sql("COALESCE(SUM(input_tokens), 0)"),
+        Arel.sql("COALESCE(SUM(output_tokens), 0)"),
+        Arel.sql("COUNT(*)"),
+        Arel.sql("COALESCE(SUM(cost_micros), 0)")
+      ) || [ 0, 0, 0, 0 ]
+      a = AuthEvent.pick(Arel.sql("COUNT(*)"), FAIL_FILTER) || [ 0, 0 ]
+
+      {
+        users: User.count,
+        active_users: UsageEvent.distinct.count(:user_id),
+        input: u[0].to_i,
+        output: u[1].to_i,
+        requests: u[2].to_i,
+        cost_micros: u[3].to_i,
+        plans: plan_counts,
+        countries: User.where.not(last_country: nil).group(:last_country).count,
+        auth_attempts: a[0].to_i,
+        auth_failures: a[1].to_i,
+        auth_failures_by_country: AuthEvent.failures.where.not(country: nil).group(:country).count
+      }
+    end
+
+    # Per-user roll-up, sorted + filtered + paginated.
+    def users(sort: "input", dir: "desc", q: nil, plan: nil, limit: 100, offset: 0)
+      rows = enriched_users
+      rows = rows.select { |r| r[:email].to_s.include?(q.to_s.strip.downcase) } if q.present?
+      rows = rows.select { |r| r[:plan] == plan } if plan.present?
+
+      key = SORTS.include?(sort.to_s) ? sort.to_s : "input"
+      rows = rows.sort_by { |r| sort_value(r, key) }
+      rows.reverse! unless dir.to_s == "asc"
+
+      { total: rows.size, limit: limit, offset: offset, users: rows[offset, limit] || [] }
+    end
+
+    # --- internals -----------------------------------------------------------
+
+    def enriched_users
+      usage = UsageEvent.group(:user_id).pluck(
+        :user_id,
+        Arel.sql("COALESCE(SUM(input_tokens), 0)"),
+        Arel.sql("COALESCE(SUM(output_tokens), 0)"),
+        Arel.sql("COUNT(*)"),
+        Arel.sql("COALESCE(SUM(cost_micros), 0)")
+      ).each_with_object({}) { |(uid, i, o, r, c), h| h[uid] = [ i.to_i, o.to_i, r.to_i, c.to_i ] }
+
+      auth = AuthEvent.where.not(user_id: nil).group(:user_id).pluck(:user_id, Arel.sql("COUNT(*)"), FAIL_FILTER)
+                      .each_with_object({}) { |(uid, n, f), h| h[uid] = [ n.to_i, f.to_i ] }
+
+      wallets = CreditWallet.where(product: PRODUCT).pluck(:user_id, :plan_key).to_h
+
+      # Enrich only the ACTIVE set — users who have usage, an auth event, or a wallet — since every
+      # admin metric (tokens/requests/plan/country/auth) is about users who did something. This bounds
+      # the Ruby materialization to active users instead of every signup (the grouped aggregates above
+      # are DB-side and already return one row per active user).
+      ids = (usage.keys + auth.keys + wallets.keys).uniq
+      User.where(id: ids).pluck(:id, :email, :role, :last_country, :last_seen_at, :created_at).map do |id, email, role, country, seen, created|
+        us = usage[id] || [ 0, 0, 0, 0 ]
+        au = auth[id] || [ 0, 0 ]
+        {
+          id: id, email: email, role: role, plan: plan_label(wallets[id]),
+          input: us[0], output: us[1], requests: us[2], cost_micros: us[3],
+          country: country, last_seen_at: seen,
+          auth_attempts: au[0], auth_failures: au[1], created_at: created
+        }
+      end
+    end
+
+    def sort_value(row, key)
+      case key
+      when "email", "plan" then row[key.to_sym].to_s
+      when "last_seen"     then row[:last_seen_at]&.to_i || 0
+      when "created"       then row[:created_at]&.to_i || 0
+      else row[key.to_sym].to_i # input/output/requests/cost/auth_attempts/auth_failures
+      end
+    end
+
+    def plan_counts
+      CreditWallet.where(product: PRODUCT).group(:plan_key).count
+                  .each_with_object(Hash.new(0)) { |(k, n), h| h[plan_label(k)] += n }
+    end
+
+    def plan_label(key)
+      k = key.to_s
+      return "Free" if k.blank? || k == Levelcode::FREE_PLAN_KEY
+
+      Levelcode.plan(k)&.dig(:name) || k
+    end
+
+    private_class_method :enriched_users, :sort_value, :plan_counts, :plan_label
+  end
+end

--- a/app/services/levelcode/ai_router.rb
+++ b/app/services/levelcode/ai_router.rb
@@ -1,0 +1,55 @@
+module Levelcode
+  # Picks the upstream adapter and streams the OpenAI-compatible completion through
+  # transparently (SPEC §7). The EFFECTIVE MODEL is decided by the caller from the
+  # user's tier (Levelcode.gateway_model) and passed in — the router never lets the
+  # request's own `model` field pick a pricier engine than the plan allows.
+  #
+  #   Levelcode::AiRouter.call(body, model:, on_chunk:)
+  #
+  # `on_chunk` receives each raw SSE `data:` payload verbatim. Returns the adapter
+  # Result (usage + effective model).
+  class AiRouter
+    # Fallback only — the caller always passes an explicit model.
+    DEFAULT_MODEL = ENV.fetch("LEVELCODE_MODEL", "moonshotai/kimi-k2.7-code").freeze
+
+    def self.call(body, model:, on_chunk:)
+      new(body, model: model).call(on_chunk: on_chunk)
+    end
+
+    def self.complete(body, model:)
+      new(body, model: model).complete
+    end
+
+    def initialize(body, model:)
+      @body = body
+      @model = model.presence || DEFAULT_MODEL
+    end
+
+    def call(on_chunk:)
+      adapter.stream(routed_body, on_chunk: on_chunk)
+    end
+
+    def complete
+      adapter.complete(routed_body)
+    end
+
+    private
+
+    attr_reader :body, :model
+
+    def adapter
+      @adapter ||=
+        if defined?(MoonshotAdapter) && MoonshotAdapter.enabled? && model.to_s.start_with?("moonshotai/")
+          MoonshotAdapter.new
+        else
+          OpenRouterAdapter.new
+        end
+    end
+
+    # Force the tier's model; leave every other field (messages, tools,
+    # stream_options, …) untouched.
+    def routed_body
+      body.merge("model" => model)
+    end
+  end
+end

--- a/app/services/levelcode/editor_token.rb
+++ b/app/services/levelcode/editor_token.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+module Levelcode
+  # Mints, verifies and revokes the **editor access/refresh tokens** used by the
+  # LevelCode editor to talk to `/api/levelcode/v1/*` (SPEC §2).
+  #
+  # These are distinct from the browser (devise-jwt) tokens: they are signed with
+  # LEVELCODE_JWT_SECRET, HS256, and carry an explicit scope. Revocation is a `jti`
+  # denylist held in a Redis set (`levelcode:revoked:jti`).
+  #
+  #   access  — TTL 60 min, scope "ai:chat account:read"
+  #   refresh — TTL 30 days, scope "refresh"
+  module EditorToken
+    module_function
+
+    ALGORITHM      = "HS256"
+    ACCESS_TTL     = 60.minutes
+    REFRESH_TTL    = 30.days
+    # ai:chat  — plain completions through the gateway
+    # ai:agent — tool-calling (agent) turns; same endpoint, distinct scope so a
+    #            reduced-capability token can be issued and so agent use is
+    #            explicit. (Per-USER agent access is a PLAN entitlement, enforced
+    #            in the gateway — not the token scope.)
+    # account:read — profile/usage/billing reads.
+    ACCESS_SCOPE   = "ai:chat ai:agent account:read"
+    REFRESH_SCOPE  = "refresh"
+    SESSION_TTL    = 30.days
+    SESSION_SCOPE  = "account:read" # web session: account/billing reads only, NOT the AI gateway
+    REVOKED_SET    = "levelcode:revoked:jti"
+
+    class Error < StandardError; end
+    class InvalidToken < Error; end
+
+    # Mint a short-lived access token for the user.
+    def mint_access(user)
+      encode(user, scope: ACCESS_SCOPE, ttl: ACCESS_TTL)
+    end
+
+    # Mint a long-lived refresh token for silent renewal.
+    def mint_refresh(user)
+      encode(user, scope: REFRESH_SCOPE, ttl: REFRESH_TTL)
+    end
+
+    # Mint the WEB session token (levelcode.ai httpOnly cookie). Long-lived to match
+    # the cookie, and scoped to account reads only — it must NOT be usable at the
+    # AI gateway (carries no ai:* scope).
+    def mint_session(user)
+      encode(user, scope: SESSION_SCOPE, ttl: SESSION_TTL)
+    end
+
+    # Verify signature + expiry, then (optionally) assert the scope and that the
+    # jti has not been revoked. Returns the decoded claims hash, or raises
+    # InvalidToken.
+    def verify(token, scope: nil)
+      claims, = JWT.decode(token.to_s, secret, true, algorithm: ALGORITHM)
+
+      if scope && !scopes_for(claims).include?(scope)
+        raise InvalidToken, "token missing required scope: #{scope}"
+      end
+      raise InvalidToken, "token revoked" if revoked?(claims["jti"])
+
+      claims
+    rescue JWT::DecodeError => e
+      raise InvalidToken, e.message
+    end
+
+    # Add a jti to the Redis denylist so future verifications reject it. Kept for
+    # the token's remaining lifetime; we set a generous TTL matching the longest
+    # (refresh) token so the entry self-expires.
+    def revoke!(jti)
+      return false if jti.blank?
+      return false unless redis
+
+      redis.sadd(REVOKED_SET, jti)
+      redis.expire(REVOKED_SET, REFRESH_TTL.to_i)
+      true
+    end
+
+    def revoked?(jti)
+      return false if jti.blank?
+      return false unless redis
+
+      redis.sismember(REVOKED_SET, jti)
+    rescue StandardError => e
+      # Fail-open on Redis trouble — a signed, unexpired token still authenticates.
+      Rails.logger.warn("Levelcode::EditorToken revoked? check failed: #{e.message}")
+      false
+    end
+
+    # --- internals -----------------------------------------------------------
+
+    def encode(user, scope:, ttl:)
+      now = Time.now.to_i
+      payload = {
+        sub: user.id,
+        jti: SecureRandom.uuid,
+        scope: scope,
+        iat: now,
+        exp: now + ttl.to_i
+      }
+      JWT.encode(payload, secret, ALGORITHM)
+    end
+
+    def scopes_for(claims)
+      claims["scope"].to_s.split(/\s+/)
+    end
+
+    def redis
+      defined?($redis) ? $redis : nil
+    end
+
+    def secret
+      ENV["LEVELCODE_JWT_SECRET"].presence ||
+        Rails.application.credentials.dig(:levelcode_jwt_secret) ||
+        raise(Error, "LEVELCODE_JWT_SECRET is not configured")
+    end
+    private_class_method :encode, :scopes_for, :redis, :secret
+  end
+end

--- a/app/services/levelcode/email_code.rb
+++ b/app/services/levelcode/email_code.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+module Levelcode
+  # Passwordless email one-time-code (OTP) for LevelCode Cloud sign-in — the
+  # OpenRouter/Cursor "magic code" flow: request a code by email, type it in,
+  # you're in (SPEC §2, email method). Distinct from Levelcode::OneTimeCode, which
+  # is the internal OAuth-style handoff to the editor AFTER auth.
+  #
+  # Security posture:
+  #   - 6-digit numeric code, HMAC-hashed at rest (Redis leak != plaintext codes),
+  #     bound to the email address.
+  #   - 10-minute TTL, SINGLE-USE (deleted on first success).
+  #   - MAX_ATTEMPTS online guesses per code, then the code is burned.
+  #   - Per-email resend throttle (RESEND_WINDOW) to blunt email-bombing; the
+  #     controller adds a per-IP cap on top.
+  # A 6-digit code is 10^6; the attempt cap + single-use + short TTL bound online
+  # brute force. (Widen to 8 digits if desired — CODE_DIGITS.)
+  module EmailCode
+    module_function
+
+    TTL           = 10.minutes
+    RESEND_WINDOW = 60.seconds
+    MAX_ATTEMPTS  = 5
+    CODE_DIGITS   = 6
+
+    class Error < StandardError; end
+    class RateLimited < Error; end
+
+    # Issue a fresh code for `email`, store it hashed, return the plaintext code
+    # for the caller to email. Raises RateLimited if one was issued < RESEND_WINDOW ago.
+    def issue(email)
+      raise Error, "redis unavailable" unless redis
+
+      norm = normalize(email)
+      # Redis#exists? returns a boolean (redis-rb >= 4.2).
+      raise RateLimited, "code recently sent" if redis.exists?(resend_key(norm))
+
+      code = format("%0#{CODE_DIGITS}d", SecureRandom.random_number(10**CODE_DIGITS))
+      redis.setex(code_key(norm), TTL.to_i, digest(norm, code)) # store the hash only
+      redis.del(attempts_key(norm))                             # fresh guess counter
+      redis.setex(resend_key(norm), RESEND_WINDOW.to_i, "1")
+      code
+    end
+
+    # Clear a pending code, its guess counter, and the resend throttle — used when
+    # delivery failed so the user can request a new one immediately.
+    def clear(email)
+      return unless redis
+
+      norm = normalize(email)
+      redis.del(code_key(norm), attempts_key(norm), resend_key(norm))
+    end
+
+    # Verify `code` for `email`. Constant-time; single-use on success; attempt-capped.
+    # Returns true/false (never raises for a bad code).
+    def verify(email, code)
+      return false if email.blank? || code.blank?
+      raise Error, "redis unavailable" unless redis
+
+      norm = normalize(email)
+      stored = redis.get(code_key(norm))
+      return false if stored.blank?
+
+      # Atomic attempt cap: INCR a sibling counter so parallel wrong guesses can't
+      # race past MAX_ATTEMPTS (a Ruby-side read-modify-write would undercount and
+      # let an attacker exceed the cap against the 10^6 space within the TTL).
+      attempts = redis.incr(attempts_key(norm))
+      redis.expire(attempts_key(norm), TTL.to_i) if attempts == 1
+      if attempts > MAX_ATTEMPTS
+        redis.del(code_key(norm), attempts_key(norm)) # burn the code
+        return false
+      end
+
+      if ActiveSupport::SecurityUtils.secure_compare(stored.to_s, digest(norm, code))
+        redis.del(code_key(norm), attempts_key(norm)) # single-use
+        true
+      else
+        false
+      end
+    end
+
+    # --- internals -----------------------------------------------------------
+
+    def normalize(email)
+      email.to_s.strip.downcase
+    end
+
+    def digest(email, code)
+      OpenSSL::HMAC.hexdigest("SHA256", hmac_secret, "#{email}:#{code}")
+    end
+
+    def hmac_secret
+      # Fail CLOSED — never degrade to a constant. This HMAC key is the only
+      # at-rest protection for OTP hashes; a known key makes them brute-forceable
+      # offline (10^6). Mirrors Levelcode::EditorToken#secret.
+      ENV["LEVELCODE_JWT_SECRET"].presence ||
+        (defined?(Rails) && Rails.application.credentials.dig(:levelcode_jwt_secret)) ||
+        raise(Error, "LEVELCODE_JWT_SECRET is not configured")
+    end
+
+    def code_key(email)
+      "levelcode:emailcode:#{email}"
+    end
+
+    def resend_key(email)
+      "levelcode:emailcode:sent:#{email}"
+    end
+
+    def attempts_key(email)
+      "levelcode:emailcode:attempts:#{email}"
+    end
+
+    def redis
+      defined?($redis) ? $redis : nil
+    end
+    private_class_method :normalize, :digest, :hmac_secret, :code_key, :resend_key, :attempts_key, :redis
+  end
+end

--- a/app/services/levelcode/free_tier.rb
+++ b/app/services/levelcode/free_tier.rb
@@ -37,10 +37,20 @@ module Levelcode
       CreditWallet.find_by!(user: user, product: PRODUCT)
     end
 
-    # An ACTIVE paid plan — leave it alone. (Enforcement is the dollar budget now.)
+    # A grace window past period_end before a paid wallet is treated as lapsed — covers normal
+    # renewal/dunning lag so a paying user is never downgraded mid-renewal.
+    PAID_GRACE = 3.days
+
+    # An ACTIVE paid plan — leave it alone. (Enforcement is the dollar budget now.) A paid wallet whose
+    # period ended well beyond the renewal/dunning window is treated as LAPSED (its cancel/expiry
+    # webhook was likely dropped) → it stops shielding the wallet from the free roll, so entitlement
+    # falls back to free instead of honoring flagship access indefinitely for free.
     def paid?(wallet)
       key = wallet.plan_key.to_s
-      key.present? && key != FREE_PLAN_KEY && wallet.budget_micros.to_i.positive?
+      return false unless key.present? && key != FREE_PLAN_KEY && wallet.budget_micros.to_i.positive?
+      return true if wallet.period_end.blank?
+
+      wallet.period_end >= Time.current - PAID_GRACE
     end
 
     # (Re)provision when the wallet isn't a valid free wallet yet: brand new / not

--- a/app/services/levelcode/free_tier.rb
+++ b/app/services/levelcode/free_tier.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module Levelcode
+  # Free tier (M11): a logged-in, not-yet-paid editor user gets gateway access on
+  # the cheap open-weights engine (Levelcode::FREE_MODEL). This provisions — and
+  # lazily rolls each month — a "free" plan CreditWallet, which is the metering
+  # anchor. It NEVER touches a real paid plan (that's the Stripe webhook's job).
+  module FreeTier
+    module_function
+
+    PRODUCT = "levelcode"
+
+    # The user's levelcode wallet: their PAID plan if active, otherwise a fresh (or
+    # month-rolled) free wallet. Always returns a persisted wallet. Idempotent.
+    #
+    # Concurrency: a brand-new wallet is created optimistically (the (user, product)
+    # unique index + the RecordNotUnique rescue serialize the INSERT race). An EXISTING
+    # wallet is (re)checked and rolled UNDER A ROW LOCK (with_lock → SELECT … FOR UPDATE,
+    # which reloads), so a concurrent paid-plan write (Levelcode::WebhookSync upgrading the
+    # same row on a Stripe webhook) can't be clobbered by our free roll — without the lock
+    # that read-decide-write is a TOCTOU lost update that silently downgrades a payer.
+    def wallet_for(user)
+      wallet = CreditWallet.find_or_initialize_by(user: user, product: PRODUCT)
+
+      if wallet.new_record?
+        roll_free!(wallet) # nothing to clobber; a lost INSERT race is caught below
+        return wallet
+      end
+
+      wallet.with_lock do
+        roll_free!(wallet) if !paid?(wallet) && needs_free_provision?(wallet)
+      end
+      wallet
+    rescue ActiveRecord::RecordNotUnique
+      # Lost the INSERT race to a concurrent provisioner (e.g. the paid-plan webhook) —
+      # return the winner untouched rather than rolling it to free.
+      CreditWallet.find_by!(user: user, product: PRODUCT)
+    end
+
+    # An ACTIVE paid plan — leave it alone. (Enforcement is the dollar budget now.)
+    def paid?(wallet)
+      key = wallet.plan_key.to_s
+      key.present? && key != FREE_PLAN_KEY && wallet.budget_micros.to_i.positive?
+    end
+
+    # (Re)provision when the wallet isn't a valid free wallet yet: brand new / not
+    # free / no period / month elapsed / budget somehow zeroed. Does NOT re-roll on a
+    # mid-period value tweak, so usage isn't reset by an ENV change.
+    def needs_free_provision?(wallet)
+      wallet.plan_key.to_s != FREE_PLAN_KEY ||
+        wallet.period_end.blank? ||
+        wallet.period_end < Time.current ||
+        wallet.budget_micros.to_i <= 0
+    end
+
+    def roll_free!(wallet)
+      now = Time.current
+      wallet.update!(
+        plan_key: FREE_PLAN_KEY,
+        input_cap: FREE_INPUT_CAP,
+        output_cap: FREE_OUTPUT_CAP,
+        # M14: the enforced ceiling is the DOLLAR budget (~$0.30/mo). Token caps stay as info.
+        budget_micros: Levelcode.free_budget_micros,
+        spent_micros: 0,
+        # Hard cap → upgrade CTA (the M11 cost ceiling). The Redis hot counters key
+        # on period_end, so a new period_end starts fresh counters automatically.
+        overage_policy: "stop",
+        period_start: now,
+        period_end: now + 1.month,
+        input_used: 0,
+        output_used: 0
+      )
+    end
+
+    private_class_method :paid?, :needs_free_provision?, :roll_free!
+  end
+end

--- a/app/services/levelcode/metering.rb
+++ b/app/services/levelcode/metering.rb
@@ -1,0 +1,135 @@
+module Levelcode
+  # Redis hot-counter metering + pre-request enforcement (SPEC §5).
+  #
+  # Counters live at `levelcode:used:{user}:{period}:{in|out}` and are the fast
+  # path consulted before each request; the durable ledger (usage_events) is
+  # written off-request by RecordUsageJob. All Redis access is fail-open: if
+  # Redis is down we warn and let the request through rather than hard-blocking
+  # a paying user on an infra hiccup.
+  module Metering
+    module_function
+
+    # Orphaned per-period counter keys (the key embeds period_end) would otherwise
+    # live forever; expire them well past any billing period so they self-clean.
+    COUNTER_TTL = 60 * 24 * 60 * 60 # 60 days
+
+    # Result of a pre-request check. `allowed` false ⇒ caller must 402.
+    # `throttle` true ⇒ caller forces the small model. `policy` echoes the
+    # wallet's overage_policy for building the error payload.
+    Decision = Struct.new(:allowed, :throttle, :policy, keyword_init: true) do
+      def blocked?
+        !allowed
+      end
+    end
+
+    # Decide whether/how to serve the request against the wallet's DOLLAR budget (M14). Compares the
+    # micro-$ spent this period (Redis hot counter) to budget_micros. Fail-open on Redis errors.
+    def check!(wallet)
+      # No budget ⇒ no active managed plan (BYOK / canceled / unprovisioned). BLOCK — a zero budget
+      # is NOT "unlimited". This must come before any fail-open Redis path.
+      if wallet.budget_micros.to_i <= 0
+        return Decision.new(allowed: false, throttle: false, policy: "stop")
+      end
+
+      # spent_micros falls back to the DURABLE wallet.spent_micros if Redis is down — so an
+      # over-budget hard-stop wallet stays blocked through an outage, while an under-budget wallet
+      # still passes (no paying user blocked on infra noise).
+      decide(over_budget?(spent_micros(wallet), wallet), wallet)
+    end
+
+    # True when this period's spend has reached the dollar budget.
+    def over_budget?(spent, wallet)
+      spent >= wallet.budget_micros.to_i
+    end
+
+    # Map (over_cap?, policy) → a Decision. Under cap: allow. Over cap: throttle
+    # forces the small model (allowed); topup/stop 402 (the controller shapes the body).
+    def decide(over_cap, wallet)
+      return Decision.new(allowed: true, throttle: false, policy: wallet.overage_policy) unless over_cap
+
+      case wallet.overage_policy
+      when "throttle"
+        Decision.new(allowed: true, throttle: true, policy: "throttle")
+      else # "topup" or "stop" — both 402; the controller differentiates the body
+        Decision.new(allowed: false, throttle: false, policy: wallet.overage_policy)
+      end
+    end
+
+    # Increment the hot counters once the final usage is known: input/output tokens (informational)
+    # AND the micro-$ SPEND (the enforced budget). Fail-open. Durable per-period totals live in the
+    # CreditWallet columns (kept in sync by RecordUsageJob); these Redis counters are the fast cache.
+    def record(wallet, input_tokens, output_tokens, cost_micros = 0)
+      input_tokens = input_tokens.to_i
+      output_tokens = output_tokens.to_i
+      cost_micros = cost_micros.to_i
+      return if input_tokens.zero? && output_tokens.zero? && cost_micros.zero?
+
+      redis.pipelined do |pipe|
+        pipe.incrby(key(wallet, "in"), input_tokens)
+        pipe.incrby(key(wallet, "out"), output_tokens)
+        pipe.incrby(key(wallet, "spent"), cost_micros)
+        pipe.expire(key(wallet, "in"), COUNTER_TTL)
+        pipe.expire(key(wallet, "out"), COUNTER_TTL)
+        pipe.expire(key(wallet, "spent"), COUNTER_TTL)
+      end
+      true
+    rescue => e
+      warn_redis(e)
+      false
+    end
+
+    # Micro-$ spent this period, for enforcement. Takes the MAX of the live Redis counter and the
+    # durable wallet.spent_micros — always enforcing on whichever shows MORE spend. This closes the
+    # money-direction fail-open where the Redis counter UNDERCOUNTS while Redis is up and answering:
+    #   - a lost INCRBY during a prior Redis outage (record() fail-opens; the durable ledger still
+    #     bumps via RecordUsageJob),
+    #   - an LRU eviction / cold-replica failover / FLUSHDB (GET misses → 0),
+    #   - a period_end re-anchor (mid-cycle plan change) orphaning the old key (GET on the new key
+    #     misses → 0) while spent_micros is deliberately preserved.
+    # In steady state the Redis counter leads (the durable column lags the async job), so max == Redis;
+    # when Redis is behind/empty, max == the durable column → an over-budget wallet stays blocked and
+    # spend is never refunded. It's a MAX, not a sum, so it never double-counts.
+    def spent_micros(wallet)
+      [ redis.get(key(wallet, "spent")).to_i, wallet.spent_micros.to_i ].max
+    rescue => e
+      warn_redis(e)
+      wallet.spent_micros.to_i
+    end
+
+    # Live per-period token usage [input, output] for the account dashboard (informational).
+    # Falls back to the durable wallet columns if Redis is unavailable.
+    def usage(wallet)
+      current_usage(wallet)
+    rescue => e
+      warn_redis(e)
+      [ wallet.input_used.to_i, wallet.output_used.to_i ]
+    end
+
+    # -- internals ------------------------------------------------------------
+
+    def current_usage(wallet)
+      values = redis.mget(key(wallet, "in"), key(wallet, "out"))
+      [ values[0].to_i, values[1].to_i ]
+    end
+
+    def key(wallet, direction)
+      "levelcode:used:#{wallet.user_id}:#{period(wallet)}:#{direction}"
+    end
+
+    # A stable per-billing-period token so counters roll over with the wallet.
+    def period(wallet)
+      wallet.period_end&.to_i || wallet.period_start&.to_i || "current"
+    end
+
+    def redis
+      $redis
+    end
+
+    def warn_redis(error)
+      Rails.logger.warn("[Levelcode::Metering] Redis unavailable, degrading gracefully: #{error.class}: #{error.message}")
+      StatsD.increment("orbits.metering.redis_error") if defined?(StatsD)
+    end
+
+    private_class_method :over_budget?, :decide, :current_usage, :key, :period, :redis, :warn_redis
+  end
+end

--- a/app/services/levelcode/metering.rb
+++ b/app/services/levelcode/metering.rb
@@ -22,6 +22,11 @@ module Levelcode
       end
     end
 
+    # Result of an admission-time budget reservation (M14 concurrency guard). `ok` false ⇒ the request
+    # would push spend past the budget and must 402. `amount` is the micro-$ reserved (0 when nothing
+    # was reserved: a non-positive estimate, or a fail-open Redis error) — pass it back to settle!.
+    Reservation = Struct.new(:ok, :amount, keyword_init: true)
+
     # Decide whether/how to serve the request against the wallet's DOLLAR budget (M14). Compares the
     # micro-$ spent this period (Redis hot counter) to budget_micros. Fail-open on Redis errors.
     def check!(wallet)
@@ -78,6 +83,88 @@ module Levelcode
       false
     end
 
+    # Reserve `estimate_micros` of budget for an IN-FLIGHT request, atomically, so CONCURRENT
+    # admissions see each other's reservations and can't collectively overshoot the dollar budget
+    # (the check!-then-record window: spend only lands after a stream closes). INCRBYs the hot spend
+    # counter up-front; if that tips total spend past the budget, it rolls the reservation back and
+    # returns ok:false (caller must 402). Fail-open on Redis error (allow, amount 0) so a paying user
+    # isn't blocked on an infra blip — the durable ledger still records the real spend afterward.
+    def reserve!(wallet, estimate_micros)
+      estimate_micros = estimate_micros.to_i
+      return Reservation.new(ok: true, amount: 0) if estimate_micros <= 0
+
+      k = key(wallet, "spent")
+      new_spent = redis.incrby(k, estimate_micros) # the reservation is now on the counter
+      begin
+        redis.expire(k, COUNTER_TTL)
+      rescue => e
+        # TTL is best-effort; the reservation still stands, so we must fall through and RETURN its
+        # amount so settle! subtracts it later (returning 0 here would strand the estimate).
+        warn_redis(e)
+      end
+
+      if new_spent > wallet.budget_micros.to_i
+        begin
+          redis.incrby(k, -estimate_micros) # roll back — this request doesn't fit the remaining budget
+        rescue => e
+          warn_redis(e) # rollback is best-effort; a stranded estimate over-counts (safe direction, TTL'd)
+        end
+        return Reservation.new(ok: false, amount: 0)
+      end
+      Reservation.new(ok: true, amount: estimate_micros)
+    rescue => e
+      # The reserving INCRBY itself failed → nothing landed on the counter → fail open (no reservation).
+      warn_redis(e)
+      Reservation.new(ok: true, amount: 0)
+    end
+
+    # Reconcile a reservation to the ACTUAL spend once the request settles. The hot counter already
+    # holds `reserved_micros` (from reserve!), so adjust it by (actual − reserved) to land on the real
+    # spend; with no reservation (throttle / fail-open path) just add the actual. Always bumps the
+    # informational input/output token counters too. Fail-open.
+    def settle!(wallet, reserved_micros, input_tokens, output_tokens, actual_micros)
+      reserved_micros = reserved_micros.to_i
+      actual_micros   = actual_micros.to_i
+      input_tokens    = input_tokens.to_i
+      output_tokens   = output_tokens.to_i
+      delta = actual_micros - reserved_micros
+      return true if delta.zero? && input_tokens.zero? && output_tokens.zero?
+
+      unless delta.zero?
+        spent_key = key(wallet, "spent")
+        new_spent = redis.incrby(spent_key, delta)
+        # A same-epoch reset (clear!) or eviction between reserve! and here can leave the estimate OFF
+        # the counter, so a negative delta would drive it below zero and mask real spend against the
+        # budget — floor it at 0. (spent_micros also floors defensively for the same reason.)
+        redis.set(spent_key, 0) if new_spent.to_i.negative?
+        redis.expire(spent_key, COUNTER_TTL)
+      end
+
+      unless input_tokens.zero? && output_tokens.zero?
+        redis.pipelined do |pipe|
+          pipe.incrby(key(wallet, "in"), input_tokens) unless input_tokens.zero?
+          pipe.incrby(key(wallet, "out"), output_tokens) unless output_tokens.zero?
+          pipe.expire(key(wallet, "in"), COUNTER_TTL)
+          pipe.expire(key(wallet, "out"), COUNTER_TTL)
+        end
+      end
+      true
+    rescue => e
+      warn_redis(e)
+      false
+    end
+
+    # Best-effort wipe of the current period's hot counters (spend/in/out). Used when usage is RESET
+    # for a period that reuses the same period_end epoch — otherwise spent_micros = max(Redis, durable)
+    # would resurrect the pre-reset spend from the stale hot counter. Fail-open.
+    def clear!(wallet)
+      redis.del(key(wallet, "spent"), key(wallet, "in"), key(wallet, "out"))
+      true
+    rescue => e
+      warn_redis(e)
+      false
+    end
+
     # Micro-$ spent this period, for enforcement. Takes the MAX of the live Redis counter and the
     # durable wallet.spent_micros — always enforcing on whichever shows MORE spend. This closes the
     # money-direction fail-open where the Redis counter UNDERCOUNTS while Redis is up and answering:
@@ -90,7 +177,9 @@ module Levelcode
     # when Redis is behind/empty, max == the durable column → an over-budget wallet stays blocked and
     # spend is never refunded. It's a MAX, not a sum, so it never double-counts.
     def spent_micros(wallet)
-      [ redis.get(key(wallet, "spent")).to_i, wallet.spent_micros.to_i ].max
+      # Floor the hot counter at 0 first: a reconcile after a mid-flight reset/eviction can briefly
+      # leave it negative, and a negative value must never suppress enforcement BELOW the durable spend.
+      [ [ redis.get(key(wallet, "spent")).to_i, 0 ].max, wallet.spent_micros.to_i ].max
     rescue => e
       warn_redis(e)
       wallet.spent_micros.to_i

--- a/app/services/levelcode/model_catalog.rb
+++ b/app/services/levelcode/model_catalog.rb
@@ -50,8 +50,10 @@ module Levelcode
       },
       "anthropic/claude-opus-4-8" => {
         label: "Opus 4.8", provider: "openrouter",
+        # Confirmed vs OpenRouter (2026-07-07): output $25/M; input list ~$5/M (effective ~$1.56
+        # after ~75% prompt-cache), cached read $0.50/M. Metering splits cached/uncached, so bills right.
         input: 5.00, cached_input: 0.50, output: 25.00,
-        context: 200_000, min_tier: :pro, status: :assumption
+        context: 200_000, min_tier: :pro, status: :confirmed
       },
       "anthropic/claude-fable-5" => {
         label: "Fable 5", provider: "openrouter",

--- a/app/services/levelcode/model_catalog.rb
+++ b/app/services/levelcode/model_catalog.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+module Levelcode
+  # The Cursor-class model roster for the LevelCode Cloud gateway — the single source of truth for
+  # which engines exist, what they cost, which plan tier may reach them, and the DISPLAY economics
+  # (credit multiplier + equivalent turns). Everything downstream (rate_table, entitlement, the
+  # editor picker, the pricing page) derives from this one table.
+  #
+  # PROFITABILITY INVARIANT (see docs, M14): plan allowances are denominated in DOLLARS (a compute
+  # budget), never in raw tokens. A token allowance sized for the flagship (Kimi) becomes a 4-digit-%
+  # loss the moment it's pointed at a frontier model. So the multipliers/turns here are DISPLAY ONLY;
+  # the durable ledger meters the ACTUAL provider cost of each request against the plan's dollar budget
+  # (Levelcode.budget_micros). Under that scheme the worst-case margin is identical for any model mix.
+  module ModelCatalog
+    module_function
+
+    # Plan tiers, ranked. A model with `min_tier: T` is reachable by any plan of rank >= rank(T).
+    TIERS = { free: 0, pro: 1, pro_plus: 2, max: 3, ultra: 4 }.freeze
+
+    # The roster. Prices are micro-dollars per token (== $/M tokens). `status`:
+    #   :confirmed  — a verified provider list price.
+    #   :assumption — a lineage-based estimate. It MUST be replaced with a live quote before the model
+    #                 is billed on. (Because the ledger meters ACTUAL response cost, an assumed price
+    #                 only skews the DISPLAYED multiplier, never the charge — but keep them honest.)
+    MODELS = {
+      "openai/gpt-oss-120b" => {
+        label: "gpt-oss-120b", provider: "openrouter",
+        input: 0.03, cached_input: 0.015, output: 0.15,
+        context: 131_072, min_tier: :free, status: :confirmed
+      },
+      "moonshotai/kimi-k2.7-code" => {
+        label: "Kimi K2.7 Code", provider: "openrouter",
+        input: 0.74, cached_input: 0.15, output: 3.50,
+        context: 262_144, min_tier: :pro, status: :confirmed
+      },
+      "openai/codex-5.3" => {
+        label: "Codex 5.3", provider: "openrouter",
+        input: 1.25, cached_input: 0.125, output: 10.00,
+        context: 400_000, min_tier: :pro, status: :assumption
+      },
+      "openai/gpt-5.5" => {
+        label: "GPT-5.5", provider: "openrouter",
+        input: 1.50, cached_input: 0.15, output: 12.00,
+        context: 400_000, min_tier: :pro, status: :assumption
+      },
+      "anthropic/claude-sonnet-5" => {
+        label: "Sonnet 5", provider: "openrouter",
+        input: 3.00, cached_input: 0.30, output: 15.00,
+        context: 200_000, min_tier: :pro, status: :assumption
+      },
+      "anthropic/claude-opus-4-8" => {
+        label: "Opus 4.8", provider: "openrouter",
+        input: 5.00, cached_input: 0.50, output: 25.00,
+        context: 200_000, min_tier: :pro, status: :assumption
+      },
+      "anthropic/claude-fable-5" => {
+        label: "Fable 5", provider: "openrouter",
+        input: 10.00, cached_input: 1.00, output: 50.00,
+        # 13.35× → only ~28 Pro turns; gated to Max/Ultra so it never feels broken (rec #3).
+        context: 200_000, min_tier: :max, status: :assumption
+      }
+    }.freeze
+
+    # The reference "turn" the display multipliers + turns-left are derived against: 40k input
+    # (50% cached) + 5.3k output — the shape the published token allowances were sized to, so the
+    # numbers reproduce the pricing table exactly. NOT used for billing (the ledger uses real cost).
+    REFERENCE_TURN = { input: 40_000, output: 5_300, cache_ratio: 0.5 }.freeze
+
+    def all = MODELS
+    def ids = MODELS.keys
+    def find(id) = MODELS[id.to_s]
+    def exists?(id) = MODELS.key?(id.to_s)
+    def label(id) = (find(id) || {})[:label] || id.to_s
+
+    # { model_id => {input:, cached_input:, output:} } — the source of Levelcode.rate_table.
+    def rate_table
+      MODELS.transform_values { |m| { input: m[:input], cached_input: m[:cached_input], output: m[:output] } }
+    end
+
+    def tier_rank(tier) = TIERS[tier.to_s.to_sym] || 0
+
+    # Cost (micro-$) of one REFERENCE_TURN on a model at that turn's cache ratio.
+    def reference_cost_micros(id)
+      m = find(id)
+      return 0 unless m
+
+      inp = REFERENCE_TURN[:input]
+      out = REFERENCE_TURN[:output]
+      cached = (inp * REFERENCE_TURN[:cache_ratio]).round
+      billed = inp - cached
+      (billed * m[:input] + cached * m[:cached_input] + out * m[:output]).round
+    end
+
+    # Credit multiplier = a model's per-turn cost relative to the flagship's, 2 dp. DERIVED from
+    # prices, so it can never drift from the pricing math into a hand-entered magic number.
+    def multiplier(id)
+      base = reference_cost_micros(Levelcode::DEFAULT_MODEL)
+      return 0.0 if base.zero?
+
+      (reference_cost_micros(id).to_f / base).round(2)
+    end
+
+    # The model ids a plan tier is entitled to (its rank >= the model's min_tier rank), catalog order.
+    def entitled(tier)
+      rank = tier_rank(tier)
+      MODELS.select { |_id, m| tier_rank(m[:min_tier]) <= rank }.keys
+    end
+  end
+end

--- a/app/services/levelcode/model_catalog.rb
+++ b/app/services/levelcode/model_catalog.rb
@@ -81,6 +81,21 @@ module Levelcode
 
     def tier_rank(tier) = TIERS[tier.to_s.to_sym] || 0
 
+    # The most EXPENSIVE confirmed per-token rates (per field) — the conservative fallback when a
+    # request's billing model id isn't in the catalog (e.g. an upstream-substituted or dated-snapshot
+    # slug). Billing an unknown id at these rates means an off-catalog model can never UNDER-bill (the
+    # safe money direction). Memoized; MODELS is frozen.
+    def max_confirmed_rate
+      @max_confirmed_rate ||= begin
+        confirmed = MODELS.values.select { |m| m[:status] == :confirmed }
+        {
+          input:        confirmed.map { |m| m[:input] }.max,
+          cached_input: confirmed.map { |m| m[:cached_input] }.max,
+          output:       confirmed.map { |m| m[:output] }.max
+        }
+      end
+    end
+
     # Cost (micro-$) of one REFERENCE_TURN on a model at that turn's cache ratio.
     def reference_cost_micros(id)
       m = find(id)

--- a/app/services/levelcode/moonshot_adapter.rb
+++ b/app/services/levelcode/moonshot_adapter.rb
@@ -1,0 +1,25 @@
+module Levelcode
+  # Stub adapter for Moonshot's native API (M-G7). Interface-compatible with
+  # Levelcode::OpenRouterAdapter but not wired until the `orbits_moonshot_native`
+  # flag is flipped (SPEC §7, §11). Kimi is reachable today via OpenRouter, so
+  # this exists only to lock the interface.
+  class MoonshotAdapter
+    Result = OpenRouterAdapter::Result
+
+    def self.enabled?
+      ENV["LEVELCODE_MOONSHOT_NATIVE"] == "true"
+    end
+
+    def initialize(api_key: ENV["MOONSHOT_API_KEY"])
+      @api_key = api_key
+    end
+
+    def stream(_body, on_chunk:)
+      raise NotImplementedError, "Levelcode::MoonshotAdapter is a stub (M-G7); use OpenRouterAdapter"
+    end
+
+    def complete(_body)
+      raise NotImplementedError, "Levelcode::MoonshotAdapter is a stub (M-G7); use OpenRouterAdapter"
+    end
+  end
+end

--- a/app/services/levelcode/one_time_code.rb
+++ b/app/services/levelcode/one_time_code.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+module Levelcode
+  # Single-use, short-lived authorization codes for the hardened editor sign-in
+  # flow (SPEC §2.1, M-G6). The site 302s the editor to
+  # `<callback>?code=<one_time_code>`; the editor then POSTs `{code, verifier}`
+  # to `/api/levelcode/v1/auth/exchange`, which redeems the code and mints tokens.
+  #
+  # PKCE (S256): at issue time we store the user id plus the caller-supplied
+  # `code_challenge`. At redeem time the caller must present the matching
+  # `code_verifier` (SHA256 → base64url == stored challenge). The code is deleted
+  # on the first redemption attempt, so it can never be replayed.
+  module OneTimeCode
+    module_function
+
+    TTL          = 60.seconds
+    KEY_PREFIX   = "levelcode:otc:"
+
+    class Error < StandardError; end
+    class InvalidCode < Error; end
+    class InvalidVerifier < Error; end
+
+    # Issue a code bound to the user, optionally to a PKCE challenge. Returns the
+    # opaque code. When `pkce_challenge` is blank the code is unbound (still
+    # single-use + 60s TTL + delivered only over the editor's custom URI scheme);
+    # PKCE binding is a hardening enabled once the editor challenge is threaded
+    # through the site (DECISIONS D15).
+    def issue(user, pkce_challenge = nil)
+      raise Error, "redis unavailable" unless redis
+
+      code = SecureRandom.urlsafe_base64(32)
+      payload = { "user_id" => user.id, "challenge" => pkce_challenge.to_s.presence }
+      redis.setex(key(code), TTL.to_i, payload.to_json)
+      code
+    end
+
+    # Redeem a code, verifying the PKCE verifier IFF the code was issued with a
+    # challenge. Single-use: the code is deleted before verification so a failed
+    # attempt cannot be retried. Returns the User or raises InvalidCode /
+    # InvalidVerifier.
+    def redeem(code, verifier = nil)
+      raise InvalidCode, "missing code" if code.blank?
+      raise Error, "redis unavailable" unless redis
+
+      raw = redis.getdel(key(code))
+      raise InvalidCode, "unknown or expired code" if raw.blank?
+
+      data = JSON.parse(raw)
+      challenge = data["challenge"]
+      if challenge.present? && !pkce_matches?(challenge, verifier)
+        raise InvalidVerifier, "PKCE verifier mismatch"
+      end
+
+      user = User.find_by(id: data["user_id"])
+      raise InvalidCode, "user no longer exists" unless user
+
+      user
+    end
+
+    # --- internals -----------------------------------------------------------
+
+    # S256: BASE64URL-NO-PAD( SHA256( ASCII(verifier) ) ) == challenge.
+    def pkce_matches?(challenge, verifier)
+      return false if challenge.blank? || verifier.blank?
+
+      digest = Digest::SHA256.digest(verifier.to_s)
+      computed = Base64.urlsafe_encode64(digest, padding: false)
+      ActiveSupport::SecurityUtils.secure_compare(computed, challenge.to_s)
+    end
+
+    def key(code)
+      "#{KEY_PREFIX}#{code}"
+    end
+
+    def redis
+      defined?($redis) ? $redis : nil
+    end
+    private_class_method :pkce_matches?, :key, :redis
+  end
+end

--- a/app/services/levelcode/open_router_adapter.rb
+++ b/app/services/levelcode/open_router_adapter.rb
@@ -1,0 +1,130 @@
+require "net/http"
+require "json"
+
+module Levelcode
+  # Streams OpenRouter's OpenAI-compatible /api/v1/chat/completions endpoint.
+  #
+  # This is a *transparent* proxy adapter (SPEC §4/§7): it yields each raw SSE
+  # `data:` line verbatim to the caller (which forwards it to the editor
+  # unchanged) and only peeks at the final `usage` object so the gateway can
+  # tee it into metering.
+  class OpenRouterAdapter
+    BASE_URL = "https://openrouter.ai/api/v1/chat/completions".freeze
+    OPEN_TIMEOUT = 15  # seconds
+    READ_TIMEOUT = 300 # seconds — long-lived streams
+
+    Result = Struct.new(:usage, :model, keyword_init: true)
+
+    def initialize(api_key: ENV["OPENROUTER_API_KEY"] || Rails.application.credentials.fetch(:openrouter_api_key))
+      @api_key = api_key
+    end
+
+    # Streams the upstream response.
+    #
+    # body      — the OpenAI chat body (Hash) to POST upstream.
+    # on_chunk: — called with each raw SSE `data:` payload string (the JSON
+    #             between `data: ` and the delimiter). `[DONE]` is NOT yielded;
+    #             the caller emits its own terminator.
+    #
+    # Returns an Levelcode::OpenRouterAdapter::Result with the final usage Hash
+    # (or nil if the upstream never sent one).
+    def stream(body, on_chunk:)
+      uri = URI(BASE_URL)
+      # Force usage reporting server-side so metering NEVER depends on the client
+      # sending stream_options.include_usage — OpenAI-shaped upstreams omit the
+      # final usage chunk otherwise, and the request would consume tokens unmetered
+      # (cap bypass + under-billing). Preserve any client-supplied stream_options.
+      stream_opts = (body["stream_options"] || body[:stream_options] || {}).merge("include_usage" => true)
+      request = build_request(uri, body.merge("stream" => true, "stream_options" => stream_opts))
+
+      usage = nil
+      model = body["model"] || body[:model]
+
+      http(uri).request(request) do |response|
+        unless response.code.to_i == 200
+          raise UpstreamError.new(response.code.to_i, read_error_body(response))
+        end
+
+        buffer = +""
+        response.read_body do |segment|
+          buffer << segment
+          # SSE events are separated by a blank line; process complete lines.
+          while (newline = buffer.index("\n"))
+            line = buffer.slice!(0..newline).chomp
+            next if line.empty?
+            next unless line.start_with?("data:")
+
+            payload = line.delete_prefix("data:").strip
+            next if payload.empty?
+            break if payload == "[DONE]"
+
+            usage = extract_usage(payload) || usage
+            on_chunk.call(payload)
+          end
+        end
+      end
+
+      Result.new(usage: usage, model: model)
+    end
+
+    # Non-streaming pass-through. Returns the parsed upstream JSON Hash.
+    def complete(body)
+      uri = URI(BASE_URL)
+      request = build_request(uri, body.merge("stream" => false))
+      response = http(uri).request(request)
+
+      unless response.code.to_i == 200
+        raise UpstreamError.new(response.code.to_i, response.body)
+      end
+
+      JSON.parse(response.body)
+    end
+
+    class UpstreamError < StandardError
+      attr_reader :status, :body
+
+      def initialize(status, body)
+        @status = status
+        @body = body
+        super("OpenRouter upstream returned #{status}")
+      end
+    end
+
+    private
+
+    def http(uri)
+      client = Net::HTTP.new(uri.host, uri.port)
+      client.use_ssl = uri.scheme == "https"
+      client.open_timeout = OPEN_TIMEOUT
+      client.read_timeout = READ_TIMEOUT
+      client
+    end
+
+    def build_request(uri, body)
+      request = Net::HTTP::Post.new(uri)
+      request["Authorization"] = "Bearer #{@api_key}"
+      request["Content-Type"] = "application/json"
+      request["Accept"] = "text/event-stream"
+      # OpenRouter attribution headers (optional but recommended).
+      request["HTTP-Referer"] = ENV["SITE_ORIGIN"] if ENV["SITE_ORIGIN"].present?
+      request["X-Title"] = "LevelCode"
+      request.body = JSON.generate(body)
+      request
+    end
+
+    # Pulls the `usage` object out of a chunk if present, without reshaping the
+    # chunk itself. Returns a Hash or nil.
+    def extract_usage(payload)
+      parsed = JSON.parse(payload)
+      parsed["usage"]
+    rescue JSON::ParserError
+      nil
+    end
+
+    def read_error_body(response)
+      response.read_body
+    rescue IOError, StandardError
+      nil
+    end
+  end
+end

--- a/app/services/levelcode/provider_oauth.rb
+++ b/app/services/levelcode/provider_oauth.rb
@@ -1,0 +1,236 @@
+# frozen_string_literal: true
+
+require "net/http"
+require "uri"
+
+module Levelcode
+  # Server-side OAuth code-exchange + find/create-user for GitHub & Google
+  # (SPEC §2). Extracted verbatim from the private methods that lived in
+  # Api::Levelcode::V1::AuthController so BOTH the JSON API (site -> backend mint)
+  # and the Rails-served web account surface (Levelcode::WebController) share one
+  # hardened implementation.
+  #
+  # Security posture (unchanged from the controller original):
+  #   - GitHub: ONLY the VERIFIED PRIMARY email is trusted — never the
+  #     user-editable public profile field, which an attacker could set to a
+  #     victim's address to link into their account.
+  #   - Google: the returned id_token is cryptographically verified against the
+  #     configured client id(s) before any account is touched.
+  #   - The https/atom-plus-plus redirect_uri validation stays in the callers
+  #     (this module receives an already-decided redirect_uri and passes it
+  #     straight through to the provider token endpoint so the exchange matches
+  #     the authorize step).
+  module ProviderOAuth
+    module_function
+
+    GITHUB_PROVIDER = "github"
+
+    GITHUB_AUTHORIZE_URL = "https://github.com/login/oauth/authorize"
+    GITHUB_TOKEN_URL     = "https://github.com/login/oauth/access_token"
+    GOOGLE_AUTHORIZE_URL = "https://accounts.google.com/o/oauth2/v2/auth"
+    GOOGLE_TOKEN_URL     = "https://oauth2.googleapis.com/token"
+
+    # Exchange a GitHub authorization `code` (obtained with `redirect_uri`) for an
+    # access token, fetch the user + verified primary email, then find-or-create
+    # the local user. Returns a User or nil.
+    def github_user(code:, redirect_uri:)
+      return nil if code.blank?
+
+      access_token = github_exchange_code(code, redirect_uri)
+      return nil if access_token.blank?
+
+      gh_user = github_get("https://api.github.com/user", access_token)
+      return nil unless gh_user
+
+      # ONLY a verified primary email — never gh_user["email"] (the user-editable
+      # public profile field), which would let an attacker set a victim's address
+      # and link into their account. Mirrors the Google email_verified guard.
+      email = github_primary_email(access_token)
+      return nil if email.blank?
+
+      find_or_create_oauth_user(
+        provider: GITHUB_PROVIDER,
+        uid: gh_user["id"].to_s,
+        email: email.to_s.downcase,
+        name: gh_user["name"].presence || gh_user["login"]
+      )
+    end
+
+    # Server-side authorization-code flow for Google (site/web forwards the
+    # provider `code`). Exchange it with Google's token endpoint (client secret +
+    # the SAME redirect_uri used for authorize + PKCE verifier), verify the
+    # returned id_token, then find-or-create the user. Returns a User or nil.
+    def google_user(code:, redirect_uri:, verifier: nil)
+      return nil if code.blank?
+
+      id_token = google_exchange_code(code, redirect_uri, verifier)
+      return nil if id_token.blank?
+
+      payload = verify_google_id_token(id_token)
+      return nil unless payload
+
+      User.from_google(payload)
+    end
+
+    # Build the provider `authorize` URL the browser is redirected to. `state` is
+    # the CSRF/session-binding token; `code_challenge` (S256) enables PKCE so the
+    # matching verifier is required at the token exchange. Returns a String.
+    def authorize_url(provider:, redirect_uri:, state:, code_challenge: nil)
+      case provider.to_s
+      when "github"
+        build_url(GITHUB_AUTHORIZE_URL, {
+          client_id: ENV["GITHUB_OAUTH_ID"],
+          redirect_uri: redirect_uri,
+          scope: "read:user user:email",
+          state: state,
+          # GitHub honours S256 PKCE on the OAuth app flow.
+          code_challenge: code_challenge,
+          code_challenge_method: code_challenge.present? ? "S256" : nil,
+          allow_signup: "true"
+        })
+      when "google"
+        build_url(GOOGLE_AUTHORIZE_URL, {
+          client_id: ENV["GOOGLE_OAUTH_ID"],
+          redirect_uri: redirect_uri,
+          response_type: "code",
+          scope: "openid email profile",
+          state: state,
+          code_challenge: code_challenge,
+          code_challenge_method: code_challenge.present? ? "S256" : nil,
+          access_type: "online",
+          prompt: "select_account"
+        })
+      else
+        raise ArgumentError, "unknown provider: #{provider}"
+      end
+    end
+
+    # --- GitHub internals ----------------------------------------------------
+
+    def github_exchange_code(code, redirect_uri)
+      res = post_form(
+        GITHUB_TOKEN_URL,
+        {
+          client_id: ENV["GITHUB_OAUTH_ID"],
+          client_secret: ENV["GITHUB_OAUTH_SECRET"],
+          code: code,
+          redirect_uri: redirect_uri
+        },
+        headers: { "Accept" => "application/json" }
+      )
+      return nil unless res
+
+      JSON.parse(res)["access_token"]
+    rescue JSON::ParserError
+      nil
+    end
+
+    def github_primary_email(access_token)
+      emails = github_get("https://api.github.com/user/emails", access_token)
+      return nil unless emails.is_a?(Array)
+
+      primary = emails.find { |e| e["primary"] && e["verified"] }
+      primary && primary["email"]
+    end
+
+    def github_get(url, access_token)
+      uri = URI.parse(url)
+      req = Net::HTTP::Get.new(uri)
+      req["Authorization"] = "Bearer #{access_token}"
+      req["Accept"] = "application/vnd.github+json"
+      req["User-Agent"] = "levelcode"
+
+      body = perform_http(uri, req)
+      body && JSON.parse(body)
+    rescue JSON::ParserError
+      nil
+    end
+
+    # --- Google internals ----------------------------------------------------
+
+    def google_exchange_code(code, redirect_uri, verifier)
+      res = post_form(
+        GOOGLE_TOKEN_URL,
+        {
+          client_id: ENV["GOOGLE_OAUTH_ID"],
+          client_secret: ENV["GOOGLE_OAUTH_SECRET"],
+          code: code,
+          redirect_uri: redirect_uri,
+          grant_type: "authorization_code",
+          code_verifier: verifier
+        },
+        headers: { "Accept" => "application/json" }
+      )
+      return nil unless res
+
+      JSON.parse(res)["id_token"]
+    rescue JSON::ParserError
+      nil
+    end
+
+    # Mirror Users::GoogleAuthController#verify_google_id_token.
+    def verify_google_id_token(id_token)
+      Google::Auth::IDTokens.verify_oidc(id_token, aud: google_client_ids)
+    rescue Google::Auth::IDTokens::VerificationError => e
+      Rails.logger.warn("Google ID token verification failed: #{e.message}")
+      nil
+    end
+
+    def google_client_ids
+      ids = [ ENV["GOOGLE_CLIENT_ID"], ENV["GOOGLE_OAUTH_ID"] ]
+        .compact.flat_map { |v| v.to_s.split(",") }.map(&:strip).reject(&:empty?).uniq
+      ids.size == 1 ? ids.first : ids
+    end
+
+    # --- Local user find-or-create (OAuth) -----------------------------------
+
+    def find_or_create_oauth_user(provider:, uid:, email:, name: nil)
+      user = User.find_by(provider: provider, uid: uid) || User.find_by(email: email)
+
+      if user
+        user.update(provider: provider, uid: uid) if user.uid.blank?
+        user
+      else
+        User.create(
+          provider: provider,
+          uid: uid,
+          email: email,
+          password: Devise.friendly_token[0, 20],
+          terms_accepted: true
+        )
+      end
+    end
+
+    # --- HTTP helpers --------------------------------------------------------
+
+    def build_url(base, query)
+      uri = URI.parse(base)
+      uri.query = URI.encode_www_form(query.compact)
+      uri.to_s
+    end
+
+    def post_form(url, form, headers: {})
+      uri = URI.parse(url)
+      req = Net::HTTP::Post.new(uri)
+      headers.each { |k, v| req[k] = v }
+      req["User-Agent"] = "levelcode"
+      req.set_form_data(form.compact)
+
+      perform_http(uri, req)
+    end
+
+    def perform_http(uri, req)
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = (uri.scheme == "https")
+      res = http.request(req)
+      res.is_a?(Net::HTTPSuccess) ? res.body : nil
+    rescue StandardError => e
+      Rails.logger.warn("Levelcode OAuth HTTP error: #{e.message}")
+      nil
+    end
+
+    private_class_method :github_exchange_code, :github_primary_email, :github_get,
+                         :google_exchange_code, :verify_google_id_token, :google_client_ids,
+                         :find_or_create_oauth_user, :build_url, :post_form, :perform_http
+  end
+end

--- a/app/services/levelcode/provider_oauth.rb
+++ b/app/services/levelcode/provider_oauth.rb
@@ -16,7 +16,7 @@ module Levelcode
   #     victim's address to link into their account.
   #   - Google: the returned id_token is cryptographically verified against the
   #     configured client id(s) before any account is touched.
-  #   - The https/atom-plus-plus redirect_uri validation stays in the callers
+  #   - The https/levelcode redirect_uri validation stays in the callers
   #     (this module receives an already-decided redirect_uri and passes it
   #     straight through to the provider token endpoint so the exchange matches
   #     the authorize step).

--- a/app/services/levelcode/webhook_sync.rb
+++ b/app/services/levelcode/webhook_sync.rb
@@ -15,6 +15,11 @@ module Levelcode
   class WebhookSync
     PRODUCT = "levelcode".freeze
 
+    # Raised when a money-critical wallet sync fails AFTER Stripe idempotency was claimed. The webhook
+    # controller releases the idempotency claim and returns non-2xx so Stripe RETRIES, rather than
+    # silently stranding a teardown/provision (e.g. a canceled wallet left fully funded).
+    SyncError = Class.new(StandardError)
+
     def self.call(event)
       new(event).call
     end
@@ -68,6 +73,16 @@ module Levelcode
       user = find_user(customer_id)
       return unless user
 
+      # Only an ACTIVE/TRIALING subscription funds the wallet. A past_due/unpaid/incomplete/paused sub
+      # must NOT (re)provision the paid budget — otherwise a failed renewal keeps paying-tier credits.
+      # (A definitive cancel arrives as customer.subscription.deleted → teardown; grace-expiry in
+      # FreeTier is the backstop if that webhook is ever missed.)
+      status = stripe_subscription.respond_to?(:status) ? stripe_subscription.status.to_s : "active"
+      unless %w[active trialing].include?(status)
+        Rails.logger.info("[Levelcode::WebhookSync] Sub status=#{status} for #{user.email} — not (re)provisioning the paid budget")
+        return
+      end
+
       plan = Levelcode.plan(lookup_key)
       unless plan
         Rails.logger.warn("[Levelcode::WebhookSync] No Levelcode plan for lookup_key=#{lookup_key}")
@@ -79,26 +94,34 @@ module Levelcode
       period_end   = Time.at(item.current_period_end).to_datetime
 
       wallet = CreditWallet.find_or_initialize_by(user: user, product: PRODUCT)
+
+      # Treat an ADVANCING period_end as a fresh billing period (roll) and reset the metered counters —
+      # even on customer.subscription.updated — so the prior period's spend can't enforce against the
+      # new one. A same-period update (card change, cancel toggle) leaves spend untouched.
+      period_advanced = wallet.period_end.blank? || period_end > wallet.period_end
+      did_reset = reset_usage || wallet.new_record? || period_advanced
+
       attrs = {
         plan_key: lookup_key,
         input_cap: plan[:input_cap],
         output_cap: plan[:output_cap],
-        # M14: the enforced allowance is the DOLLAR budget (flagship worst-case for the tier).
+        # M14: the enforced allowance is the DOLLAR budget (revenue-based fraction for the tier).
         budget_micros: Levelcode.budget_micros(lookup_key),
         period_start: period_start,
         period_end: period_end,
         overage_policy: plan[:overage_policy] || wallet.overage_policy || "throttle"
       }
-      # Reset the metered counters on a fresh billing period (invoice.paid) or
-      # when the wallet is first provisioned.
-      if reset_usage || wallet.new_record?
+      if did_reset
         attrs[:input_used] = 0
         attrs[:output_used] = 0
         attrs[:spent_micros] = 0
       end
 
       wallet.update!(attrs)
-      Rails.logger.info("[Levelcode::WebhookSync] Wallet synced for #{user.email} (plan=#{lookup_key}, reset=#{reset_usage || wallet.previously_new_record?})")
+      # Wipe the hot counters on a reset too — a reset that reuses the same period_end epoch would
+      # otherwise resurrect the pre-reset spend via max(Redis, durable).
+      Levelcode::Metering.clear!(wallet) if did_reset
+      Rails.logger.info("[Levelcode::WebhookSync] Wallet synced for #{user.email} (plan=#{lookup_key}, reset=#{did_reset})")
     end
 
     def teardown(customer_id)
@@ -117,6 +140,7 @@ module Levelcode
         input_used: 0,
         output_used: 0
       )
+      Levelcode::Metering.clear!(wallet) # drop stale hot counters so they can't resurrect spend
       Rails.logger.info("[Levelcode::WebhookSync] Wallet reset to free for #{user.email}")
     end
 

--- a/app/services/levelcode/webhook_sync.rb
+++ b/app/services/levelcode/webhook_sync.rb
@@ -1,0 +1,141 @@
+module Levelcode
+  # Provisions / resets a user's levelcode CreditWallet from Stripe subscription
+  # events (SPEC §5, §6). Called from the EXISTING Api::V1::WebhooksController
+  # for every event; it self-filters to the `levelcode` product and no-ops for
+  # link-shortener (`linkly`) subscriptions, so the two products never collide.
+  #
+  # Handled events:
+  #   checkout.session.completed  → provision wallet (first purchase)
+  #   invoice.paid                → reset used counters + roll the period
+  #   customer.subscription.updated → re-provision caps for the new plan
+  #   customer.subscription.deleted → tear the wallet down to free
+  #
+  # Usage (wired by the orchestrator in webhooks_controller#handle_event):
+  #   Levelcode::WebhookSync.call(event)
+  class WebhookSync
+    PRODUCT = "levelcode".freeze
+
+    def self.call(event)
+      new(event).call
+    end
+
+    def initialize(event)
+      @event = event
+      @object = event.data.object
+    end
+
+    def call
+      case @event.type
+      when "checkout.session.completed"
+        return unless @object.mode == "subscription"
+        provision_from_subscription_id(@object.subscription, @object.customer)
+      when "invoice.paid", "invoice.payment_succeeded"
+        provision_from_invoice(@object, reset_usage: true)
+      when "customer.subscription.updated"
+        provision_from_stripe_subscription(@object, @object.customer)
+      when "customer.subscription.deleted"
+        teardown(@object.customer)
+      end
+    rescue Stripe::StripeError => e
+      Rails.logger.error("[Levelcode::WebhookSync] Stripe error on #{@event.type}: #{e.message}")
+    end
+
+    private
+
+    # ── Resolvers ─────────────────────────────────────────────────
+
+    def provision_from_invoice(invoice, reset_usage:)
+      # Stripe API 2024-12-18 moved subscription onto invoice.parent.subscription_details;
+      # older/replayed events still carry invoice.subscription. Try modern, then legacy.
+      subscription_id = invoice.parent&.subscription_details&.subscription
+      subscription_id = invoice.try(:subscription) if subscription_id.blank?
+      return if subscription_id.blank?
+
+      provision_from_subscription_id(subscription_id, invoice.customer, reset_usage: reset_usage)
+    end
+
+    def provision_from_subscription_id(subscription_id, customer_id, reset_usage: false)
+      return if subscription_id.blank?
+
+      stripe_subscription = Stripe::Subscription.retrieve(subscription_id)
+      provision_from_stripe_subscription(stripe_subscription, customer_id, reset_usage: reset_usage)
+    end
+
+    def provision_from_stripe_subscription(stripe_subscription, customer_id, reset_usage: false)
+      lookup_key = lookup_key_for(stripe_subscription)
+      return unless levelcode_plan?(lookup_key)
+
+      user = find_user(customer_id)
+      return unless user
+
+      plan = Levelcode.plan(lookup_key)
+      unless plan
+        Rails.logger.warn("[Levelcode::WebhookSync] No Levelcode plan for lookup_key=#{lookup_key}")
+        return
+      end
+
+      item = stripe_subscription.items.data[0]
+      period_start = Time.at(item.current_period_start).to_datetime
+      period_end   = Time.at(item.current_period_end).to_datetime
+
+      wallet = CreditWallet.find_or_initialize_by(user: user, product: PRODUCT)
+      attrs = {
+        plan_key: lookup_key,
+        input_cap: plan[:input_cap],
+        output_cap: plan[:output_cap],
+        # M14: the enforced allowance is the DOLLAR budget (flagship worst-case for the tier).
+        budget_micros: Levelcode.budget_micros(lookup_key),
+        period_start: period_start,
+        period_end: period_end,
+        overage_policy: plan[:overage_policy] || wallet.overage_policy || "throttle"
+      }
+      # Reset the metered counters on a fresh billing period (invoice.paid) or
+      # when the wallet is first provisioned.
+      if reset_usage || wallet.new_record?
+        attrs[:input_used] = 0
+        attrs[:output_used] = 0
+        attrs[:spent_micros] = 0
+      end
+
+      wallet.update!(attrs)
+      Rails.logger.info("[Levelcode::WebhookSync] Wallet synced for #{user.email} (plan=#{lookup_key}, reset=#{reset_usage || wallet.previously_new_record?})")
+    end
+
+    def teardown(customer_id)
+      user = find_user(customer_id)
+      return unless user
+
+      wallet = CreditWallet.find_by(user: user, product: PRODUCT)
+      return unless wallet
+
+      wallet.update!(
+        plan_key: "free",
+        input_cap: 0,
+        output_cap: 0,
+        budget_micros: 0, # zeroed → FreeTier re-provisions the free budget on next gateway access
+        spent_micros: 0,
+        input_used: 0,
+        output_used: 0
+      )
+      Rails.logger.info("[Levelcode::WebhookSync] Wallet reset to free for #{user.email}")
+    end
+
+    # ── Helpers ───────────────────────────────────────────────────
+
+    # The Stripe subscription's price carries the frozen lookup_key
+    # (orbits_pro, orbits_pro_plus, …). We key Levelcode::PLANS off it.
+    def lookup_key_for(stripe_subscription)
+      stripe_subscription.items.data[0]&.price&.lookup_key
+    end
+
+    def levelcode_plan?(lookup_key)
+      lookup_key.present? && Levelcode.plan(lookup_key).present?
+    end
+
+    def find_user(customer_id)
+      user = User.find_by(stripe_id: customer_id)
+      Rails.logger.error("[Levelcode::WebhookSync] User not found for stripe customer: #{customer_id}") unless user
+      user
+    end
+  end
+end

--- a/app/services/levelcode/webhook_sync.rb
+++ b/app/services/levelcode/webhook_sync.rb
@@ -20,6 +20,16 @@ module Levelcode
     # silently stranding a teardown/provision (e.g. a canceled wallet left fully funded).
     SyncError = Class.new(StandardError)
 
+    # Stripe failures worth a webhook retry: a network blip, rate limiting, or a Stripe-side 5xx
+    # (Stripe::APIError). Everything else — InvalidRequestError, AuthenticationError, CardError, … —
+    # is PERMANENT: retrying the same event can't help, so we ack it (200) instead of churning Stripe's
+    # retry queue. (RateLimitError and APIError are direct StripeError subclasses in stripe 13.x.)
+    TRANSIENT_STRIPE_ERRORS = [
+      Stripe::APIConnectionError,
+      Stripe::RateLimitError,
+      Stripe::APIError
+    ].freeze
+
     def self.call(event)
       new(event).call
     end
@@ -42,7 +52,11 @@ module Levelcode
         teardown(@object.customer)
       end
     rescue Stripe::StripeError => e
-      Rails.logger.error("[Levelcode::WebhookSync] Stripe error on #{@event.type}: #{e.message}")
+      Rails.logger.error("[Levelcode::WebhookSync] Stripe error on #{@event.type}: #{e.class}: #{e.message}")
+      # Transient (network / rate-limit / Stripe 5xx) → re-raise so the controller releases idempotency
+      # and returns non-2xx; Stripe redelivers (bounded to ~3 days) and the sync re-runs. Permanent
+      # errors fall through and are swallowed → 200 (retrying can't help).
+      raise SyncError, "#{e.class}: #{e.message}" if TRANSIENT_STRIPE_ERRORS.any? { |klass| e.is_a?(klass) }
     end
 
     private

--- a/app/views/api/v1/current_user/index.json.jbuilder
+++ b/app/views/api/v1/current_user/index.json.jbuilder
@@ -4,7 +4,7 @@ json.user do
   )
   json.avatar_url current_user.avatar.url if current_user.avatar.present?
   json.handle current_user.profile&.handle
-  json.role "admin"
+  json.role current_user.role
   json.plan do
     json.name current_user.plan.name
     json.features @features

--- a/app/views/levelcode_auth_mailer/login_code.html.erb
+++ b/app/views/levelcode_auth_mailer/login_code.html.erb
@@ -1,0 +1,18 @@
+<div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;max-width:480px;margin:0 auto;padding:8px 4px;color:#1b1a17;">
+  <p style="font-size:18px;font-weight:700;margin:0 0 24px;">LevelCode</p>
+
+  <h1 style="font-size:22px;font-weight:700;margin:0 0 8px;">Verification code</h1>
+  <p style="font-size:15px;color:#3a3833;margin:0 0 20px;">Enter the following code to sign in to LevelCode Cloud:</p>
+
+  <p style="font-size:40px;font-weight:800;letter-spacing:6px;margin:0 0 20px;"><%= @code %></p>
+
+  <p style="font-size:14px;color:#6b675e;margin:0 0 28px;">
+    This code expires in <%= @ttl_minutes %> minutes. To protect your account, do not share it.
+  </p>
+
+  <hr style="border:none;border-top:1px solid #e7e3da;margin:0 0 16px;">
+  <p style="font-size:13px;color:#6b675e;margin:0;">
+    <strong>Didn't request this?</strong> You can safely ignore this email — someone may have typed your
+    address by mistake. No account changes were made.
+  </p>
+</div>

--- a/app/views/levelcode_auth_mailer/login_code.text.erb
+++ b/app/views/levelcode_auth_mailer/login_code.text.erb
@@ -1,0 +1,9 @@
+LevelCode — Verification code
+
+Enter this code to sign in to LevelCode Cloud:
+
+    <%= @code %>
+
+This code expires in <%= @ttl_minutes %> minutes. To protect your account, do not share it.
+
+Didn't request this? You can safely ignore this email — no account changes were made.

--- a/app/views/static/ui_levelcode.html.erb
+++ b/app/views/static/ui_levelcode.html.erb
@@ -18,7 +18,7 @@
   <link
     href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
     rel="stylesheet">
-  <script type="module" crossorigin src="/assets/levelcode-gZmiCOIq.js"></script>
+  <script type="module" crossorigin src="/assets/levelcode-DsPvo2aV.js"></script>
   <link rel="modulepreload" crossorigin href="/assets/chunk-7R3XDUXW-BMhzTiu5.js">
   <link rel="stylesheet" crossorigin href="/assets/levelcode-B7R0p_ZN.css">
   <script>window.__ENV__ = {"GOOGLE_CLIENT_ID":"","API_BASE":"","BRAND":"levelcode"};</script>

--- a/app/views/static/ui_levelcode.html.erb
+++ b/app/views/static/ui_levelcode.html.erb
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <link rel="icon" type="image/svg+xml" href="/favicon.ico" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description"
+    content="LevelCode Cloud — manage your plan, keys, and usage. Bring your own key, or run on the metered gateway with no middleman markup." />
+  <meta name="robots" content="index, follow" />
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="LevelCode Cloud" />
+  <meta property="og:description" content="Your LevelCode plan, keys, and usage." />
+  <meta property="og:site_name" content="LevelCode Cloud" />
+  <title>LevelCode Cloud</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link
+    href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+    rel="stylesheet">
+  <script type="module" crossorigin src="/assets/levelcode-Cf1ct13O.js"></script>
+  <link rel="modulepreload" crossorigin href="/assets/chunk-7R3XDUXW-BMhzTiu5.js">
+  <link rel="stylesheet" crossorigin href="/assets/levelcode-B7R0p_ZN.css">
+  <script>window.__ENV__ = {"GOOGLE_CLIENT_ID":"","API_BASE":"","BRAND":"levelcode"};</script>
+  <%= csrf_meta_tags %>
+</head>
+
+<body class="font-sans antialiased">
+  <div id="root"></div>
+</body>
+
+</html>

--- a/app/views/static/ui_levelcode.html.erb
+++ b/app/views/static/ui_levelcode.html.erb
@@ -18,7 +18,7 @@
   <link
     href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
     rel="stylesheet">
-  <script type="module" crossorigin src="/assets/levelcode-Cf1ct13O.js"></script>
+  <script type="module" crossorigin src="/assets/levelcode-gZmiCOIq.js"></script>
   <link rel="modulepreload" crossorigin href="/assets/chunk-7R3XDUXW-BMhzTiu5.js">
   <link rel="stylesheet" crossorigin href="/assets/levelcode-B7R0p_ZN.css">
   <script>window.__ENV__ = {"GOOGLE_CLIENT_ID":"","API_BASE":"","BRAND":"levelcode"};</script>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,28 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "Mass Assignment",
+      "warning_code": 70,
+      "fingerprint": "68c03aa509ebc10a8f9c9d0588b181997aead48f238d45d4496c700753cc145a",
+      "check_name": "MassAssignment",
+      "message": "Specify exact keys allowed for mass assignment instead of using `permit!` which allows any keys",
+      "file": "app/controllers/api/levelcode/v1/ai_controller.rb",
+      "line": 338,
+      "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
+      "code": "params.permit!",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Api::Levelcode::V1::AiController",
+        "method": "chat_params"
+      },
+      "user_input": null,
+      "confidence": "Medium",
+      "cwe_id": [
+        915
+      ],
+      "note": "Intentional. AiController#chat is a TRANSPARENT PROXY of the OpenAI chat-completions body to OpenRouter. The permitted hash is forwarded verbatim as the upstream HTTP request body and is NEVER used for ActiveRecord mass-assignment, so the mass-assignment risk this check flags does not apply. Explicitly permitting a fixed key set would break the passthrough, since the editor may send any valid OpenAI field (tools, stream_options, response_format, etc.). Unknown keys are ignored by OpenRouter."
+    }
+  ],
+  "brakeman_version": "8.0.5"
+}

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -116,6 +116,8 @@ Rails.application.configure do
     "www.thin.ly",
     "thin.ly",
     "app.thin.ly",
+    "levelcode.ai", # LevelCode Cloud account app (served at /ai/*)
+    "www.levelcode.ai",
     ".elasticbeanstalk.com",
     /.*\.elasticbeanstalk\.com$/, # Allow all Elastic Beanstalk hosts
     /.*\.elb\.amazonaws\.com$/, # Allow ELB hostnames for health checks

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -14,3 +14,10 @@
 # ActiveSupport::Inflector.inflections(:en) do |inflect|
 #   inflect.acronym "RESTful"
 # end
+
+# Zeitwerk autoload inflection: map app/services/levelcode/provider_oauth.rb to
+# Levelcode::ProviderOAuth (default inflection would give ProviderOauth). The
+# LevelCode Cloud shared contract fixes the constant as ProviderOAuth.
+Rails.autoloaders.each do |autoloader|
+  autoloader.inflector.inflect("provider_oauth" => "ProviderOAuth")
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -130,15 +130,80 @@ Rails.application.routes.draw do
         end
       end
     end
+
+    # ---- LevelCode Cloud (Levelcode) — isolated namespace (SPEC §3). Sibling of :v1. ----
+    # Paths: /api/levelcode/v1/*  ·  controllers Api::Levelcode::V1::*
+    namespace :levelcode do
+      namespace :v1 do
+        # Auth (SPEC §2, §3)
+        post  "auth/callback",        to: "auth#callback"       # levelcode.ai server -> mint (service-token)
+        post  "auth/email/request",   to: "auth#email_request"  # passwordless OTP: send code
+        post  "auth/email/verify",    to: "auth#email_verify"   # passwordless OTP: verify code -> mint
+        match "auth/login",           to: "auth#login", via: %i[get post]
+        post  "auth/signup",          to: "auth#signup"
+        post  "auth/exchange",        to: "auth#exchange"   # PKCE one-time code -> tokens
+        post  "auth/refresh",         to: "auth#refresh"
+        post  "auth/signout",         to: "auth#signout"
+        post  "auth/web_handoff",     to: "auth#web_handoff"    # editor token -> one-time browser sign-in URL
+
+        # Billing + account (SPEC §3, §6)
+        get   "pricing",         to: "pricing#index"
+        resources :checkouts,    only: %i[create]
+        resources :billings,     only: %i[create]
+        get   "account/profile",  to: "account#profile"
+        get   "account/usage",    to: "account#usage"
+        get   "account/activity", to: "account#activity"   # GitHub-style contribution heatmap data
+        get   "account/models",   to: "account#models"     # plan model roster + credits + turns-left
+        post  "feedback",         to: "feedback#create"    # editor thumbs up/down -> per-model signal
+
+        # Admin dashboard (role: admin only)
+        get   "admin/summary",    to: "admin#summary"
+        get   "admin/users",      to: "admin#users"
+
+        # AI gateway (SPEC §4). The editor routes gateway traffic through its
+        # OpenAI-compatible adapter, which POSTs to `<base>/chat/completions`
+        # (base = …/api/levelcode/v1/ai). Expose that path so the request lands on
+        # this bearer-authed API controller instead of falling through to the
+        # HTML catch-all. `ai/chat` kept as an alias for the SPEC/tests.
+        post  "ai/chat/completions", to: "ai#chat"
+        post  "ai/chat",             to: "ai#chat"
+      end
+    end
   end
 
   # namespace :stripe do
   #   post "webhooks", to: "stripe/webhooks#create"
   # end
 
+  # ---- LevelCode Cloud account app (onetime SPA, served at /ai/* by static#ui) ----
+  # Only the server-side flows the SPA delegates to live here: OAuth redirect +
+  # callback (server-side code exchange), and the session-establishing / Stripe
+  # writes (CSRF-protected via Levelcode::WebController). MUST be declared BEFORE the
+  # "*ui" catch-all so they resolve to the controller; GET /ai, /ai/login,
+  # /ai/pricing, /ai/account fall through to static#ui (the levelcode shell).
+  scope "ai", module: "levelcode", as: "ai" do
+    get   "auth/oauth/:provider", to: "web#oauth_start",    as: :auth_oauth
+    get   "auth/callback",        to: "web#oauth_callback", as: :auth_callback
+    get   "auth/handoff",         to: "web#handoff",        as: :auth_handoff  # editor->browser SSO: redeem code -> session
+
+    post  "auth/email",           to: "web#email_request",  as: :auth_email
+    post  "auth/verify",          to: "web#email_verify",   as: :auth_verify
+    post  "authorize_editor",     to: "web#authorize_editor", as: :authorize_editor  # browser session -> PKCE-bound editor code
+    post  "checkout",             to: "web#checkout",        as: :checkout
+    post  "billing",              to: "web#billing",         as: :billing
+    match "signout",              to: "web#signout",         as: :signout, via: %i[delete post]
+    get   "csrf",                 to: "web#csrf",            as: :csrf
+  end
+
   get "/unsafe-link", to: "static#unsafe_link", as: :unsafe_link
   get "/link-not-found", to: "static#link_not_found", as: :link_not_found
-  get "/:lookup_code" => "api/v1/links#lookup_code", as: :lookup_code, constraints: { lookup_code: /[a-zA-Z0-9]{7}/ }
+  # The link-shortener lookup only applies on thin.ly hosts. levelcode.ai is the
+  # account app (not a shortener), so a 7-char bare path there (e.g. /pricing)
+  # must fall through to static#ui — which redirects it into the /ai app — instead
+  # of resolving as a short code.
+  constraints(->(req) { !StaticController::LEVELCODE_HOSTS.include?(req.host) }) do
+    get "/:lookup_code" => "api/v1/links#lookup_code", as: :lookup_code, constraints: { lookup_code: /[a-zA-Z0-9]{7}/ }
+  end
   match "*ui", to: "static#ui", via: :get, constraints: ->(request) { request.format.html? && !request.path.start_with?("/api/") }
   match "*path", to: "static#not_found", via: :all
 

--- a/db/migrate/20260704120001_add_role_to_users.rb
+++ b/db/migrate/20260704120001_add_role_to_users.rb
@@ -1,0 +1,5 @@
+class AddRoleToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :role, :string, null: false, default: "member"
+  end
+end

--- a/db/migrate/20260704120002_add_product_to_subscriptions.rb
+++ b/db/migrate/20260704120002_add_product_to_subscriptions.rb
@@ -1,0 +1,6 @@
+class AddProductToSubscriptions < ActiveRecord::Migration[7.2]
+  def change
+    add_column :subscriptions, :product, :string, null: false, default: "linkly"
+    add_index :subscriptions, [ :user_id, :product ]
+  end
+end

--- a/db/migrate/20260704120003_create_credit_wallets.rb
+++ b/db/migrate/20260704120003_create_credit_wallets.rb
@@ -1,0 +1,29 @@
+class CreateCreditWallets < ActiveRecord::Migration[7.2]
+  def change
+    create_table :credit_wallets do |t|
+      t.references :user, null: false, foreign_key: true
+
+      # Product scope (levelcode gateway credits are separate from the link product).
+      t.string :product,  null: false, default: "levelcode"
+      t.string :plan_key, null: false
+
+      # Per-period token caps and running usage (bigint — token counts get large).
+      t.bigint :input_cap,   null: false
+      t.bigint :output_cap,  null: false
+      t.bigint :input_used,  null: false, default: 0
+      t.bigint :output_used, null: false, default: 0
+
+      # Billing period window this wallet meters against.
+      t.datetime :period_start
+      t.datetime :period_end
+
+      # What happens once a cap is hit: throttle (default) | topup | stop.
+      t.string :overage_policy, null: false, default: "throttle"
+
+      t.timestamps
+    end
+
+    # One wallet per user per product.
+    add_index :credit_wallets, [ :user_id, :product ], unique: true
+  end
+end

--- a/db/migrate/20260704120004_create_usage_events.rb
+++ b/db/migrate/20260704120004_create_usage_events.rb
@@ -1,0 +1,22 @@
+class CreateUsageEvents < ActiveRecord::Migration[7.2]
+  def change
+    create_table :usage_events do |t|
+      t.references :user, null: false, foreign_key: true
+
+      t.string :request_id
+      t.string :model
+      t.string :provider
+
+      # Token accounting (bigint) + computed cost in micro-dollars.
+      t.bigint :input_tokens,        null: false, default: 0
+      t.bigint :output_tokens,       null: false, default: 0
+      t.bigint :cached_input_tokens, null: false, default: 0
+      t.bigint :cost_micros,         null: false, default: 0
+
+      # Durable ledger rows are append-only; only created_at is meaningful.
+      t.datetime :created_at, null: false
+    end
+
+    add_index :usage_events, [ :user_id, :created_at ]
+  end
+end

--- a/db/migrate/20260704120005_add_unique_index_to_usage_events_request_id.rb
+++ b/db/migrate/20260704120005_add_unique_index_to_usage_events_request_id.rb
@@ -1,0 +1,10 @@
+class AddUniqueIndexToUsageEventsRequestId < ActiveRecord::Migration[7.2]
+  # Partial unique index: enforce one usage_events row per request_id (idempotent
+  # RecordUsageJob via create_or_find_by!), while still allowing NULL request_ids.
+  def change
+    add_index :usage_events, :request_id,
+              unique: true,
+              where: "request_id IS NOT NULL",
+              name: "index_usage_events_on_request_id_unique"
+  end
+end

--- a/db/migrate/20260706120001_create_usage_feedbacks.rb
+++ b/db/migrate/20260706120001_create_usage_feedbacks.rb
@@ -1,0 +1,16 @@
+class CreateUsageFeedbacks < ActiveRecord::Migration[7.2]
+  def change
+    create_table :usage_feedbacks do |t|
+      t.references :user, null: false, foreign_key: true
+
+      t.string :model                     # the model that produced the reacted-to turn
+      t.string :rating, null: false        # "up" | "down"
+      t.string :request_id                 # optional link to a usage_event (future per-request linkage)
+
+      # Append-only signal rows — only created_at is meaningful.
+      t.datetime :created_at, null: false
+    end
+
+    add_index :usage_feedbacks, [ :user_id, :created_at ]
+  end
+end

--- a/db/migrate/20260706120002_add_access_fields_to_users.rb
+++ b/db/migrate/20260706120002_add_access_fields_to_users.rb
@@ -1,0 +1,10 @@
+class AddAccessFieldsToUsers < ActiveRecord::Migration[7.2]
+  def change
+    # Denormalized "where/when did we last see this user" for the admin dashboard.
+    # Country comes from the CDN edge header (CF-IPCountry / CloudFront-Viewer-Country);
+    # both are updated (throttled) whenever an authenticated request resolves.
+    add_column :users, :last_country, :string
+    add_column :users, :last_seen_at, :datetime
+    add_index  :users, :last_seen_at
+  end
+end

--- a/db/migrate/20260706120003_create_auth_events.rb
+++ b/db/migrate/20260706120003_create_auth_events.rb
@@ -1,0 +1,22 @@
+class CreateAuthEvents < ActiveRecord::Migration[7.2]
+  def change
+    create_table :auth_events do |t|
+      # user_id is NULL for a failed attempt where no account resolved (bad email, etc.).
+      t.references :user, null: true, foreign_key: true
+
+      t.string :email                 # the address the attempt was for (present even on failure)
+      t.string :kind,    null: false  # email | oauth | exchange | login | refresh
+      t.string :provider              # github | google (for oauth), else null
+      t.string :outcome, null: false  # success | failure
+      t.string :reason                # short failure code (invalid_code, oauth_failed, …)
+      t.string :ip
+      t.string :country               # CDN edge country (CF-IPCountry / CloudFront-Viewer-Country)
+
+      t.datetime :created_at, null: false
+    end
+
+    add_index :auth_events, :created_at
+    add_index :auth_events, :outcome
+    add_index :auth_events, :email
+  end
+end

--- a/db/migrate/20260706120004_add_budget_to_credit_wallets.rb
+++ b/db/migrate/20260706120004_add_budget_to_credit_wallets.rb
@@ -1,0 +1,23 @@
+class AddBudgetToCreditWallets < ActiveRecord::Migration[7.2]
+  # M14 credit metering: enforce a DOLLAR compute budget (micro-$) instead of raw token caps. The
+  # token columns stay as informational per-period aggregates; budget_micros/spent_micros are the
+  # new enforcement pair. Backfill each wallet's budget from its plan (free wallets get the free
+  # budget); spent stays 0 — the period's Redis counter + RecordUsageJob repopulate it.
+  def up
+    add_column :credit_wallets, :budget_micros, :bigint, null: false, default: 0
+    add_column :credit_wallets, :spent_micros,  :bigint, null: false, default: 0
+
+    say_with_time "backfilling budget_micros from plan" do
+      CreditWallet.reset_column_information
+      CreditWallet.where(product: Levelcode::PRODUCT).find_each do |w|
+        budget = w.plan_key == Levelcode::FREE_PLAN_KEY ? Levelcode.free_budget_micros : Levelcode.budget_micros(w.plan_key)
+        w.update_columns(budget_micros: budget.to_i)
+      end
+    end
+  end
+
+  def down
+    remove_column :credit_wallets, :budget_micros
+    remove_column :credit_wallets, :spent_micros
+  end
+end

--- a/db/migrate/20260707120001_change_credit_wallets_product_default.rb
+++ b/db/migrate/20260707120001_change_credit_wallets_product_default.rb
@@ -1,0 +1,24 @@
+# Post-rename cleanup: the LevelCode wallet product tag is now "levelcode"
+# (Levelcode::PRODUCT). The column default was left at the pre-rename "atompp".
+# Fix the default, and migrate any pre-rename wallets — but only where the user
+# doesn't already have a "levelcode" wallet (the [user_id, product] unique index
+# would otherwise reject the update).
+class ChangeCreditWalletsProductDefault < ActiveRecord::Migration[7.2]
+  def up
+    change_column_default :credit_wallets, :product, from: "atompp", to: "levelcode"
+
+    execute <<~SQL.squish
+      UPDATE credit_wallets w
+         SET product = 'levelcode'
+       WHERE w.product = 'atompp'
+         AND NOT EXISTS (
+           SELECT 1 FROM credit_wallets w2
+            WHERE w2.user_id = w.user_id AND w2.product = 'levelcode'
+         )
+    SQL
+  end
+
+  def down
+    change_column_default :credit_wallets, :product, from: "levelcode", to: "atompp"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_06_21_030000) do
+ActiveRecord::Schema[7.2].define(version: 2026_07_06_120004) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -22,6 +22,22 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_21_030000) do
     t.datetime "updated_at", null: false
     t.index ["logable_type", "logable_id"], name: "index_api_requests_on_logable"
     t.index ["plan_id"], name: "index_api_requests_on_plan_id"
+  end
+
+  create_table "auth_events", force: :cascade do |t|
+    t.bigint "user_id"
+    t.string "email"
+    t.string "kind", null: false
+    t.string "provider"
+    t.string "outcome", null: false
+    t.string "reason"
+    t.string "ip"
+    t.string "country"
+    t.datetime "created_at", null: false
+    t.index ["created_at"], name: "index_auth_events_on_created_at"
+    t.index ["email"], name: "index_auth_events_on_email"
+    t.index ["outcome"], name: "index_auth_events_on_outcome"
+    t.index ["user_id"], name: "index_auth_events_on_user_id"
   end
 
   create_table "brand_pages", force: :cascade do |t|
@@ -78,6 +94,25 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_21_030000) do
     t.index ["link_id"], name: "index_clicks_on_link_id"
     t.index ["region"], name: "index_clicks_on_region"
     t.index ["source"], name: "index_clicks_on_source"
+  end
+
+  create_table "credit_wallets", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "product", default: "levelcode", null: false
+    t.string "plan_key", null: false
+    t.bigint "input_cap", null: false
+    t.bigint "output_cap", null: false
+    t.bigint "input_used", default: 0, null: false
+    t.bigint "output_used", default: 0, null: false
+    t.datetime "period_start"
+    t.datetime "period_end"
+    t.string "overage_policy", default: "throttle", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "budget_micros", default: 0, null: false
+    t.bigint "spent_micros", default: 0, null: false
+    t.index ["user_id", "product"], name: "index_credit_wallets_on_user_id_and_product", unique: true
+    t.index ["user_id"], name: "index_credit_wallets_on_user_id"
   end
 
   create_table "link_campaigns", force: :cascade do |t|
@@ -287,6 +322,8 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_21_030000) do
     t.datetime "updated_at", null: false
     t.boolean "cancel_at_period_end", default: false, null: false
     t.string "stripe_price_id"
+    t.string "product", default: "linkly", null: false
+    t.index ["user_id", "product"], name: "index_subscriptions_on_user_id_and_product"
     t.index ["user_id"], name: "index_subscriptions_on_user_id"
   end
 
@@ -308,6 +345,31 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_21_030000) do
     t.index ["status"], name: "index_threat_detections_on_status"
   end
 
+  create_table "usage_events", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "request_id"
+    t.string "model"
+    t.string "provider"
+    t.bigint "input_tokens", default: 0, null: false
+    t.bigint "output_tokens", default: 0, null: false
+    t.bigint "cached_input_tokens", default: 0, null: false
+    t.bigint "cost_micros", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.index ["request_id"], name: "index_usage_events_on_request_id_unique", unique: true, where: "(request_id IS NOT NULL)"
+    t.index ["user_id", "created_at"], name: "index_usage_events_on_user_id_and_created_at"
+    t.index ["user_id"], name: "index_usage_events_on_user_id"
+  end
+
+  create_table "usage_feedbacks", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "model"
+    t.string "rating", null: false
+    t.string "request_id"
+    t.datetime "created_at", null: false
+    t.index ["user_id", "created_at"], name: "index_usage_feedbacks_on_user_id_and_created_at"
+    t.index ["user_id"], name: "index_usage_feedbacks_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -324,16 +386,22 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_21_030000) do
     t.string "uid"
     t.datetime "terms_accepted_at"
     t.string "terms_accepted_version"
+    t.string "role", default: "member", null: false
+    t.string "last_country"
+    t.datetime "last_seen_at"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["jti"], name: "index_users_on_jti", unique: true
+    t.index ["last_seen_at"], name: "index_users_on_last_seen_at"
     t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
   add_foreign_key "api_requests", "plans"
+  add_foreign_key "auth_events", "users"
   add_foreign_key "brand_pages", "brand_pages", column: "published_version_id"
   add_foreign_key "brand_pages", "users"
   add_foreign_key "clicks", "links"
+  add_foreign_key "credit_wallets", "users"
   add_foreign_key "link_campaigns", "users"
   add_foreign_key "link_destination_histories", "links"
   add_foreign_key "link_governance_logs", "links"
@@ -350,4 +418,6 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_21_030000) do
   add_foreign_key "qr_codes", "users"
   add_foreign_key "resources", "brand_pages", column: "page_id"
   add_foreign_key "subscriptions", "users"
+  add_foreign_key "usage_events", "users"
+  add_foreign_key "usage_feedbacks", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_07_06_120004) do
+ActiveRecord::Schema[7.2].define(version: 2026_07_07_120001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/lib/levelcode.rb
+++ b/lib/levelcode.rb
@@ -1,0 +1,317 @@
+# frozen_string_literal: true
+
+# Levelcode — LevelCode managed-hosting namespace (SPEC §1, §6).
+#
+# This file is the EXPLICIT definition of the `Levelcode` module for Zeitwerk. It
+# must live at lib/levelcode.rb (not lib/levelcode/plans.rb) so that autoloading maps
+# lib/levelcode.rb -> Levelcode; the child constants (Levelcode::EditorToken, ::AiRouter,
+# ::Metering, ::WebhookSync, …) are provided by app/services/levelcode/*.rb.
+module Levelcode
+  # Product tag for every Levelcode (LevelCode) subscription / wallet / usage row.
+  PRODUCT = "levelcode"
+
+  # Server-side source of truth for the four managed-hosting tiers.
+  #
+  # Caps are tokens/month and prices are cents (SPEC §6, DECISIONS D10):
+  #   pro 15M/2M, pro_plus 35M/4.5M, max 55M/7M, ultra 95M/12M;
+  #   $20 / $40 / $60 / $100.
+  #
+  # The frontend never hard-codes any of this — `GET /pricing` surfaces it.
+  PLANS = [
+    {
+      key: "orbits_pro",
+      name: "Pro",
+      price_cents: 2_000,
+      interval: "month",
+      input_cap: 15_000_000,
+      output_cap: 2_000_000,
+      turns: 375,
+      stripe_lookup_key: "orbits_pro",
+      features: [
+        "~375 agent turns / month",
+        "15M input · 2M output tokens",
+        "Kimi K2.7 Code gateway",
+        "Bring-your-own-key always free"
+      ]
+    },
+    {
+      key: "orbits_pro_plus",
+      name: "Pro+",
+      price_cents: 4_000,
+      interval: "month",
+      input_cap: 35_000_000,
+      output_cap: 4_500_000,
+      turns: 875,
+      stripe_lookup_key: "orbits_pro_plus",
+      features: [
+        "~875 agent turns / month",
+        "35M input · 4.5M output tokens",
+        "Kimi K2.7 Code gateway",
+        "Priority routing"
+      ]
+    },
+    {
+      key: "orbits_max",
+      name: "Max",
+      price_cents: 6_000,
+      interval: "month",
+      input_cap: 55_000_000,
+      output_cap: 7_000_000,
+      turns: 1_375,
+      stripe_lookup_key: "orbits_max",
+      features: [
+        "~1,375 agent turns / month",
+        "55M input · 7M output tokens",
+        "Kimi K2.7 Code gateway",
+        "Priority routing"
+      ]
+    },
+    {
+      key: "orbits_ultra",
+      name: "Ultra",
+      price_cents: 10_000,
+      interval: "month",
+      input_cap: 95_000_000,
+      output_cap: 12_000_000,
+      turns: 2_375,
+      stripe_lookup_key: "orbits_ultra",
+      features: [
+        "~2,375 agent turns / month",
+        "95M input · 12M output tokens",
+        "Kimi K2.7 Code gateway",
+        "Highest priority routing"
+      ]
+    }
+  ].freeze
+
+  # Default model keys (mirror the backend ENV defaults in SPEC §1). These MUST be
+  # real OpenRouter slugs — an unknown id makes every gateway request 400. (The
+  # earlier "kimi-k2.6"/"kimi-k2.6-small" placeholders don't exist on OpenRouter.)
+  DEFAULT_MODEL = "moonshotai/kimi-k2.7-code"
+  # There is NO genuinely-smaller Kimi — `kimi-latest` is an unstable alias to the
+  # newest model (often as pricey as, or pricier than, the flagship), so it's the
+  # wrong "cheap request" target. Default the small/cheap path to the flagship;
+  # override LEVELCODE_SMALL_MODEL to route trivial completions to a real cheaper model.
+  DEFAULT_SMALL_MODEL = DEFAULT_MODEL
+
+  # ── Free tier (M11) — logged-in, not-yet-paid users get the gateway on a cheap
+  # open-weights engine (gpt-oss-120b: ~$0.03/M in · $0.15/M out — ~25× cheaper
+  # than the flagship). Metered against a hard monthly cap; over-cap → upgrade CTA.
+  FREE_PLAN_KEY = "free"
+  FREE_MODEL = ENV.fetch("LEVELCODE_FREE_MODEL", "openai/gpt-oss-120b").freeze
+  # Tunable via ENV (economics TBD). Lean-ish default: ~5M in / 1M out per month
+  # (~300–400 12K-context agent turns + inline completions).
+  FREE_INPUT_CAP  = ENV.fetch("LEVELCODE_FREE_INPUT_CAP", 5_000_000).to_i
+  FREE_OUTPUT_CAP = ENV.fetch("LEVELCODE_FREE_OUTPUT_CAP", 1_000_000).to_i
+  # Per-request output ceiling for the free tier (a throttle): the monthly cap is checked
+  # per-request-start, so without this a burst of concurrent streams could each request a
+  # huge max_tokens and overshoot the cap before the counters catch up. Generous enough for
+  # normal chat/agent turns; the editor's default is 4096.
+  FREE_MAX_TOKENS = ENV.fetch("LEVELCODE_FREE_MAX_TOKENS", 8_192).to_i
+  # Per-request output ceiling for PAID plans (M14). Enforcement is per-request-start, so without a
+  # per-request bound a burst of concurrent streams could overshoot the DOLLAR budget before the
+  # counters land. Generous for agent turns; bounds a single request's cost. Matters most once a
+  # frontier model (Opus/Fable) is confirmed-live — a single unclamped huge request would cost dollars.
+  PAID_MAX_TOKENS = ENV.fetch("LEVELCODE_PAID_MAX_TOKENS", 32_768).to_i
+
+  # The "Auto" pseudo-model the editor can request — the gateway routes each turn to the cheapest
+  # engine that fits (free margin, rec #4). Reachable on any plan (free stays on gpt-oss anyway).
+  AUTO_MODEL = "auto"
+  # A turn is "trivial" (→ cheap engine) when it carries no tools and little input text.
+  AUTO_TRIVIAL_CHARS = ENV.fetch("LEVELCODE_AUTO_TRIVIAL_CHARS", 4_000).to_i
+
+  class << self
+    # Look up a single plan definition by its key (e.g. "orbits_pro").
+    def plan(key)
+      PLANS.find { |p| p[:key] == key.to_s }
+    end
+
+    # Per-model token rates, expressed in **micro-dollars per token**
+    # (equivalently: $/M tokens, since $1/M == 1 micro-dollar/token).
+    #
+    # Real OpenRouter list prices (verified): kimi-k2.7-code $0.74/M in · $3.50/M
+    # out · $0.15/M cached; kimi-latest $0.66/M in · $3.41/M out · $0.14/M cached.
+    # NOTE: the plan caps/prices in PLANS were sized against the old ~$0.66/$3.41
+    # assumption — re-check margins now that the flagship is a touch pricier.
+    # Per-model {input:, cached_input:, output:} micro-$/token rates — derived from the ONE roster
+    # definition (Levelcode::ModelCatalog). An unknown model falls back to the flagship's rate in
+    # cost_micros. Verify the frontier rows' `status: :assumption` prices before billing on them.
+    def rate_table
+      Levelcode::ModelCatalog.rate_table
+    end
+
+    # The plan's DEFAULT gateway model, used when the request doesn't name a reachable one
+    # (paid → flagship, free → open-weights).
+    def default_model(plan_key)
+      plan_tier(plan_key) == :free ? FREE_MODEL : DEFAULT_MODEL
+    end
+
+    # "Auto" routing: send trivial turns (no tools + small input) to the cheap open-weights engine,
+    # standard/agent turns to the plan default. Both targets are always live + entitled, so this
+    # never over-reaches the plan; it only ever routes DOWN in cost.
+    def auto_route(plan_key, body)
+      return default_model(plan_key) if body["tools"].present? # agent/tool turns need the strong model
+
+      message_chars(body["messages"]) <= AUTO_TRIVIAL_CHARS ? FREE_MODEL : default_model(plan_key)
+    end
+
+    # Total characters of message content — defensively. `body` is a CLIENT-CONTROLLED transparent
+    # proxy payload with NO shape validation, so `messages` may be a bare object, contain scalars, or
+    # carry array (multimodal) content. Never raise: a malformed body must not 500 the gateway. Any
+    # oddity falls back toward the larger count (→ the strong model), which is the safe cost direction.
+    def message_chars(messages)
+      list = messages.is_a?(Array) ? messages : [ messages ]
+      list.sum { |m| m.is_a?(Hash) ? content_length(m["content"]) : 0 }
+    end
+
+    # Length of a single message's `content`. A String → its length. A multimodal parts array →
+    # the sum of text-part lengths, but ANY non-text part (image/audio) forces the turn past the
+    # trivial threshold so vision/audio turns always route to the strong model. Anything else → 0.
+    def content_length(content)
+      case content
+      when String then content.length
+      when Array
+        content.sum do |part|
+          if part.is_a?(Hash) && (part["type"].nil? || part["type"] == "text")
+            part["text"].to_s.length
+          else
+            AUTO_TRIVIAL_CHARS + 1 # image/audio/unknown part → not trivial → strong model
+          end
+        end
+      else 0
+      end
+    end
+
+    # Live-REACHABLE roster for a plan: the models it's entitled to (by tier) that ALSO carry a
+    # CONFIRMED price — we never meter/bill against an assumed price. As frontier prices are confirmed
+    # in ModelCatalog they auto-go-live here. Free → [gpt-oss]; paid → [Kimi, gpt-oss] today, widening
+    # as prices land. Entitlement stays server-side: a free user can never reach the flagship.
+    def allowed_models(plan_key)
+      entitled_models(plan_key).select { |id| Levelcode::ModelCatalog.find(id)&.dig(:status) == :confirmed }
+    end
+
+    # The EFFECTIVE gateway model: the requested model iff it's reachable for the plan, else the
+    # plan default. Under the DOLLAR-budget scheme (M14) any reachable model is safe — it burns the
+    # plan's budget at its real cost — so this is entitlement, not price-protection.
+    def gateway_model(plan_key, requested = nil)
+      req = requested.to_s
+      allowed_models(plan_key).include?(req) ? req : default_model(plan_key)
+    end
+
+    # Compute the durable-ledger cost of a single request in micro-dollars.
+    #
+    #   model  — upstream model id (falls back to the default model's rates)
+    #   input  — prompt tokens billed at the full input rate
+    #   output — completion tokens
+    #   cached — cached-input tokens billed at the cheaper cached rate; these
+    #            are a subset of `input`, so the non-cached remainder is billed
+    #            at the full input rate.
+    #
+    # Returns a rounded integer (micro-dollars).
+    def cost_micros(model, input, output, cached = 0)
+      table = rate_table
+      rate = table[model.to_s] || table[DEFAULT_MODEL]
+
+      input = input.to_i
+      output = output.to_i
+      cached = cached.to_i.clamp(0, input)
+      billed_input = input - cached
+
+      micros =
+        (billed_input * rate[:input]) +
+        (cached * rate[:cached_input]) +
+        (output * rate[:output])
+
+      micros.round
+    end
+
+    # ── Credit economics (M14) ──────────────────────────────────────────────
+    # DISPLAY layer over the roster. The plan allowance is a DOLLAR budget (budget_micros); every
+    # model burns it at its real per-request cost. Multipliers/turns below are a UI convenience that
+    # reproduces the pricing table from prices — the ledger is always metered in dollars.
+
+    # OpenRouter's top-up fee on routed traffic (~5.5%). Folded into the plan budget so the published
+    # dollar allowance already covers it; move to direct provider keys at volume to shed it.
+    ROUTING_FEE = 1.055
+
+    # Plan key → catalog tier symbol (drives which roster models the plan may reach).
+    def plan_tier(plan_key)
+      case plan_key.to_s
+      when "orbits_ultra"    then :ultra
+      when "orbits_max"      then :max
+      when "orbits_pro_plus" then :pro_plus
+      when "orbits_pro"      then :pro
+      else :free
+      end
+    end
+
+    # The roster model ids a plan may use through the gateway (its tier ⊇ the model's min_tier).
+    def entitled_models(plan_key)
+      Levelcode::ModelCatalog.entitled(plan_tier(plan_key))
+    end
+
+    # A plan's DOLLAR compute budget (micro-$/month) — DERIVED as the flagship (Kimi) worst-case:
+    # the full token allowance run at the flagship rate with 50% input cache, plus the routing fee.
+    # This is the dollar allowance every model burns; the credit scheme makes worst-case margin
+    # identical for any model mix (see docs, M14).
+    def budget_micros(plan_key)
+      p = plan(plan_key)
+      return 0 unless p
+
+      rate = Levelcode::ModelCatalog.find(DEFAULT_MODEL)
+      in_cap = p[:input_cap].to_i
+      out_cap = p[:output_cap].to_i
+      cached = in_cap / 2
+      billed = in_cap - cached
+      raw = (billed * rate[:input]) + (cached * rate[:cached_input]) + (out_cap * rate[:output])
+      (raw * ROUTING_FEE).round
+    end
+
+    # The free tier's DOLLAR budget (micro-$): its token caps run on the open-weights engine
+    # (worst case, no cache credit) — ~$0.30/mo. This is the hard ceiling free users burn.
+    # FREE_MODEL is ENV-overridable, so fall back to the canonical gpt-oss rates if the override
+    # isn't in the catalog (never crash free-wallet provisioning on a config typo).
+    def free_budget_micros
+      rate = Levelcode::ModelCatalog.find(FREE_MODEL) || Levelcode::ModelCatalog.find("openai/gpt-oss-120b")
+      (FREE_INPUT_CAP * rate[:input] + FREE_OUTPUT_CAP * rate[:output]).round
+    end
+
+    # Credit multiplier for a model (cost relative to the flagship) — derived, DISPLAY only.
+    def model_multiplier(model)
+      Levelcode::ModelCatalog.multiplier(model)
+    end
+
+    # How many reference turns a plan's budget buys on a model (budget ÷ per-turn cost incl. routing).
+    def turns_for(plan_key, model)
+      turns_in_budget(budget_micros(plan_key), model)
+    end
+
+    # How many reference turns a given DOLLAR balance buys on a model (used for "≈ N turns left").
+    def turns_in_budget(budget, model)
+      per_turn = Levelcode::ModelCatalog.reference_cost_micros(model) * ROUTING_FEE
+      return 0 if per_turn <= 0
+
+      (budget.to_i / per_turn).floor
+    end
+
+    # The plan's model roster for the picker/dashboard: every ENTITLED model with its display
+    # economics and, when `remaining_micros` is given, how many more turns the current balance buys.
+    # `live` = actually reachable (confirmed price); staged (assumption-priced) models are shown but
+    # not selectable/billable. This is the ONE surface the editor + dashboard render.
+    def roster_for(plan_key, remaining_micros = nil)
+      live = allowed_models(plan_key)
+      entitled_models(plan_key).map do |id|
+        m = Levelcode::ModelCatalog.find(id)
+        {
+          id: id,
+          label: m[:label],
+          context: m[:context],
+          multiplier: model_multiplier(id),
+          live: live.include?(id),
+          turns_budget: turns_for(plan_key, id),
+          turns_left: remaining_micros.nil? ? nil : turns_in_budget(remaining_micros, id)
+        }
+      end
+    end
+  end
+end

--- a/lib/levelcode.rb
+++ b/lib/levelcode.rb
@@ -213,10 +213,12 @@ module Levelcode
     #            are a subset of `input`, so the non-cached remainder is billed
     #            at the full input rate.
     #
-    # Returns a rounded integer (micro-dollars).
+    # Returns a rounded integer (micro-dollars), INCLUSIVE of the OpenRouter routing fee — this is the
+    # true wire cost, so the enforced dollar budget is spent at the real rate and the target margin
+    # (1 − CREDIT_COGS_RATIO) holds. Callers should pass the ROUTED catalog model id (what we intend to
+    # charge); an unknown id falls back to the most expensive confirmed rate so it can never under-bill.
     def cost_micros(model, input, output, cached = 0)
-      table = rate_table
-      rate = table[model.to_s] || table[DEFAULT_MODEL]
+      rate = rate_for(model)
 
       input = input.to_i
       output = output.to_i
@@ -228,7 +230,36 @@ module Levelcode
         (cached * rate[:cached_input]) +
         (output * rate[:output])
 
-      micros.round
+      (micros * ROUTING_FEE).round
+    end
+
+    # The per-token rate row for a model id. A KNOWN catalog id → its own rate. An UNKNOWN id (an
+    # upstream-substituted slug, or a dated snapshot the caller didn't normalize) → the most expensive
+    # CONFIRMED rate, so an off-catalog id never UNDER-bills (the safe money direction). This is why the
+    # gateway bills at the ROUTED catalog model, not the upstream-reported string.
+    def rate_for(model)
+      rate_table[model.to_s] || Levelcode::ModelCatalog.max_confirmed_rate
+    end
+
+    # Rough tokens-per-character used to estimate input size for the admission-time budget reservation.
+    CHARS_PER_TOKEN = 4
+
+    # Worst-case cost (micro-$) of a request BEFORE it runs — for the admission-time budget reservation
+    # (M14 concurrency guard). Estimates input tokens from the body's character count (≈ CHARS_PER_TOKEN
+    # chars/token, clamped to the model's context window) and assumes the full per-request output
+    # ceiling. Deliberately conservative (reserves high, never caches); the real cost reconciles the
+    # reservation DOWN on settle. `model` must be the routed catalog id (its rate + context window).
+    def estimate_cost_micros(model, body, free_tier: false)
+      body ||= {}
+      ctx = (Levelcode::ModelCatalog.find(model.to_s) || {})[:context].to_i
+      est_input = (message_chars(body["messages"]).to_f / CHARS_PER_TOKEN).ceil
+      est_input = [ est_input, ctx ].min if ctx.positive?
+
+      ceiling = free_tier ? FREE_MAX_TOKENS : PAID_MAX_TOKENS
+      requested_out = [ body["max_tokens"], body["max_completion_tokens"] ].compact.map(&:to_i).select(&:positive?).min
+      est_output = requested_out ? [ requested_out, ceiling ].min : ceiling
+
+      cost_micros(model, est_input, est_output, 0)
     end
 
     # ── Credit economics (M14) ──────────────────────────────────────────────
@@ -256,10 +287,10 @@ module Levelcode
       Levelcode::ModelCatalog.entitled(plan_tier(plan_key))
     end
 
-    # A plan's DOLLAR compute budget (micro-$/month) — DERIVED as the flagship (Kimi) worst-case:
-    # the full token allowance run at the flagship rate with 50% input cache, plus the routing fee.
-    # This is the dollar allowance every model burns; the credit scheme makes worst-case margin
-    # identical for any model mix (see docs, M14).
+    # A plan's DOLLAR compute budget (micro-$/month) — a fixed fraction of subscription revenue
+    # (CREDIT_COGS_RATIO). Every model burns this same allowance at its real per-request wire cost
+    # (cost_micros already includes the routing fee), so the target margin (1 − CREDIT_COGS_RATIO)
+    # holds for any model mix (see docs, M14).
     def budget_micros(plan_key)
       p = plan(plan_key)
       return 0 unless p

--- a/lib/levelcode.rb
+++ b/lib/levelcode.rb
@@ -25,12 +25,12 @@ module Levelcode
       interval: "month",
       input_cap: 15_000_000,
       output_cap: 2_000_000,
-      turns: 375,
+      turns: 260,
       stripe_lookup_key: "orbits_pro",
       features: [
-        "~375 agent turns / month",
-        "15M input · 2M output tokens",
-        "Kimi K2.7 Code gateway",
+        "~260 Kimi turns/mo · ~39 on Opus 4.8",
+        "$10/mo of AI credits (dollar-metered)",
+        "Kimi K2.7 Code + Opus 4.8",
         "Bring-your-own-key always free"
       ]
     },
@@ -41,12 +41,12 @@ module Levelcode
       interval: "month",
       input_cap: 35_000_000,
       output_cap: 4_500_000,
-      turns: 875,
+      turns: 520,
       stripe_lookup_key: "orbits_pro_plus",
       features: [
-        "~875 agent turns / month",
-        "35M input · 4.5M output tokens",
-        "Kimi K2.7 Code gateway",
+        "~520 Kimi turns/mo · ~78 on Opus 4.8",
+        "$20/mo of AI credits (dollar-metered)",
+        "Kimi K2.7 Code + Opus 4.8",
         "Priority routing"
       ]
     },
@@ -57,12 +57,12 @@ module Levelcode
       interval: "month",
       input_cap: 55_000_000,
       output_cap: 7_000_000,
-      turns: 1_375,
+      turns: 780,
       stripe_lookup_key: "orbits_max",
       features: [
-        "~1,375 agent turns / month",
-        "55M input · 7M output tokens",
-        "Kimi K2.7 Code gateway",
+        "~780 Kimi turns/mo · ~117 on Opus 4.8",
+        "$30/mo of AI credits (dollar-metered)",
+        "Kimi K2.7 Code + Opus 4.8",
         "Priority routing"
       ]
     },
@@ -73,12 +73,12 @@ module Levelcode
       interval: "month",
       input_cap: 95_000_000,
       output_cap: 12_000_000,
-      turns: 2_375,
+      turns: 1_300,
       stripe_lookup_key: "orbits_ultra",
       features: [
-        "~2,375 agent turns / month",
-        "95M input · 12M output tokens",
-        "Kimi K2.7 Code gateway",
+        "~1,300 Kimi turns/mo · ~195 on Opus 4.8",
+        "$50/mo of AI credits (dollar-metered)",
+        "Kimi K2.7 Code + Opus 4.8",
         "Highest priority routing"
       ]
     }
@@ -119,6 +119,12 @@ module Levelcode
   AUTO_MODEL = "auto"
   # A turn is "trivial" (→ cheap engine) when it carries no tools and little input text.
   AUTO_TRIVIAL_CHARS = ENV.fetch("LEVELCODE_AUTO_TRIVIAL_CHARS", 4_000).to_i
+
+  # Target model-COGS as a fraction of subscription revenue → the enforced monthly credit budget is
+  # `plan price × CREDIT_COGS_RATIO`. Gross margin = 1 - this (before Stripe/infra). Because metering
+  # charges each model its REAL per-token cost, this margin holds for ANY model mix — pricey models
+  # (Opus ≈ 7× Kimi) just burn the budget faster. ENV-tunable so pricing can move without a deploy.
+  CREDIT_COGS_RATIO = ENV.fetch("LEVELCODE_CREDIT_COGS_RATIO", 0.50).to_f
 
   class << self
     # Look up a single plan definition by its key (e.g. "orbits_pro").
@@ -258,13 +264,10 @@ module Levelcode
       p = plan(plan_key)
       return 0 unless p
 
-      rate = Levelcode::ModelCatalog.find(DEFAULT_MODEL)
-      in_cap = p[:input_cap].to_i
-      out_cap = p[:output_cap].to_i
-      cached = in_cap / 2
-      billed = in_cap - cached
-      raw = (billed * rate[:input]) + (cached * rate[:cached_input]) + (out_cap * rate[:output])
-      (raw * ROUTING_FEE).round
+      # Revenue-based (Cursor-style): the monthly credit allowance is a fixed fraction of the plan's
+      # price, so gross margin = 1 - CREDIT_COGS_RATIO regardless of which models the user picks.
+      # micro-$ = dollars × 1_000_000; price_cents / 100 = dollars of revenue.
+      (p[:price_cents] / 100.0 * CREDIT_COGS_RATIO * 1_000_000).round
     end
 
     # The free tier's DOLLAR budget (micro-$): its token caps run on the open-weights engine

--- a/spec/factories/subscriptions.rb
+++ b/spec/factories/subscriptions.rb
@@ -7,6 +7,7 @@
 #  current_period_end   :datetime
 #  current_period_start :datetime
 #  interval             :string
+#  product              :string           default("linkly"), not null
 #  status               :string
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
@@ -17,7 +18,8 @@
 #
 # Indexes
 #
-#  index_subscriptions_on_user_id  (user_id)
+#  index_subscriptions_on_user_id              (user_id)
+#  index_subscriptions_on_user_id_and_product  (user_id,product)
 #
 # Foreign Keys
 #

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -7,10 +7,13 @@
 #  email                  :string           default(""), not null
 #  encrypted_password     :string           default(""), not null
 #  jti                    :string           not null
+#  last_country           :string
+#  last_seen_at           :datetime
 #  provider               :string
 #  remember_created_at    :datetime
 #  reset_password_sent_at :datetime
 #  reset_password_token   :string
+#  role                   :string           default("member"), not null
 #  terms_accepted         :boolean          default(FALSE), not null
 #  terms_accepted_at      :datetime
 #  terms_accepted_version :string
@@ -23,6 +26,7 @@
 #
 #  index_users_on_email                 (email) UNIQUE
 #  index_users_on_jti                   (jti) UNIQUE
+#  index_users_on_last_seen_at          (last_seen_at)
 #  index_users_on_provider_and_uid      (provider,uid) UNIQUE
 #  index_users_on_reset_password_token  (reset_password_token) UNIQUE
 #

--- a/spec/jobs/record_usage_job_spec.rb
+++ b/spec/jobs/record_usage_job_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+
+RSpec.describe RecordUsageJob, type: :job do
+  let(:user) { create(:user) }
+
+  # The enqueue side (AiController#meter!) passes `wallet.period_end.to_i`, which TRUNCATES to whole
+  # seconds. The job must match the wallet on the SAME truncated epoch — even when period_end carries
+  # sub-second precision — or the durable counters silently never bump.
+  def wallet_with(period_end:, **attrs)
+    CreditWallet.create!(
+      { user: user, product: Levelcode::PRODUCT, plan_key: "orbits_pro",
+        input_cap: 15_000_000, output_cap: 2_000_000,
+        budget_micros: 14_427_125, spent_micros: 0, input_used: 0, output_used: 0,
+        period_start: period_end - 1.month, period_end: period_end,
+        overage_policy: "throttle" }.merge(attrs)
+    )
+  end
+
+  it "bumps the durable per-period counters on the first (unique) ledger insert" do
+    pe = Time.zone.local(2026, 8, 7, 6, 32, 37)
+    wallet = wallet_with(period_end: pe)
+
+    described_class.new.perform(user.id, "req-1", "anthropic/claude-4.8-opus", "openrouter",
+                                20_000, 800, 0, 18_068, pe.to_i)
+
+    wallet.reload
+    expect(wallet.spent_micros).to eq(18_068)
+    expect(wallet.input_used).to eq(20_000)
+    expect(wallet.output_used).to eq(800)
+    expect(UsageEvent.where(request_id: "req-1").count).to eq(1)
+  end
+
+  # The regression: period_end stored with ≥ .5µs. Ruby to_i FLOORS (→ ...37); a bare
+  # EXTRACT(EPOCH)::bigint ROUNDS UP (→ ...38). The two must still match, or spend freezes at 0.
+  it "still bumps the counter when period_end has a fractional second ≥ .5 (epoch-rounding bug)" do
+    pe = Time.zone.local(2026, 8, 7, 6, 32, 37) + 0.75 # rounds UP under ::bigint, floors under to_i
+    wallet = wallet_with(period_end: pe)
+    expect(pe.to_i).to eq(pe.to_i) # the enqueued arg is the TRUNCATED epoch (…37, not …38)
+
+    described_class.new.perform(user.id, "req-frac", "anthropic/claude-4.8-opus", "openrouter",
+                                5_000, 100, 0, 6_868, pe.to_i)
+
+    expect(wallet.reload.spent_micros).to eq(6_868)
+  end
+
+  it "does NOT double-bump on a duplicate (same request_id) enqueue" do
+    pe = Time.zone.local(2026, 8, 7, 6, 32, 37) + 0.75
+    wallet = wallet_with(period_end: pe)
+
+    2.times { described_class.new.perform(user.id, "req-dup", "m", "openrouter", 1_000, 10, 0, 500, pe.to_i) }
+
+    expect(wallet.reload.spent_micros).to eq(500) # only the first insert bumps
+    expect(UsageEvent.where(request_id: "req-dup").count).to eq(1)
+  end
+
+  it "no-ops the counter bump when the job lands after the period has rolled" do
+    pe = Time.zone.local(2026, 8, 7, 6, 32, 37)
+    wallet = wallet_with(period_end: pe)
+
+    # A stale job carrying the PREVIOUS period's epoch must not corrupt the current period.
+    described_class.new.perform(user.id, "req-stale", "m", "openrouter", 1_000, 10, 0, 500, (pe - 1.month).to_i)
+
+    expect(wallet.reload.spent_micros).to eq(0)
+    expect(UsageEvent.where(request_id: "req-stale").count).to eq(1) # ledger row still written
+  end
+end

--- a/spec/models/credit_wallet_spec.rb
+++ b/spec/models/credit_wallet_spec.rb
@@ -1,0 +1,148 @@
+# == Schema Information
+#
+# Table name: credit_wallets
+#
+#  id             :bigint           not null, primary key
+#  budget_micros  :bigint           default(0), not null
+#  input_cap      :bigint           not null
+#  input_used     :bigint           default(0), not null
+#  output_cap     :bigint           not null
+#  output_used    :bigint           default(0), not null
+#  overage_policy :string           default("throttle"), not null
+#  period_end     :datetime
+#  period_start   :datetime
+#  plan_key       :string           not null
+#  product        :string           default("levelcode"), not null
+#  spent_micros   :bigint           default(0), not null
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  user_id        :bigint           not null
+#
+# Indexes
+#
+#  index_credit_wallets_on_user_id              (user_id)
+#  index_credit_wallets_on_user_id_and_product  (user_id,product) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
+require 'rails_helper'
+
+RSpec.describe CreditWallet, type: :model do
+  let(:user) { create(:user) }
+
+  describe 'associations' do
+    it 'belongs to a user' do
+      assoc = described_class.reflect_on_association(:user)
+      expect(assoc.macro).to eq(:belongs_to)
+    end
+  end
+
+  describe 'validations' do
+    subject { CreditWallet.for(user) }
+
+    it 'is valid when provisioned from a plan' do
+      expect(subject).to be_valid
+    end
+
+    it 'rejects an unknown overage policy' do
+      subject.overage_policy = 'nope'
+      expect(subject).not_to be_valid
+    end
+
+    it 'requires a plan_key' do
+      subject.plan_key = nil
+      expect(subject).not_to be_valid
+    end
+  end
+
+  describe '.for' do
+    it 'provisions a wallet seeded from the default plan' do
+      wallet = CreditWallet.for(user)
+      plan = Levelcode::PLANS.first
+
+      expect(wallet).to be_persisted
+      expect(wallet.product).to eq(Levelcode::PRODUCT)
+      expect(wallet.plan_key).to eq(plan[:key])
+      expect(wallet.input_cap).to eq(plan[:input_cap])
+      expect(wallet.output_cap).to eq(plan[:output_cap])
+      expect(wallet.overage_policy).to eq('throttle')
+    end
+
+    it 'is idempotent per [user, product]' do
+      first = CreditWallet.for(user)
+      second = CreditWallet.for(user)
+
+      expect(second.id).to eq(first.id)
+      expect(user.credit_wallets.count).to eq(1)
+    end
+
+    it 'seeds caps from a specified plan_key' do
+      wallet = CreditWallet.for(user, plan_key: 'orbits_ultra')
+      plan = Levelcode.plan('orbits_ultra')
+
+      expect(wallet.plan_key).to eq('orbits_ultra')
+      expect(wallet.input_cap).to eq(plan[:input_cap])
+      expect(wallet.output_cap).to eq(plan[:output_cap])
+    end
+  end
+
+  describe 'cap helpers' do
+    let(:wallet) { CreditWallet.for(user) }
+
+    it 'reports remaining tokens per dimension' do
+      wallet.update!(input_used: 1_000_000, output_used: 500_000)
+
+      expect(wallet.input_remaining).to eq(wallet.input_cap - 1_000_000)
+      expect(wallet.output_remaining).to eq(wallet.output_cap - 500_000)
+    end
+
+    it 'never reports negative remaining' do
+      wallet.update!(input_used: wallet.input_cap + 999)
+      expect(wallet.input_remaining).to eq(0)
+    end
+
+    it 'flags cap_reached when input hits the cap' do
+      wallet.update!(input_used: wallet.input_cap)
+      expect(wallet.input_cap_reached?).to be true
+      expect(wallet.cap_reached?).to be true
+    end
+
+    it 'flags cap_reached when output hits the cap' do
+      wallet.update!(output_used: wallet.output_cap)
+      expect(wallet.output_cap_reached?).to be true
+      expect(wallet.cap_reached?).to be true
+    end
+
+    it 'is not over cap exactly at the cap' do
+      wallet.update!(input_used: wallet.input_cap)
+      expect(wallet.overage?).to be false
+    end
+
+    it 'is over cap past the cap' do
+      wallet.update!(output_used: wallet.output_cap + 1)
+      expect(wallet.overage?).to be true
+    end
+  end
+
+  describe 'overage policy predicates' do
+    let(:wallet) { CreditWallet.for(user) }
+
+    it 'defaults to throttle' do
+      expect(wallet.throttle?).to be true
+      expect(wallet.topup?).to be false
+      expect(wallet.stop?).to be false
+    end
+
+    it 'reflects a topup policy' do
+      wallet.update!(overage_policy: 'topup')
+      expect(wallet.topup?).to be true
+    end
+
+    it 'reflects a stop policy' do
+      wallet.update!(overage_policy: 'stop')
+      expect(wallet.stop?).to be true
+    end
+  end
+end

--- a/spec/models/levelcode_model_catalog_spec.rb
+++ b/spec/models/levelcode_model_catalog_spec.rb
@@ -7,8 +7,10 @@ RSpec.describe Levelcode::ModelCatalog do
     it "marks only the verified engines as confirmed; frontier rows are assumptions" do
       expect(described_class.find("openai/gpt-oss-120b")[:status]).to eq(:confirmed)
       expect(described_class.find("moonshotai/kimi-k2.7-code")[:status]).to eq(:confirmed)
+      expect(described_class.find("anthropic/claude-opus-4-8")[:status]).to eq(:confirmed) # price confirmed 2026-07-07
       assumed = described_class.all.select { |_id, m| m[:status] == :assumption }.keys
-      expect(assumed).to include("anthropic/claude-opus-4-8", "anthropic/claude-fable-5", "openai/gpt-5.5")
+      expect(assumed).to include("anthropic/claude-fable-5", "openai/gpt-5.5")
+      expect(assumed).not_to include("anthropic/claude-opus-4-8")
     end
 
     it "rate_table exposes every roster model's per-token rates (feeds Levelcode.cost_micros)" do
@@ -59,11 +61,11 @@ RSpec.describe Levelcode::ModelCatalog do
 end
 
 RSpec.describe "Levelcode credit economics (M14)" do
-  describe ".budget_micros — the DOLLAR compute budget (flagship worst-case)" do
-    it "matches the analysis budgets (~$14.43 / $33.05 / $51.67 / $88.91), within cents" do
-      { "orbits_pro" => 14_430_000, "orbits_pro_plus" => 33_050_000,
-        "orbits_max" => 51_670_000, "orbits_ultra" => 88_910_000 }.each do |key, expected|
-        expect(Levelcode.budget_micros(key)).to be_within(60_000).of(expected)
+  describe ".budget_micros — the DOLLAR compute budget (revenue × CREDIT_COGS_RATIO)" do
+    it "is a fixed 50% of plan revenue ($10 / $20 / $30 / $50 of credits)" do
+      { "orbits_pro" => 10_000_000, "orbits_pro_plus" => 20_000_000,
+        "orbits_max" => 30_000_000, "orbits_ultra" => 50_000_000 }.each do |key, expected|
+        expect(Levelcode.budget_micros(key)).to eq(expected)
       end
     end
 
@@ -74,11 +76,11 @@ RSpec.describe "Levelcode credit economics (M14)" do
   end
 
   describe ".turns_for — equivalent turns a budget buys on a model" do
-    it "reproduces the analysis turn counts (within rounding)" do
-      expect(Levelcode.turns_for("orbits_pro", "moonshotai/kimi-k2.7-code")).to be_within(2).of(375)
-      expect(Levelcode.turns_for("orbits_pro", "anthropic/claude-opus-4-8")).to be_within(2).of(56)
-      expect(Levelcode.turns_for("orbits_pro", "anthropic/claude-fable-5")).to be_within(2).of(28)
-      expect(Levelcode.turns_for("orbits_pro", "openai/gpt-oss-120b")).to be > 7_000
+    it "reproduces the turn counts for the $10 Pro budget (50% of revenue)" do
+      expect(Levelcode.turns_for("orbits_pro", "moonshotai/kimi-k2.7-code")).to be_within(2).of(260)
+      expect(Levelcode.turns_for("orbits_pro", "anthropic/claude-opus-4-8")).to be_within(2).of(39)
+      expect(Levelcode.turns_for("orbits_pro", "anthropic/claude-fable-5")).to be_within(2).of(19)
+      expect(Levelcode.turns_for("orbits_pro", "openai/gpt-oss-120b")).to be > 4_000
     end
 
     it "buys far more turns on a cheaper model for the same budget" do

--- a/spec/models/levelcode_model_catalog_spec.rb
+++ b/spec/models/levelcode_model_catalog_spec.rb
@@ -1,0 +1,99 @@
+require "rails_helper"
+
+# Proves the credit economics are DERIVED from prices and reproduce the M14 analysis, and that the
+# design invariants hold (entitlement tiers, monotonic multipliers, dollar-denominated budgets).
+RSpec.describe Levelcode::ModelCatalog do
+  describe "roster integrity" do
+    it "marks only the verified engines as confirmed; frontier rows are assumptions" do
+      expect(described_class.find("openai/gpt-oss-120b")[:status]).to eq(:confirmed)
+      expect(described_class.find("moonshotai/kimi-k2.7-code")[:status]).to eq(:confirmed)
+      assumed = described_class.all.select { |_id, m| m[:status] == :assumption }.keys
+      expect(assumed).to include("anthropic/claude-opus-4-8", "anthropic/claude-fable-5", "openai/gpt-5.5")
+    end
+
+    it "rate_table exposes every roster model's per-token rates (feeds Levelcode.cost_micros)" do
+      expect(described_class.rate_table["moonshotai/kimi-k2.7-code"]).to eq(input: 0.74, cached_input: 0.15, output: 3.50)
+      expect(described_class.rate_table.keys).to match_array(described_class.ids)
+    end
+  end
+
+  describe "credit multipliers (derived, DISPLAY only)" do
+    it "is exactly the per-turn cost ratio to the flagship — never a hand-entered number" do
+      base = described_class.reference_cost_micros(Levelcode::DEFAULT_MODEL)
+      described_class.ids.each do |id|
+        expect(described_class.multiplier(id)).to eq((described_class.reference_cost_micros(id).to_f / base).round(2))
+      end
+    end
+
+    it "reproduces the analysis multipliers (within rounding)" do
+      {
+        "openai/gpt-oss-120b" => 0.05, "moonshotai/kimi-k2.7-code" => 1.00, "openai/codex-5.3" => 2.22,
+        "openai/gpt-5.5" => 2.66, "anthropic/claude-sonnet-5" => 4.00, "anthropic/claude-opus-4-8" => 6.67,
+        "anthropic/claude-fable-5" => 13.35
+      }.each { |id, mult| expect(described_class.multiplier(id)).to be_within(0.02).of(mult) }
+    end
+
+    it "increases monotonically with price (pricier model ⇒ higher multiplier)" do
+      mults = described_class.ids.map { |id| described_class.multiplier(id) }
+      expect(mults).to eq(mults.sort)
+      expect(described_class.multiplier(Levelcode::FREE_MODEL)).to be < described_class.multiplier(Levelcode::DEFAULT_MODEL)
+    end
+  end
+
+  describe "entitlement tiers" do
+    it "free reaches ONLY the open-weights engine" do
+      expect(described_class.entitled(:free)).to eq([ "openai/gpt-oss-120b" ])
+    end
+
+    it "pro reaches the roster EXCEPT Fable (gated to Max/Ultra by UX, rec #3)" do
+      pro = described_class.entitled(:pro)
+      expect(pro).to include("moonshotai/kimi-k2.7-code", "anthropic/claude-opus-4-8", "openai/gpt-5.5")
+      expect(pro).not_to include("anthropic/claude-fable-5")
+    end
+
+    it "Max/Ultra reach the full roster incl. Fable" do
+      expect(described_class.entitled(:max)).to include("anthropic/claude-fable-5")
+      expect(described_class.entitled(:ultra)).to match_array(described_class.ids)
+    end
+  end
+end
+
+RSpec.describe "Levelcode credit economics (M14)" do
+  describe ".budget_micros — the DOLLAR compute budget (flagship worst-case)" do
+    it "matches the analysis budgets (~$14.43 / $33.05 / $51.67 / $88.91), within cents" do
+      { "orbits_pro" => 14_430_000, "orbits_pro_plus" => 33_050_000,
+        "orbits_max" => 51_670_000, "orbits_ultra" => 88_910_000 }.each do |key, expected|
+        expect(Levelcode.budget_micros(key)).to be_within(60_000).of(expected)
+      end
+    end
+
+    it "increases with tier; free/unknown plans have no paid budget" do
+      expect(Levelcode.budget_micros("orbits_pro")).to be < Levelcode.budget_micros("orbits_ultra")
+      expect(Levelcode.budget_micros("free")).to eq(0)
+    end
+  end
+
+  describe ".turns_for — equivalent turns a budget buys on a model" do
+    it "reproduces the analysis turn counts (within rounding)" do
+      expect(Levelcode.turns_for("orbits_pro", "moonshotai/kimi-k2.7-code")).to be_within(2).of(375)
+      expect(Levelcode.turns_for("orbits_pro", "anthropic/claude-opus-4-8")).to be_within(2).of(56)
+      expect(Levelcode.turns_for("orbits_pro", "anthropic/claude-fable-5")).to be_within(2).of(28)
+      expect(Levelcode.turns_for("orbits_pro", "openai/gpt-oss-120b")).to be > 7_000
+    end
+
+    it "buys far more turns on a cheaper model for the same budget" do
+      gpt = Levelcode.turns_for("orbits_max", "openai/gpt-oss-120b")
+      opus = Levelcode.turns_for("orbits_max", "anthropic/claude-opus-4-8")
+      expect(gpt).to be > opus * 100
+    end
+  end
+
+  describe ".entitled_models / .plan_tier" do
+    it "maps plan keys to tiers and gates Fable to Max/Ultra" do
+      expect(Levelcode.plan_tier("orbits_pro")).to eq(:pro)
+      expect(Levelcode.entitled_models("orbits_pro")).not_to include("anthropic/claude-fable-5")
+      expect(Levelcode.entitled_models("orbits_ultra")).to include("anthropic/claude-fable-5")
+      expect(Levelcode.entitled_models("free")).to eq([ "openai/gpt-oss-120b" ])
+    end
+  end
+end

--- a/spec/models/levelcode_plans_spec.rb
+++ b/spec/models/levelcode_plans_spec.rb
@@ -1,0 +1,179 @@
+require 'rails_helper'
+
+RSpec.describe Levelcode do
+  describe 'PLANS' do
+    it 'defines the four frozen tiers in order' do
+      expect(Levelcode::PLANS.map { |p| p[:key] }).to eq(
+        %w[orbits_pro orbits_pro_plus orbits_max orbits_ultra]
+      )
+    end
+
+    it 'matches the SPEC §6 caps and prices' do
+      expected = {
+        'orbits_pro'      => { price_cents: 2_000,  input_cap: 15_000_000, output_cap: 2_000_000 },
+        'orbits_pro_plus' => { price_cents: 4_000,  input_cap: 35_000_000, output_cap: 4_500_000 },
+        'orbits_max'      => { price_cents: 6_000,  input_cap: 55_000_000, output_cap: 7_000_000 },
+        'orbits_ultra'    => { price_cents: 10_000, input_cap: 95_000_000, output_cap: 12_000_000 }
+      }
+
+      Levelcode::PLANS.each do |plan|
+        e = expected[plan[:key]]
+        expect(plan[:price_cents]).to eq(e[:price_cents])
+        expect(plan[:input_cap]).to eq(e[:input_cap])
+        expect(plan[:output_cap]).to eq(e[:output_cap])
+        expect(plan[:interval]).to eq('month')
+        expect(plan[:stripe_lookup_key]).to eq(plan[:key])
+        expect(plan[:features]).to be_an(Array).and be_present
+      end
+    end
+  end
+
+  describe '.plan' do
+    it 'looks up a plan by key' do
+      expect(Levelcode.plan('orbits_max')[:name]).to eq('Max')
+    end
+
+    it 'returns nil for an unknown key' do
+      expect(Levelcode.plan('nope')).to be_nil
+    end
+  end
+
+  describe '.allowed_models / .gateway_model (entitlement)' do
+    it 'free/no-plan may use ONLY the open-weights engine' do
+      expect(Levelcode.allowed_models('free')).to eq([ Levelcode::FREE_MODEL ])
+      expect(Levelcode.allowed_models(nil)).to eq([ Levelcode::FREE_MODEL ])
+    end
+
+    it 'a paid plan may use the flagship AND the open-weights engine (confirmed-price roster)' do
+      expect(Levelcode.allowed_models('orbits_pro')).to match_array([ Levelcode::DEFAULT_MODEL, Levelcode::FREE_MODEL ])
+      # Frontier models are entitled but NOT live yet (assumption-priced) — never billed on assumptions.
+      expect(Levelcode.allowed_models('orbits_pro')).not_to include('anthropic/claude-opus-4-8')
+    end
+
+    it 'free CANNOT reach the flagship no matter what is requested' do
+      expect(Levelcode.gateway_model('free', Levelcode::DEFAULT_MODEL)).to eq(Levelcode::FREE_MODEL)
+      expect(Levelcode.gateway_model('free', nil)).to eq(Levelcode::FREE_MODEL)
+    end
+
+    it 'paid HONORS a requested allowed model (gpt-oss too), else defaults to the flagship' do
+      expect(Levelcode.gateway_model('orbits_pro', Levelcode::FREE_MODEL)).to eq(Levelcode::FREE_MODEL)
+      expect(Levelcode.gateway_model('orbits_pro', Levelcode::DEFAULT_MODEL)).to eq(Levelcode::DEFAULT_MODEL)
+      expect(Levelcode.gateway_model('orbits_pro', 'some/other-model')).to eq(Levelcode::DEFAULT_MODEL)
+      expect(Levelcode.gateway_model('orbits_pro', nil)).to eq(Levelcode::DEFAULT_MODEL)
+    end
+  end
+
+  describe '.auto_route (the "Auto" pseudo-model — cheapest engine that fits)' do
+    let(:trivial) { { "messages" => [ { "role" => "user", "content" => "hi there" } ] } }
+    let(:long_content) { "x" * (Levelcode::AUTO_TRIVIAL_CHARS + 1) }
+    let(:heavy) { { "messages" => [ { "role" => "user", "content" => long_content } ] } }
+    let(:with_tools) { trivial.merge("tools" => [ { "type" => "function", "function" => { "name" => "read" } } ]) }
+
+    it 'routes a trivial (short, tool-less) turn to the cheap open-weights engine' do
+      expect(Levelcode.auto_route('orbits_pro', trivial)).to eq(Levelcode::FREE_MODEL)
+    end
+
+    it 'routes a large-input turn to the plan default (flagship on paid)' do
+      expect(Levelcode.auto_route('orbits_pro', heavy)).to eq(Levelcode::DEFAULT_MODEL)
+    end
+
+    it 'routes ANY tool/agent turn to the plan default (tools need the strong model)' do
+      expect(Levelcode.auto_route('orbits_pro', with_tools)).to eq(Levelcode::DEFAULT_MODEL)
+    end
+
+    it 'never over-reaches a free plan — both branches land on the open-weights engine' do
+      expect(Levelcode.auto_route('free', trivial)).to eq(Levelcode::FREE_MODEL)
+      expect(Levelcode.auto_route('free', heavy)).to eq(Levelcode::FREE_MODEL)
+      expect(Levelcode.auto_route('free', with_tools)).to eq(Levelcode::FREE_MODEL)
+    end
+
+    it 'tolerates a missing/blank messages array (defaults to the cheap engine)' do
+      expect(Levelcode.auto_route('orbits_pro', {})).to eq(Levelcode::FREE_MODEL)
+      expect(Levelcode.auto_route('orbits_pro', { "messages" => nil })).to eq(Levelcode::FREE_MODEL)
+    end
+
+    # Malformed, CLIENT-CONTROLLED bodies must never 500 the gateway (D56 adversarial review — 4
+    # confirmed crash variants). The transparent proxy does no message-shape validation.
+    it 'never raises on a malformed messages payload (nil/scalar element, bare object)' do
+      expect { Levelcode.auto_route('orbits_pro', { "messages" => [ nil ] }) }.not_to raise_error
+      expect { Levelcode.auto_route('orbits_pro', { "messages" => [ 5 ] }) }.not_to raise_error
+      expect { Levelcode.auto_route('orbits_pro', { "messages" => { "role" => "user", "content" => "hi" } }) }.not_to raise_error
+      expect { Levelcode.auto_route('orbits_pro', { "messages" => "just a string" }) }.not_to raise_error
+      # A trailing null turn appended after a real one → skip the junk, still measure the real content.
+      expect(Levelcode.auto_route('orbits_pro', { "messages" => [ { "role" => "user", "content" => "hi" }, nil ] })).to eq(Levelcode::FREE_MODEL)
+    end
+
+    it 'measures a single bare-object message by its content (routes trivial → cheap)' do
+      expect(Levelcode.auto_route('orbits_pro', { "messages" => { "role" => "user", "content" => "hi" } })).to eq(Levelcode::FREE_MODEL)
+      expect(Levelcode.auto_route('orbits_pro', { "messages" => { "role" => "user", "content" => long_content } })).to eq(Levelcode::DEFAULT_MODEL)
+    end
+
+    it 'routes a multimodal (image) turn to the strong model regardless of text length' do
+      vision = { "messages" => [ { "role" => "user", "content" => [
+        { "type" => "text", "text" => "what is this?" },
+        { "type" => "image_url", "image_url" => { "url" => "data:image/png;base64,AAAA" } }
+      ] } ] }
+      expect(Levelcode.auto_route('orbits_pro', vision)).to eq(Levelcode::DEFAULT_MODEL)
+    end
+
+    it 'measures a text-only multimodal parts array by its text (short → cheap)' do
+      text_parts = { "messages" => [ { "role" => "user", "content" => [ { "type" => "text", "text" => "hi" } ] } ] }
+      expect(Levelcode.auto_route('orbits_pro', text_parts)).to eq(Levelcode::FREE_MODEL)
+    end
+
+    it 'the routed target is always allowed on the plan (never over-reaches entitlement)' do
+      [ trivial, heavy, with_tools ].each do |body|
+        model = Levelcode.auto_route('orbits_pro', body)
+        expect(Levelcode.allowed_models('orbits_pro')).to include(model)
+      end
+    end
+  end
+
+  describe '.rate_table' do
+    it 'uses the SPEC §1.1 per-token micro rates for the default model' do
+      rate = Levelcode.rate_table[Levelcode::DEFAULT_MODEL]
+      expect(rate[:input]).to eq(0.74)
+      expect(rate[:cached_input]).to eq(0.15)
+      expect(rate[:output]).to eq(3.50)
+    end
+
+    it 'prices the free-tier engine (gpt-oss-120b) well below the flagship' do
+      free = Levelcode.rate_table[Levelcode::FREE_MODEL]
+      expect(free[:input]).to eq(0.03)
+      expect(free[:output]).to eq(0.15)
+      expect(free[:input]).to be < Levelcode.rate_table[Levelcode::DEFAULT_MODEL][:input]
+    end
+  end
+
+  describe '.cost_micros' do
+    it 'bills uncached input, cached input, and output at their rates' do
+      # 1M input (all uncached) + 1M output on the default model.
+      # 1_000_000 * 0.74 + 1_000_000 * 3.50 = 4_240_000
+      expect(Levelcode.cost_micros(Levelcode::DEFAULT_MODEL, 1_000_000, 1_000_000, 0))
+        .to eq(4_240_000)
+    end
+
+    it 'bills the cached subset at the cheaper cached rate' do
+      # 1M input of which 600k cached, no output:
+      # 400_000 * 0.74 + 600_000 * 0.15 = 296_000 + 90_000 = 386_000
+      expect(Levelcode.cost_micros(Levelcode::DEFAULT_MODEL, 1_000_000, 0, 600_000))
+        .to eq(386_000)
+    end
+
+    it 'clamps cached tokens to the input count' do
+      # cached > input → treated as fully cached, no negative uncached billing.
+      # 1000 * 0.15 = 150
+      expect(Levelcode.cost_micros(Levelcode::DEFAULT_MODEL, 1_000, 0, 5_000)).to eq(150)
+    end
+
+    it 'falls back to the default model rates for unknown models' do
+      expect(Levelcode.cost_micros('some/unknown-model', 1_000_000, 0, 0)).to eq(740_000)
+    end
+
+    it 'bills the free-tier engine at its own (much cheaper) rate' do
+      # 1M in + 1M out on gpt-oss-120b: 1_000_000 * 0.03 + 1_000_000 * 0.15 = 180_000
+      expect(Levelcode.cost_micros(Levelcode::FREE_MODEL, 1_000_000, 1_000_000, 0))
+        .to eq(180_000)
+    end
+  end
+end

--- a/spec/models/levelcode_plans_spec.rb
+++ b/spec/models/levelcode_plans_spec.rb
@@ -45,9 +45,9 @@ RSpec.describe Levelcode do
     end
 
     it 'a paid plan may use the flagship AND the open-weights engine (confirmed-price roster)' do
-      expect(Levelcode.allowed_models('orbits_pro')).to match_array([ Levelcode::DEFAULT_MODEL, Levelcode::FREE_MODEL ])
-      # Frontier models are entitled but NOT live yet (assumption-priced) — never billed on assumptions.
-      expect(Levelcode.allowed_models('orbits_pro')).not_to include('anthropic/claude-opus-4-8')
+      expect(Levelcode.allowed_models('orbits_pro')).to match_array([ Levelcode::DEFAULT_MODEL, Levelcode::FREE_MODEL, 'anthropic/claude-opus-4-8' ])
+      # A tier-entitled but ASSUMPTION-priced frontier model stays staged — never billed on a guess.
+      expect(Levelcode.allowed_models('orbits_pro')).not_to include('openai/gpt-5.5')
     end
 
     it 'free CANNOT reach the flagship no matter what is requested' do

--- a/spec/models/levelcode_plans_spec.rb
+++ b/spec/models/levelcode_plans_spec.rb
@@ -146,34 +146,36 @@ RSpec.describe Levelcode do
   end
 
   describe '.cost_micros' do
-    it 'bills uncached input, cached input, and output at their rates' do
-      # 1M input (all uncached) + 1M output on the default model.
-      # 1_000_000 * 0.74 + 1_000_000 * 3.50 = 4_240_000
+    # Every charge includes the OpenRouter routing fee (× ROUTING_FEE) so the ledger meters the true
+    # wire cost and the target margin holds. Base list-price figures below, then × 1.055.
+    it 'bills uncached input, cached input, and output at their rates (incl. routing fee)' do
+      # 1M input (all uncached) + 1M output on the default model:
+      # (1_000_000 * 0.74 + 1_000_000 * 3.50) * 1.055 = 4_240_000 * 1.055 = 4_473_200
       expect(Levelcode.cost_micros(Levelcode::DEFAULT_MODEL, 1_000_000, 1_000_000, 0))
-        .to eq(4_240_000)
+        .to eq(4_473_200)
     end
 
-    it 'bills the cached subset at the cheaper cached rate' do
-      # 1M input of which 600k cached, no output:
-      # 400_000 * 0.74 + 600_000 * 0.15 = 296_000 + 90_000 = 386_000
+    it 'bills the cached subset at the cheaper cached rate (incl. routing fee)' do
+      # (400_000 * 0.74 + 600_000 * 0.15) * 1.055 = 386_000 * 1.055 = 407_230
       expect(Levelcode.cost_micros(Levelcode::DEFAULT_MODEL, 1_000_000, 0, 600_000))
-        .to eq(386_000)
+        .to eq(407_230)
     end
 
     it 'clamps cached tokens to the input count' do
-      # cached > input → treated as fully cached, no negative uncached billing.
-      # 1000 * 0.15 = 150
-      expect(Levelcode.cost_micros(Levelcode::DEFAULT_MODEL, 1_000, 0, 5_000)).to eq(150)
+      # cached > input → fully cached: (1000 * 0.15) * 1.055 = 150 * 1.055 = 158.25 → 158
+      expect(Levelcode.cost_micros(Levelcode::DEFAULT_MODEL, 1_000, 0, 5_000)).to eq(158)
     end
 
-    it 'falls back to the default model rates for unknown models' do
-      expect(Levelcode.cost_micros('some/unknown-model', 1_000_000, 0, 0)).to eq(740_000)
+    it 'falls back to the MOST EXPENSIVE confirmed rate for unknown/off-catalog models (never under-bills)' do
+      # An off-catalog id (e.g. a dated snapshot or upstream substitution) must not bill at the cheapest
+      # rate. Conservative fallback = the max confirmed rate (Opus input 5.0): 1M * 5.0 * 1.055 = 5_275_000
+      expect(Levelcode.cost_micros('some/unknown-model', 1_000_000, 0, 0)).to eq(5_275_000)
     end
 
-    it 'bills the free-tier engine at its own (much cheaper) rate' do
-      # 1M in + 1M out on gpt-oss-120b: 1_000_000 * 0.03 + 1_000_000 * 0.15 = 180_000
+    it 'bills the free-tier engine at its own (much cheaper) rate (incl. routing fee)' do
+      # (1M * 0.03 + 1M * 0.15) * 1.055 = 180_000 * 1.055 = 189_900
       expect(Levelcode.cost_micros(Levelcode::FREE_MODEL, 1_000_000, 1_000_000, 0))
-        .to eq(180_000)
+        .to eq(189_900)
     end
   end
 end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -7,6 +7,7 @@
 #  current_period_end   :datetime
 #  current_period_start :datetime
 #  interval             :string
+#  product              :string           default("linkly"), not null
 #  status               :string
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
@@ -17,7 +18,8 @@
 #
 # Indexes
 #
-#  index_subscriptions_on_user_id  (user_id)
+#  index_subscriptions_on_user_id              (user_id)
+#  index_subscriptions_on_user_id_and_product  (user_id,product)
 #
 # Foreign Keys
 #

--- a/spec/models/usage_event_spec.rb
+++ b/spec/models/usage_event_spec.rb
@@ -1,0 +1,64 @@
+# == Schema Information
+#
+# Table name: usage_events
+#
+#  id                  :bigint           not null, primary key
+#  cached_input_tokens :bigint           default(0), not null
+#  cost_micros         :bigint           default(0), not null
+#  input_tokens        :bigint           default(0), not null
+#  model               :string
+#  output_tokens       :bigint           default(0), not null
+#  provider            :string
+#  created_at          :datetime         not null
+#  request_id          :string
+#  user_id             :bigint           not null
+#
+# Indexes
+#
+#  index_usage_events_on_request_id_unique       (request_id) UNIQUE WHERE (request_id IS NOT NULL)
+#  index_usage_events_on_user_id                 (user_id)
+#  index_usage_events_on_user_id_and_created_at  (user_id,created_at)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
+require 'rails_helper'
+
+RSpec.describe UsageEvent, type: :model do
+  let(:user) { create(:user) }
+
+  describe 'associations' do
+    it 'belongs to a user' do
+      assoc = described_class.reflect_on_association(:user)
+      expect(assoc.macro).to eq(:belongs_to)
+    end
+  end
+
+  describe 'validations' do
+    it 'is valid with non-negative token counts' do
+      event = user.usage_events.build(
+        request_id: 'req_1',
+        model: Levelcode::DEFAULT_MODEL,
+        provider: 'openrouter',
+        input_tokens: 40_000,
+        output_tokens: 3_000,
+        cached_input_tokens: 20_000,
+        cost_micros: 123
+      )
+      expect(event).to be_valid
+    end
+
+    it 'rejects negative token counts' do
+      event = user.usage_events.build(input_tokens: -1)
+      expect(event).not_to be_valid
+    end
+  end
+
+  describe '#cost_dollars' do
+    it 'converts micro-dollars to dollars' do
+      event = user.usage_events.build(cost_micros: 1_500_000)
+      expect(event.cost_dollars).to eq(1.5)
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -7,10 +7,13 @@
 #  email                  :string           default(""), not null
 #  encrypted_password     :string           default(""), not null
 #  jti                    :string           not null
+#  last_country           :string
+#  last_seen_at           :datetime
 #  provider               :string
 #  remember_created_at    :datetime
 #  reset_password_sent_at :datetime
 #  reset_password_token   :string
+#  role                   :string           default("member"), not null
 #  terms_accepted         :boolean          default(FALSE), not null
 #  terms_accepted_at      :datetime
 #  terms_accepted_version :string
@@ -23,6 +26,7 @@
 #
 #  index_users_on_email                 (email) UNIQUE
 #  index_users_on_jti                   (jti) UNIQUE
+#  index_users_on_last_seen_at          (last_seen_at)
 #  index_users_on_provider_and_uid      (provider,uid) UNIQUE
 #  index_users_on_reset_password_token  (reset_password_token) UNIQUE
 #

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,6 +1,12 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
+# The OpenRouter adapter resolves its key from ENV *or* Rails credentials at construction time
+# (`OpenRouterAdapter#initialize`). CI has neither (no OPENROUTER_API_KEY, no master key to decrypt
+# credentials), so `.new` would raise before the stubbed HTTP methods run. Every spec stubs the
+# adapter's `stream`/`complete`, so this dummy key is never used for a real request — it only lets
+# construction succeed hermetically. `||=` keeps a real dev key if one is already exported.
+ENV['OPENROUTER_API_KEY'] ||= 'test-openrouter-key'
 require_relative '../config/environment'
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -9,6 +9,7 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 # return unless Rails.env.test?
 require 'rspec/rails'
 require 'support/auth_helpers'
+require 'support/fake_redis'
 require 'sidekiq/testing'
 # Add additional requires below this line. Rails is not loaded until this point!
 

--- a/spec/requests/api/levelcode/v1/account_spec.rb
+++ b/spec/requests/api/levelcode/v1/account_spec.rb
@@ -1,0 +1,150 @@
+require "rails_helper"
+
+RSpec.describe "Api::Levelcode::V1::Account", type: :request do
+  PROFILE_URL = "/api/levelcode/v1/account/profile"
+  USAGE_URL   = "/api/levelcode/v1/account/usage"
+
+  let(:user) { create(:user, stripe_id: "cus_test123") }
+
+  before do
+    allow(Stripe::Customer).to receive(:create).and_return(double(id: "cus_test123"))
+    allow_any_instance_of(Api::Levelcode::V1::BaseController).to receive(:authenticate_levelcode!).and_return(true)
+    allow_any_instance_of(Api::Levelcode::V1::BaseController).to receive(:current_user).and_return(user)
+    allow(user).to receive(:role).and_return("member")
+  end
+
+  describe "GET /api/levelcode/v1/account/activity" do
+    it "returns per-day counts, a per-model breakdown, and totals from the ledger" do
+      UsageEvent.create!(user: user, model: "openai/gpt-oss-120b", provider: "openrouter",
+                         input_tokens: 100, output_tokens: 50, cost_micros: 10, created_at: Time.zone.local(2026, 3, 4, 12))
+      UsageEvent.create!(user: user, model: "moonshotai/kimi-k2.7-code", provider: "openrouter",
+                         input_tokens: 200, output_tokens: 80, cost_micros: 40, created_at: Time.zone.local(2026, 3, 4, 15))
+      UsageEvent.create!(user: user, model: "openai/gpt-oss-120b", provider: "openrouter",
+                         input_tokens: 10, output_tokens: 5, cost_micros: 1, created_at: Time.zone.local(2025, 1, 1, 9)) # other year
+      UsageFeedback.create!(user: user, model: "openai/gpt-oss-120b", rating: "up", created_at: Time.zone.local(2026, 3, 4, 12))
+
+      get "/api/levelcode/v1/account/activity", params: { year: 2026 }
+
+      expect(response).to have_http_status(:ok)
+      body = response.parsed_body
+      expect(body["year"]).to eq(2026)
+      expect(body["total"]).to eq(2)                       # only the two 2026 events
+      expect(body.dig("days", "2026-03-04", "count")).to eq(2)
+      expect(body["days"]).not_to have_key("2025-01-01")   # scoped to the requested year
+      gpt = body["models"].find { |m| m["model"] == "openai/gpt-oss-120b" }
+      expect(gpt["count"]).to eq(1)
+      expect(gpt["up"]).to eq(1)
+      expect(body["years"]).to include(2026, 2025)
+    end
+
+    it "merges a dated model snapshot with feedback recorded against the base model id" do
+      # Metering records the upstream-resolved snapshot; the editor records feedback against the
+      # requested base id. They must aggregate to ONE per-model row (the reported bug).
+      UsageEvent.create!(user: user, model: "moonshotai/kimi-k2.7-code-20260612", provider: "openrouter",
+                         input_tokens: 100, output_tokens: 50, cost_micros: 10, created_at: Time.zone.local(2026, 4, 1, 10))
+      UsageFeedback.create!(user: user, model: "moonshotai/kimi-k2.7-code", rating: "up", created_at: Time.zone.local(2026, 4, 1, 10))
+      UsageFeedback.create!(user: user, model: "moonshotai/kimi-k2.7-code", rating: "down", created_at: Time.zone.local(2026, 4, 1, 11))
+
+      get "/api/levelcode/v1/account/activity", params: { year: 2026 }
+
+      expect(response).to have_http_status(:ok)
+      kimi = response.parsed_body["models"].find { |m| m["model"] == "moonshotai/kimi-k2.7-code" }
+      expect(kimi).to be_present
+      expect(kimi["count"]).to eq(1)  # the dated usage_event
+      expect(kimi["up"]).to eq(1)     # feedback on the base id joins the dated snapshot
+      expect(kimi["down"]).to eq(1)
+    end
+  end
+
+  describe "GET /api/levelcode/v1/account/models" do
+    it "returns the entitled roster with multipliers, turns-left, and a live flag" do
+      CreditWallet.create!(user: user, product: "levelcode", plan_key: "orbits_pro",
+                           input_cap: 15_000_000, output_cap: 2_000_000,
+                           budget_micros: Levelcode.budget_micros("orbits_pro"), spent_micros: 0,
+                           period_start: Time.current, period_end: 1.month.from_now, overage_policy: "throttle")
+      allow(Levelcode::Metering).to receive(:spent_micros).and_return(0)
+
+      get "/api/levelcode/v1/account/models"
+
+      expect(response).to have_http_status(:ok)
+      body = response.parsed_body
+      expect(body["plan"]).to eq("Pro")
+      ids = body["models"].map { |m| m["id"] }
+      expect(ids).to include("openai/gpt-oss-120b", "moonshotai/kimi-k2.7-code", "anthropic/claude-opus-4-8")
+      kimi = body["models"].find { |m| m["id"] == "moonshotai/kimi-k2.7-code" }
+      expect(kimi["live"]).to be(true)
+      expect(kimi["multiplier"]).to eq(1.0)
+      expect(kimi["turns_left"]).to be_within(2).of(375)
+      opus = body["models"].find { |m| m["id"] == "anthropic/claude-opus-4-8" }
+      expect(opus["live"]).to be(false)               # staged — assumption-priced
+      expect(opus["multiplier"]).to be_within(0.05).of(6.67)
+    end
+  end
+
+  describe "GET /api/levelcode/v1/account/profile" do
+    it "returns the SPEC §3 profile shape" do
+      get PROFILE_URL
+
+      expect(response).to have_http_status(:ok)
+      body = response.parsed_body
+      expect(body.keys).to include("id", "email", "name", "plan", "role")
+      expect(body["id"]).to eq(user.id)
+      expect(body["email"]).to eq(user.email)
+      expect(body["role"]).to eq("member")
+    end
+  end
+
+  describe "GET /api/levelcode/v1/account/usage" do
+    context "when the user has a provisioned wallet" do
+      let!(:wallet) do
+        CreditWallet.create!(
+          user: user,
+          product: "levelcode",
+          plan_key: "orbits_pro",
+          input_cap: 15_000_000,
+          output_cap: 2_000_000,
+          budget_micros: Levelcode.budget_micros("orbits_pro"), # M14: the enforced DOLLAR allowance
+          spent_micros: 5_000_000,
+          input_used: 1_234,
+          output_used: 567,
+          period_start: Time.current,
+          period_end: 1.month.from_now,
+          overage_policy: "throttle"
+        )
+      end
+
+      it "returns the plan, dollar budget/spend, and token usage from the CreditWallet" do
+        allow(Levelcode::Metering).to receive(:spent_micros).and_return(5_000_000) # live spend (Redis path stubbed)
+        get USAGE_URL
+
+        expect(response).to have_http_status(:ok)
+        body = response.parsed_body
+        expect(body["plan"]).to eq("Pro") # friendly Levelcode name, not the raw "orbits_pro" key
+        expect(body["budget_micros"]).to eq(Levelcode.budget_micros("orbits_pro"))
+        expect(body["spent_micros"]).to eq(5_000_000)
+        expect(body["credits_remaining_micros"]).to eq(Levelcode.budget_micros("orbits_pro") - 5_000_000)
+        expect(body["input_used"]).to eq(1_234)
+        expect(body["input_cap"]).to eq(15_000_000)
+        expect(body["output_used"]).to eq(567)
+        expect(body["output_cap"]).to eq(2_000_000)
+        expect(body["overage_policy"]).to eq("throttle")
+        expect(body).to have_key("period_end")
+      end
+    end
+
+    context "when the user has no wallet yet (M11 free tier)" do
+      it "provisions the free tier — gpt-oss engine, free caps, hard-cap policy" do
+        get USAGE_URL
+
+        expect(response).to have_http_status(:ok)
+        body = response.parsed_body
+        expect(body["plan"]).to eq("Free")
+        expect(body["model"]).to eq(Levelcode::FREE_MODEL)
+        expect(body["input_used"]).to eq(0)
+        expect(body["input_cap"]).to eq(Levelcode::FREE_INPUT_CAP)
+        expect(body["output_cap"]).to eq(Levelcode::FREE_OUTPUT_CAP)
+        expect(body["overage_policy"]).to eq("stop")
+      end
+    end
+  end
+end

--- a/spec/requests/api/levelcode/v1/account_spec.rb
+++ b/spec/requests/api/levelcode/v1/account_spec.rb
@@ -74,9 +74,9 @@ RSpec.describe "Api::Levelcode::V1::Account", type: :request do
       kimi = body["models"].find { |m| m["id"] == "moonshotai/kimi-k2.7-code" }
       expect(kimi["live"]).to be(true)
       expect(kimi["multiplier"]).to eq(1.0)
-      expect(kimi["turns_left"]).to be_within(2).of(375)
+      expect(kimi["turns_left"]).to be_within(2).of(260)  # $10 budget (50% of $20) ÷ Kimi ref-turn
       opus = body["models"].find { |m| m["id"] == "anthropic/claude-opus-4-8" }
-      expect(opus["live"]).to be(false)               # staged — assumption-priced
+      expect(opus["live"]).to be(true)                # price confirmed → live + billable
       expect(opus["multiplier"]).to be_within(0.05).of(6.67)
     end
   end

--- a/spec/requests/api/levelcode/v1/admin_spec.rb
+++ b/spec/requests/api/levelcode/v1/admin_spec.rb
@@ -1,0 +1,77 @@
+require "rails_helper"
+
+RSpec.describe "Api::Levelcode::V1::Admin", type: :request do
+  let(:admin)  { create(:user, email: "admin@example.com") }
+  let(:member) { create(:user, email: "member@example.com") }
+
+  before do
+    allow(admin).to receive(:role).and_return("admin")
+    allow(admin).to receive(:admin?).and_return(true)
+  end
+
+  def as_user(user)
+    allow_any_instance_of(Api::Levelcode::V1::BaseController).to receive(:authenticate_levelcode!).and_return(true)
+    allow_any_instance_of(Api::Levelcode::V1::BaseController).to receive(:current_levelcode_user).and_return(user)
+    allow_any_instance_of(Api::Levelcode::V1::BaseController).to receive(:current_user).and_return(user)
+  end
+
+  describe "authorization" do
+    it "403s for a non-admin" do
+      as_user(member)
+      get "/api/levelcode/v1/admin/summary"
+      expect(response).to have_http_status(:forbidden)
+      expect(response.parsed_body.dig("error", "code")).to eq("forbidden")
+    end
+  end
+
+  describe "GET /admin/summary + /admin/users (admin)" do
+    before do
+      as_user(admin)
+      # Two users burning tokens; one auth failure.
+      UsageEvent.create!(user: admin, model: "moonshotai/kimi-k2.7-code", provider: "openrouter",
+                         input_tokens: 900, output_tokens: 100, cost_micros: 50, created_at: 1.day.ago)
+      UsageEvent.create!(user: member, model: "openai/gpt-oss-120b", provider: "openrouter",
+                         input_tokens: 50, output_tokens: 10, cost_micros: 1, created_at: 2.days.ago)
+      member.update_columns(last_country: "DE", last_seen_at: 1.hour.ago)
+      AuthEvent.create!(user: member, email: member.email, kind: "login", outcome: "failure",
+                        reason: "invalid_credentials", country: "DE", created_at: 1.hour.ago)
+      CreditWallet.create!(user: admin, product: "levelcode", plan_key: "orbits_pro", input_cap: 15_000_000,
+                           output_cap: 2_000_000, period_start: Time.current, period_end: 1.month.from_now, overage_policy: "throttle")
+    end
+
+    it "summarizes system-wide totals + breakdowns" do
+      get "/api/levelcode/v1/admin/summary"
+
+      expect(response).to have_http_status(:ok)
+      s = response.parsed_body
+      expect(s["input"]).to eq(950)
+      expect(s["output"]).to eq(110)
+      expect(s["requests"]).to eq(2)
+      expect(s["active_users"]).to eq(2)
+      expect(s["auth_failures"]).to eq(1)
+      expect(s["plans"]).to include("Pro" => 1)
+      expect(s["countries"]).to include("DE" => 1)
+    end
+
+    it "returns a per-user roll-up sorted by input tokens (top burner first)" do
+      get "/api/levelcode/v1/admin/users", params: { sort: "input", dir: "desc" }
+
+      expect(response).to have_http_status(:ok)
+      users = response.parsed_body["users"]
+      expect(users.first["email"]).to eq("admin@example.com")
+      expect(users.first["input"]).to eq(900)
+      expect(users.first["plan"]).to eq("Pro")
+      member_row = users.find { |u| u["email"] == "member@example.com" }
+      expect(member_row["country"]).to eq("DE")
+      expect(member_row["auth_failures"]).to eq(1)
+    end
+
+    it "filters by email and by plan" do
+      get "/api/levelcode/v1/admin/users", params: { q: "member" }
+      expect(response.parsed_body["users"].map { |u| u["email"] }).to eq([ "member@example.com" ])
+
+      get "/api/levelcode/v1/admin/users", params: { plan: "Pro" }
+      expect(response.parsed_body["users"].map { |u| u["email"] }).to eq([ "admin@example.com" ])
+    end
+  end
+end

--- a/spec/requests/api/levelcode/v1/ai_spec.rb
+++ b/spec/requests/api/levelcode/v1/ai_spec.rb
@@ -1,0 +1,388 @@
+require 'rails_helper'
+
+# Gateway request spec (SPEC §4/§5/§7). The upstream adapter is stubbed to emit
+# canned SSE chunks so we assert (a) the transparent SSE shape and (b) that the
+# final usage is teed into metering. Cross-slice collaborators owned by the auth
+# and data slices (BaseController#authenticate_levelcode!, current_levelcode_user,
+# CreditWallet.for, Levelcode.cost_micros) are stubbed at their interfaces.
+RSpec.describe "Api::Levelcode::V1::Ai", type: :request do
+  let(:user) { create(:user) }
+
+  # A minimal wallet double matching the CreditWallet interface the controller
+  # and Levelcode::Metering rely on.
+  let(:wallet) do
+    instance_double(
+      "CreditWallet",
+      user_id: user.id,
+      plan_key: "orbits_pro",
+      input_cap: 15_000_000,
+      output_cap: 2_000_000,
+      input_used: 0,
+      output_used: 0,
+      period_start: Time.current.beginning_of_month,
+      period_end: Time.current.end_of_month,
+      overage_policy: "throttle"
+    )
+  end
+
+  let(:canned_chunks) do
+    [
+      '{"choices":[{"index":0,"delta":{"content":"Hel"}}]}',
+      '{"choices":[{"index":0,"delta":{"content":"lo"}}]}',
+      '{"choices":[{"index":0,"delta":{}}],"usage":{"prompt_tokens":12,"completion_tokens":8,"prompt_tokens_details":{"cached_tokens":4}}}'
+    ]
+  end
+
+  let(:final_usage) do
+    { "prompt_tokens" => 12, "completion_tokens" => 8, "prompt_tokens_details" => { "cached_tokens" => 4 } }
+  end
+
+  before do
+    # Auth slice: treat the request as authenticated with a full-scope token.
+    allow_any_instance_of(Api::Levelcode::V1::AiController)
+      .to receive(:authenticate_levelcode!).and_return(true)
+    allow_any_instance_of(Api::Levelcode::V1::AiController)
+      .to receive(:current_levelcode_user).and_return(user)
+    allow_any_instance_of(Api::Levelcode::V1::AiController)
+      .to receive(:levelcode_token_claims).and_return("scope" => "ai:chat ai:agent account:read")
+
+    # Tier resolution (M11): FreeTier returns the paid wallet (this double) for a
+    # paid user, or a free wallet otherwise. Stub it to the paid wallet by default.
+    allow(Levelcode::FreeTier).to receive(:wallet_for).with(user).and_return(wallet)
+
+    # Cost table is a data-slice concern; keep it deterministic here.
+    allow(Levelcode).to receive(:cost_micros).and_return(1_000)
+
+    # Redis hot counters — assert on record without a live Redis.
+    allow(Levelcode::Metering).to receive(:check!).and_call_original
+  end
+
+  def stub_streaming_adapter
+    allow_any_instance_of(Levelcode::OpenRouterAdapter).to receive(:stream) do |_adapter, _body, on_chunk:|
+      canned_chunks.each { |c| on_chunk.call(c) }
+      Levelcode::OpenRouterAdapter::Result.new(usage: final_usage, model: ENV.fetch("LEVELCODE_MODEL", "moonshotai/kimi-k2.6"))
+    end
+  end
+
+  describe "POST /api/levelcode/v1/ai/chat (stream)" do
+    let(:body) do
+      { model: "moonshotai/kimi-k2.6", stream: true, stream_options: { include_usage: true },
+        messages: [ { role: "user", content: "hi" } ] }
+    end
+
+    before do
+      allow(Levelcode::Metering).to receive(:check!)
+        .and_return(Levelcode::Metering::Decision.new(allowed: true, throttle: false, policy: "throttle"))
+      stub_streaming_adapter
+    end
+
+    it "streams upstream chunks verbatim as SSE and terminates with [DONE]" do
+      post "/api/levelcode/v1/ai/chat", params: body, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(response.headers["Content-Type"]).to include("text/event-stream")
+
+      canned_chunks.each do |chunk|
+        expect(response.body).to include("data: #{chunk}\n\n")
+      end
+      expect(response.body).to include("data: [DONE]\n\n")
+    end
+
+    it "tees the final usage into Redis metering (tokens + $ spend) and the durable ledger" do
+      expect(Levelcode::Metering).to receive(:record).with(wallet, 12, 8, 1_000) # 4th arg = cost_micros
+      expect(RecordUsageJob).to receive(:perform_async)
+        .with(user.id, anything, kind_of(String), "openrouter", 12, 8, 4, 1_000, kind_of(Integer))
+
+      post "/api/levelcode/v1/ai/chat", params: body, as: :json
+    end
+  end
+
+  describe "POST /api/levelcode/v1/ai/chat when cap reached" do
+    let(:body) { { model: "moonshotai/kimi-k2.6", stream: true, messages: [] } }
+
+    it "returns 402 cap_reached for a topup wallet" do
+      topup_wallet = instance_double(
+        "CreditWallet", user_id: user.id, plan_key: "orbits_pro", input_cap: 1, output_cap: 1,
+        input_used: 5, output_used: 5, period_start: Time.current, period_end: Time.current,
+        overage_policy: "topup"
+      )
+      allow(Levelcode::FreeTier).to receive(:wallet_for).and_return(topup_wallet)
+      allow(Levelcode::Metering).to receive(:check!)
+        .and_return(Levelcode::Metering::Decision.new(allowed: false, throttle: false, policy: "topup"))
+
+      post "/api/levelcode/v1/ai/chat", params: body, as: :json
+
+      expect(response).to have_http_status(:payment_required)
+      json = JSON.parse(response.body)
+      expect(json.dig("error", "code")).to eq("cap_reached")
+      expect(json.dig("error", "topup_url")).to be_present
+    end
+  end
+
+  describe "scope enforcement (ai:chat vs ai:agent)" do
+    before do
+      allow(Levelcode::Metering).to receive(:check!)
+        .and_return(Levelcode::Metering::Decision.new(allowed: true, throttle: false, policy: "throttle"))
+      stub_streaming_adapter
+    end
+
+    def with_scope(scope)
+      allow_any_instance_of(Api::Levelcode::V1::AiController)
+        .to receive(:levelcode_token_claims).and_return("scope" => scope)
+    end
+
+    it "allows an agent turn (tools present) with ai:agent" do
+      with_scope("ai:chat ai:agent account:read")
+      post "/api/levelcode/v1/ai/chat",
+           params: { model: "x", stream: true, tools: [ { type: "function" } ], messages: [] }, as: :json
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "REJECTS an agent turn with a chat-only token (missing ai:agent)" do
+      with_scope("ai:chat account:read")
+      post "/api/levelcode/v1/ai/chat",
+           params: { model: "x", stream: true, tools: [ { type: "function" } ], messages: [] }, as: :json
+      expect(response).to have_http_status(:forbidden)
+      expect(JSON.parse(response.body).dig("error", "code")).to eq("insufficient_scope")
+    end
+
+    it "allows plain chat with a chat-only token" do
+      with_scope("ai:chat account:read")
+      post "/api/levelcode/v1/ai/chat",
+           params: { model: "x", stream: true, messages: [ { role: "user", content: "hi" } ] }, as: :json
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "REJECTS the gateway for a web-session token (account:read only)" do
+      with_scope("account:read")
+      post "/api/levelcode/v1/ai/chat", params: { model: "x", stream: true, messages: [] }, as: :json
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe "POST /api/levelcode/v1/ai/chat on the FREE tier (M11)" do
+    let(:free_wallet) do
+      instance_double(
+        "CreditWallet", user_id: user.id, plan_key: "free",
+        input_cap: Levelcode::FREE_INPUT_CAP, output_cap: Levelcode::FREE_OUTPUT_CAP,
+        input_used: 0, output_used: 0, period_start: Time.current, period_end: 1.month.from_now,
+        overage_policy: "stop"
+      )
+    end
+
+    before { allow(Levelcode::FreeTier).to receive(:wallet_for).and_return(free_wallet) }
+
+    it "serves gpt-oss-120b (not 402) and FORCES the free engine regardless of the requested model" do
+      allow(Levelcode::Metering).to receive(:check!)
+        .and_return(Levelcode::Metering::Decision.new(allowed: true, throttle: false, policy: "stop"))
+      captured_model = nil
+      allow_any_instance_of(Levelcode::OpenRouterAdapter).to receive(:stream) do |_a, routed, on_chunk:|
+        captured_model = routed["model"]
+        canned_chunks.each { |c| on_chunk.call(c) }
+        Levelcode::OpenRouterAdapter::Result.new(usage: final_usage, model: "openai/gpt-oss-120b")
+      end
+
+      # A free user asking for the flagship must NOT get it.
+      post "/api/levelcode/v1/ai/chat",
+           params: { model: "moonshotai/kimi-k2.7-code", stream: true, messages: [ { role: "user", content: "hi" } ] }, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(captured_model).to eq("openai/gpt-oss-120b")
+    end
+
+    it "clamps free-tier output to FREE_MAX_TOKENS (concurrent-overshoot throttle)" do
+      allow(Levelcode::Metering).to receive(:check!)
+        .and_return(Levelcode::Metering::Decision.new(allowed: true, throttle: false, policy: "stop"))
+      captured = nil
+      allow_any_instance_of(Levelcode::OpenRouterAdapter).to receive(:stream) do |_a, routed, on_chunk:|
+        captured = routed
+        canned_chunks.each { |c| on_chunk.call(c) }
+        Levelcode::OpenRouterAdapter::Result.new(usage: final_usage, model: "openai/gpt-oss-120b")
+      end
+
+      post "/api/levelcode/v1/ai/chat",
+           params: { model: "x", stream: true, max_tokens: 999_999, messages: [ { role: "user", content: "hi" } ] }, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(captured["max_tokens"]).to eq(Levelcode::FREE_MAX_TOKENS)
+    end
+
+    it "402s cap_reached with an upgrade_url when the free monthly cap is hit" do
+      allow(Levelcode::Metering).to receive(:check!)
+        .and_return(Levelcode::Metering::Decision.new(allowed: false, throttle: false, policy: "stop"))
+
+      post "/api/levelcode/v1/ai/chat", params: { model: "x", stream: true, messages: [] }, as: :json
+
+      expect(response).to have_http_status(:payment_required)
+      json = JSON.parse(response.body)
+      expect(json.dig("error", "code")).to eq("cap_reached")
+      expect(json.dig("error", "upgrade_url")).to include("/ai/pricing")
+    end
+  end
+
+  describe "POST /api/levelcode/v1/ai/chat on a PAID plan (may pick either engine)" do
+    # The default before-block stubs FreeTier.wallet_for -> the paid `wallet` (plan_key orbits_pro).
+    before do
+      allow(Levelcode::Metering).to receive(:check!)
+        .and_return(Levelcode::Metering::Decision.new(allowed: true, throttle: false, policy: "throttle"))
+    end
+
+    def capture_routed_model(response_model)
+      captured = nil
+      allow_any_instance_of(Levelcode::OpenRouterAdapter).to receive(:stream) do |_a, routed, on_chunk:|
+        captured = routed["model"]
+        canned_chunks.each { |c| on_chunk.call(c) }
+        Levelcode::OpenRouterAdapter::Result.new(usage: final_usage, model: response_model)
+      end
+      -> { captured }
+    end
+
+    it "HONORS a paid user's request for gpt-oss-120b (not just the flagship)" do
+      captured = capture_routed_model("openai/gpt-oss-120b")
+      post "/api/levelcode/v1/ai/chat",
+           params: { model: "openai/gpt-oss-120b", stream: true, messages: [ { role: "user", content: "hi" } ] }, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(captured.call).to eq("openai/gpt-oss-120b")
+    end
+
+    it "defaults a paid user to the flagship for an un-entitled/unknown requested model" do
+      captured = capture_routed_model("moonshotai/kimi-k2.7-code")
+      post "/api/levelcode/v1/ai/chat",
+           params: { model: "gpt-4o", stream: true, messages: [ { role: "user", content: "hi" } ] }, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(captured.call).to eq("moonshotai/kimi-k2.7-code")
+    end
+
+    it "clamps a PAID request's output to PAID_MAX_TOKENS (per-request overshoot guard)" do
+      captured = nil
+      allow_any_instance_of(Levelcode::OpenRouterAdapter).to receive(:stream) do |_a, routed, on_chunk:|
+        captured = routed["max_tokens"]
+        canned_chunks.each { |c| on_chunk.call(c) }
+        Levelcode::OpenRouterAdapter::Result.new(usage: final_usage, model: "moonshotai/kimi-k2.7-code")
+      end
+
+      post "/api/levelcode/v1/ai/chat",
+           params: { model: "moonshotai/kimi-k2.7-code", stream: true, max_tokens: 999_999, messages: [ { role: "user", content: "hi" } ] }, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(captured).to eq(Levelcode::PAID_MAX_TOKENS)
+    end
+
+    it "routes model=auto — a trivial turn goes to the cheap engine" do
+      captured = capture_routed_model("openai/gpt-oss-120b")
+      post "/api/levelcode/v1/ai/chat",
+           params: { model: "auto", stream: true, messages: [ { role: "user", content: "hi" } ] }, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(captured.call).to eq("openai/gpt-oss-120b")
+    end
+
+    it "routes model=auto — a tool/agent turn goes to the flagship" do
+      captured = capture_routed_model("moonshotai/kimi-k2.7-code")
+      post "/api/levelcode/v1/ai/chat",
+           params: { model: "auto", stream: true, tools: [ { type: "function", function: { name: "read" } } ],
+                     messages: [ { role: "user", content: "refactor this" } ] }, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(captured.call).to eq("moonshotai/kimi-k2.7-code")
+    end
+  end
+
+  describe "POST /api/levelcode/v1/ai/chat (non-stream)" do
+    let(:body) { { model: "moonshotai/kimi-k2.6", stream: false, messages: [ { role: "user", content: "hi" } ] } }
+    let(:upstream_json) { { "id" => "x", "choices" => [ { "message" => { "content" => "Hi" } } ], "usage" => final_usage, "model" => "moonshotai/kimi-k2.6" } }
+
+    it "passes the upstream JSON through and meters" do
+      allow(Levelcode::Metering).to receive(:check!)
+        .and_return(Levelcode::Metering::Decision.new(allowed: true, throttle: false, policy: "throttle"))
+      allow_any_instance_of(Levelcode::OpenRouterAdapter).to receive(:complete).and_return(upstream_json)
+      expect(Levelcode::Metering).to receive(:record).with(wallet, 12, 8, 1_000)
+
+      post "/api/levelcode/v1/ai/chat", params: body, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)).to eq(upstream_json)
+    end
+  end
+end
+
+RSpec.describe Levelcode::Metering do
+  let(:wallet) do
+    instance_double(
+      "CreditWallet", user_id: 42, budget_micros: 1_000_000, spent_micros: 0,
+      period_start: Time.at(0), period_end: Time.at(1000), overage_policy: "throttle"
+    )
+  end
+
+  describe ".check! (M14 — enforces the DOLLAR budget)" do
+    it "allows and does not throttle when under budget" do
+      allow($redis).to receive(:get).and_return("500000") # spent < budget
+      decision = described_class.check!(wallet)
+      expect(decision.allowed).to be(true)
+      expect(decision.throttle).to be(false)
+    end
+
+    it "throttles when over budget under a throttle policy" do
+      allow($redis).to receive(:get).and_return("1200000") # spent >= budget
+      decision = described_class.check!(wallet)
+      expect(decision.allowed).to be(true)
+      expect(decision.throttle).to be(true)
+    end
+
+    it "blocks a zero-budget (no-plan / BYOK) wallet without touching Redis" do
+      decision = described_class.check!(instance_double("CreditWallet", budget_micros: 0))
+      expect(decision.allowed).to be(false)
+    end
+
+    it "degrades gracefully when Redis errors — an UNDER-budget wallet still passes" do
+      allow($redis).to receive(:get).and_raise(StandardError, "down")
+      decision = described_class.check!(wallet) # durable spent_micros 0 → under budget
+      expect(decision.allowed).to be(true)
+    end
+
+    it "on a Redis error falls back to the DURABLE spend and still BLOCKS an over-budget hard-stop wallet" do
+      over = instance_double(
+        "CreditWallet", user_id: 7, budget_micros: 1_000_000, spent_micros: 1_000_000,
+        period_start: Time.at(0), period_end: Time.at(1000), overage_policy: "stop"
+      )
+      allow($redis).to receive(:get).and_raise(StandardError, "down")
+      decision = described_class.check!(over)
+      expect(decision.allowed).to be(false) # durable spent == budget → hard stop survives the outage
+    end
+
+    it "enforces on the MAX of the Redis counter and durable spend — an UNDERCOUNTING Redis can't refund" do
+      over = instance_double(
+        "CreditWallet", user_id: 9, budget_micros: 1_000_000, spent_micros: 1_500_000,
+        period_start: Time.at(0), period_end: Time.at(2000), overage_policy: "stop"
+      )
+      allow($redis).to receive(:get).and_return("100000") # Redis undercounts (outage/eviction/period shift)
+      decision = described_class.check!(over)
+      expect(decision.allowed).to be(false) # max(100k, durable 1.5M) ≥ budget → still blocked
+    end
+
+    it "treats a MISSING Redis key (period re-anchor / eviction → nil) as the durable spend, not zero" do
+      over = instance_double(
+        "CreditWallet", user_id: 10, budget_micros: 1_000_000, spent_micros: 1_200_000,
+        period_start: Time.at(0), period_end: Time.at(3000), overage_policy: "stop"
+      )
+      allow($redis).to receive(:get).and_return(nil) # key miss → would be 0 without the max()
+      decision = described_class.check!(over)
+      expect(decision.allowed).to be(false) # max(0, durable 1.2M) → blocked (no mid-period refund)
+    end
+  end
+
+  describe ".record" do
+    it "increments the in/out token AND the $ spend hot counters" do
+      pipe = double("pipe")
+      expect(pipe).to receive(:incrby).with("levelcode:used:42:1000:in", 12)
+      expect(pipe).to receive(:incrby).with("levelcode:used:42:1000:out", 8)
+      expect(pipe).to receive(:incrby).with("levelcode:used:42:1000:spent", 1_000)
+      allow(pipe).to receive(:expire) # TTL refresh on each write — value asserted elsewhere
+      allow($redis).to receive(:pipelined).and_yield(pipe)
+
+      expect(described_class.record(wallet, 12, 8, 1_000)).to be(true)
+    end
+  end
+end

--- a/spec/requests/api/levelcode/v1/ai_spec.rb
+++ b/spec/requests/api/levelcode/v1/ai_spec.rb
@@ -53,8 +53,13 @@ RSpec.describe "Api::Levelcode::V1::Ai", type: :request do
     # Cost table is a data-slice concern; keep it deterministic here.
     allow(Levelcode).to receive(:cost_micros).and_return(1_000)
 
-    # Redis hot counters — assert on record without a live Redis.
+    # Redis hot counters — assert on settle without a live Redis.
     allow(Levelcode::Metering).to receive(:check!).and_call_original
+    # Admission reservation + settlement touch Redis + wallet.budget_micros; stub them so the request
+    # specs exercise routing/metering without a live Redis (individual specs override settle! to assert).
+    allow(Levelcode::Metering).to receive(:reserve!)
+      .and_return(Levelcode::Metering::Reservation.new(ok: true, amount: 0))
+    allow(Levelcode::Metering).to receive(:settle!).and_return(true)
   end
 
   def stub_streaming_adapter
@@ -88,8 +93,9 @@ RSpec.describe "Api::Levelcode::V1::Ai", type: :request do
       expect(response.body).to include("data: [DONE]\n\n")
     end
 
-    it "tees the final usage into Redis metering (tokens + $ spend) and the durable ledger" do
-      expect(Levelcode::Metering).to receive(:record).with(wallet, 12, 8, 1_000) # 4th arg = cost_micros
+    it "settles the reservation to the final usage (tokens + $ spend) and writes the durable ledger" do
+      # reservation amount 0 (stubbed) → settle! reconciles to the actual cost_micros (1_000).
+      expect(Levelcode::Metering).to receive(:settle!).with(wallet, 0, 12, 8, 1_000)
       expect(RecordUsageJob).to receive(:perform_async)
         .with(user.id, anything, kind_of(String), "openrouter", 12, 8, 4, 1_000, kind_of(Integer))
 
@@ -298,7 +304,7 @@ RSpec.describe "Api::Levelcode::V1::Ai", type: :request do
       allow(Levelcode::Metering).to receive(:check!)
         .and_return(Levelcode::Metering::Decision.new(allowed: true, throttle: false, policy: "throttle"))
       allow_any_instance_of(Levelcode::OpenRouterAdapter).to receive(:complete).and_return(upstream_json)
-      expect(Levelcode::Metering).to receive(:record).with(wallet, 12, 8, 1_000)
+      expect(Levelcode::Metering).to receive(:settle!).with(wallet, 0, 12, 8, 1_000)
 
       post "/api/levelcode/v1/ai/chat", params: body, as: :json
 
@@ -383,6 +389,81 @@ RSpec.describe Levelcode::Metering do
       allow($redis).to receive(:pipelined).and_yield(pipe)
 
       expect(described_class.record(wallet, 12, 8, 1_000)).to be(true)
+    end
+  end
+
+  # Admission-time budget reservation (M14 concurrency guard). Real FakeRedis so the atomic
+  # INCRBY/roll-back and settle reconciliation actually run.
+  describe ".reserve! / .settle! / .clear!" do
+    around { |ex| with_fake_redis { ex.run } }
+    let(:spent_key) { "levelcode:used:42:1000:spent" }
+
+    it "reserves within budget and leaves the reservation on the hot spend counter" do
+      res = described_class.reserve!(wallet, 300_000)
+      expect(res.ok).to be(true)
+      expect(res.amount).to eq(300_000)
+      expect($redis.get(spent_key).to_i).to eq(300_000)
+    end
+
+    it "REJECTS and rolls back a reservation that would exceed the budget (concurrent overshoot guard)" do
+      $redis.set(spent_key, 900_000)                    # another in-flight request already reserved
+      res = described_class.reserve!(wallet, 200_000)   # 900k + 200k = 1.1M > 1M budget
+      expect(res.ok).to be(false)
+      expect(res.amount).to eq(0)
+      expect($redis.get(spent_key).to_i).to eq(900_000) # rolled back — no strand
+    end
+
+    it "reserves nothing (ok) for a non-positive estimate" do
+      res = described_class.reserve!(wallet, 0)
+      expect(res.ok).to be(true)
+      expect(res.amount).to eq(0)
+      expect($redis.get(spent_key)).to be_nil
+    end
+
+    it "fails OPEN (allows, no reservation) when Redis errors" do
+      allow($redis).to receive(:incrby).and_raise(StandardError, "down")
+      res = described_class.reserve!(wallet, 300_000)
+      expect(res.ok).to be(true)
+      expect(res.amount).to eq(0)
+    end
+
+    it "settles a reservation DOWN to the real cost (reserved 300k, actual 100k → counter 100k)" do
+      described_class.reserve!(wallet, 300_000)
+      described_class.settle!(wallet, 300_000, 12, 8, 100_000)
+      expect($redis.get(spent_key).to_i).to eq(100_000)
+      expect($redis.get("levelcode:used:42:1000:in").to_i).to eq(12)
+      expect($redis.get("levelcode:used:42:1000:out").to_i).to eq(8)
+    end
+
+    it "settles with NO reservation by adding the actual spend (throttle/fail-open path)" do
+      described_class.settle!(wallet, 0, 5, 5, 50_000)
+      expect($redis.get(spent_key).to_i).to eq(50_000)
+    end
+
+    it "RELEASES a reservation on a failed turn (reserved 300k, actual 0 → counter 0)" do
+      described_class.reserve!(wallet, 300_000)
+      described_class.settle!(wallet, 300_000, 0, 0, 0)
+      expect($redis.get(spent_key).to_i).to eq(0)
+    end
+
+    it "clear! wipes the period's hot counters so a same-epoch reset can't resurrect spend" do
+      $redis.set(spent_key, 500_000)
+      $redis.set("levelcode:used:42:1000:in", 10)
+      described_class.clear!(wallet)
+      expect($redis.get(spent_key)).to be_nil
+      expect($redis.get("levelcode:used:42:1000:in")).to be_nil
+    end
+
+    it "FLOORS the counter at 0 when a mid-flight reset wiped the reservation (no negative under-count)" do
+      described_class.reserve!(wallet, 300_000)              # counter 300k
+      described_class.clear!(wallet)                         # a same-epoch reset wipes it → absent (0)
+      described_class.settle!(wallet, 300_000, 0, 0, 100_000) # delta -200k applied to a 0 key
+      expect($redis.get(spent_key).to_i).to eq(0)           # floored, not -200_000
+    end
+
+    it "spent_micros floors a negative hot counter so it can't suppress enforcement below durable" do
+      $redis.set(spent_key, -50_000)                        # a stranded-negative counter
+      expect(described_class.spent_micros(wallet)).to eq(0) # max(max(-50k, 0), durable 0) = 0, not -50k
     end
   end
 end

--- a/spec/requests/api/levelcode/v1/auth_spec.rb
+++ b/spec/requests/api/levelcode/v1/auth_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'Api::Levelcode::V1::Auth', type: :request do
 
   let(:password) { 'password123' }
   let!(:user) { create(:user, email: 'editor@example.com', password: password) }
-  let(:redirect_uri) { 'atom-plus-plus://levelcode.atom-ai/auth/callback' }
+  let(:redirect_uri) { 'levelcode://levelcode.levelcode-ai/auth/callback' }
 
   def json
     JSON.parse(response.body)
@@ -50,7 +50,7 @@ RSpec.describe 'Api::Levelcode::V1::Auth', type: :request do
 
         expect(response).to have_http_status(:found)
         location = URI.parse(response.headers['Location'])
-        expect(location.scheme).to eq('atom-plus-plus')
+        expect(location.scheme).to eq('levelcode')
         expect(Rack::Utils.parse_query(location.query)['code']).to be_present
       end
     end

--- a/spec/requests/api/levelcode/v1/auth_spec.rb
+++ b/spec/requests/api/levelcode/v1/auth_spec.rb
@@ -1,0 +1,280 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::Levelcode::V1::Auth', type: :request do
+  # The editor tokens are signed with a dedicated secret; set it for the suite.
+  around do |example|
+    prev = ENV['LEVELCODE_JWT_SECRET']
+    ENV['LEVELCODE_JWT_SECRET'] = 'test-levelcode-secret'
+    example.run
+  ensure
+    ENV['LEVELCODE_JWT_SECRET'] = prev
+  end
+
+  # One-time codes and the jti revocation denylist live in Redis, which the app
+  # skips in test — give these specs an in-memory stand-in with real single-use
+  # + set semantics.
+  around { |example| with_fake_redis { example.run } }
+
+  before do
+    # The OAuth callback + one-time-code exchange create users through the
+    # controller (not the factory), firing the real create_stripe_customer
+    # callback — stub Stripe so these specs stay hermetic.
+    allow(Stripe::Customer).to receive(:create).and_return(Stripe::Customer.construct_from(id: 'cus_test'))
+    allow(Stripe::Customer).to receive(:retrieve).and_return(Stripe::Customer.construct_from(id: 'cus_test'))
+  end
+
+  let(:password) { 'password123' }
+  let!(:user) { create(:user, email: 'editor@example.com', password: password) }
+  let(:redirect_uri) { 'atom-plus-plus://levelcode.atom-ai/auth/callback' }
+
+  def json
+    JSON.parse(response.body)
+  end
+
+  describe 'POST /api/levelcode/v1/auth/login' do
+    context 'with valid credentials and no redirect_uri (JSON)' do
+      it 'returns access, refresh and profile' do
+        post '/api/levelcode/v1/auth/login', params: { email: user.email, password: password }, as: :json
+
+        expect(response).to have_http_status(:ok)
+        expect(json['access']).to be_present
+        expect(json['refresh']).to be_present
+        expect(json.dig('profile', 'email')).to eq(user.email)
+      end
+    end
+
+    context 'with a redirect_uri (browser, hardened code flow)' do
+      it '302s to the callback carrying a one-time code' do
+        post '/api/levelcode/v1/auth/login',
+             params: { email: user.email, password: password, redirect_uri: redirect_uri, code_challenge: 'chal' }
+
+        expect(response).to have_http_status(:found)
+        location = URI.parse(response.headers['Location'])
+        expect(location.scheme).to eq('atom-plus-plus')
+        expect(Rack::Utils.parse_query(location.query)['code']).to be_present
+      end
+    end
+
+    context 'even when token_fallback is requested (now removed for security)' do
+      it 'still returns a one-time code and never raw tokens in the redirect URL' do
+        post '/api/levelcode/v1/auth/login',
+             params: { email: user.email, password: password, redirect_uri: redirect_uri, token_fallback: '1' }
+
+        expect(response).to have_http_status(:found)
+        q = Rack::Utils.parse_query(URI.parse(response.headers['Location']).query)
+        expect(q['code']).to be_present
+        expect(q['token']).to be_nil
+        expect(q['refresh']).to be_nil
+      end
+    end
+
+    it 'rejects bad credentials' do
+      post '/api/levelcode/v1/auth/login', params: { email: user.email, password: 'wrong' }, as: :json
+
+      expect(response).to have_http_status(:unauthorized)
+      expect(json.dig('error', 'code')).to eq('invalid_credentials')
+    end
+
+    it 'refuses a non-https/non-editor redirect_uri (no open redirect)' do
+      post '/api/levelcode/v1/auth/login',
+           params: { email: user.email, password: password, redirect_uri: 'http://evil.example.com' }
+
+      # Falls back to JSON rather than redirecting to an untrusted host.
+      expect(response).to have_http_status(:ok)
+      expect(json['access']).to be_present
+    end
+  end
+
+  describe 'POST /api/levelcode/v1/auth/signup' do
+    it 'creates a user and returns tokens' do
+      expect {
+        post '/api/levelcode/v1/auth/signup',
+             params: { email: 'new@example.com', password: password, terms: true }, as: :json
+      }.to change(User, :count).by(1)
+
+      expect(response).to have_http_status(:ok)
+      expect(json['access']).to be_present
+    end
+
+    it 'rejects signup without accepted terms' do
+      post '/api/levelcode/v1/auth/signup',
+           params: { email: 'noterms@example.com', password: password, terms: false }, as: :json
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(json.dig('error', 'code')).to eq('signup_failed')
+    end
+  end
+
+  describe 'POST /api/levelcode/v1/auth/exchange (PKCE)' do
+    let(:verifier) { 'a' * 64 }
+    let(:challenge) do
+      digest = Digest::SHA256.digest(verifier)
+      Base64.urlsafe_encode64(digest, padding: false)
+    end
+
+    it 'redeems a valid code+verifier for tokens' do
+      code = Levelcode::OneTimeCode.issue(user, challenge)
+
+      post '/api/levelcode/v1/auth/exchange', params: { code: code, verifier: verifier }, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(json['access']).to be_present
+      expect(json['refresh']).to be_present
+      expect(json.dig('profile', 'email')).to eq(user.email)
+    end
+
+    it 'rejects a wrong verifier' do
+      code = Levelcode::OneTimeCode.issue(user, challenge)
+
+      post '/api/levelcode/v1/auth/exchange', params: { code: code, verifier: 'wrong' }, as: :json
+
+      expect(response).to have_http_status(:unauthorized)
+      expect(json.dig('error', 'code')).to eq('invalid_verifier')
+    end
+
+    it 'rejects an unknown code' do
+      post '/api/levelcode/v1/auth/exchange', params: { code: 'nope', verifier: verifier }, as: :json
+
+      expect(response).to have_http_status(:unauthorized)
+      expect(json.dig('error', 'code')).to eq('invalid_code')
+    end
+
+    it 'is single-use' do
+      code = Levelcode::OneTimeCode.issue(user, challenge)
+      post '/api/levelcode/v1/auth/exchange', params: { code: code, verifier: verifier }, as: :json
+      post '/api/levelcode/v1/auth/exchange', params: { code: code, verifier: verifier }, as: :json
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  describe 'POST /api/levelcode/v1/auth/refresh' do
+    it 'mints a new access token from a refresh token' do
+      refresh = Levelcode::EditorToken.mint_refresh(user)
+
+      post '/api/levelcode/v1/auth/refresh', params: { refresh: refresh }, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(json['access']).to be_present
+    end
+
+    it 'rejects an access token used as a refresh token (wrong scope)' do
+      access = Levelcode::EditorToken.mint_access(user)
+
+      post '/api/levelcode/v1/auth/refresh', params: { refresh: access }, as: :json
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  describe 'POST /api/levelcode/v1/auth/signout' do
+    it 'revokes the presented token jti' do
+      access = Levelcode::EditorToken.mint_access(user)
+
+      post '/api/levelcode/v1/auth/signout', headers: { 'Authorization' => "Bearer #{access}" }, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(json['ok']).to eq(true)
+
+      # The revoked token must now fail verification.
+      expect {
+        Levelcode::EditorToken.verify(access, scope: 'account:read')
+      }.to raise_error(Levelcode::EditorToken::InvalidToken)
+    end
+
+    it 'requires authentication' do
+      post '/api/levelcode/v1/auth/signout', as: :json
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  describe 'POST /api/levelcode/v1/auth/web_handoff' do
+    it 'mints a one-time browser sign-in URL that redeems to the same user' do
+      access = Levelcode::EditorToken.mint_access(user)
+
+      post '/api/levelcode/v1/auth/web_handoff', headers: { 'Authorization' => "Bearer #{access}" }, as: :json
+
+      expect(response).to have_http_status(:ok)
+      uri = URI.parse(json['url'])
+      expect(uri.path).to eq('/ai/auth/handoff')
+      code = Rack::Utils.parse_query(uri.query)['code']
+      expect(code).to be_present
+      # Single-use code, bound to this user (no PKCE — issued to an already-authed editor).
+      expect(Levelcode::OneTimeCode.redeem(code)).to eq(user)
+    end
+
+    it 'requires a valid editor token' do
+      post '/api/levelcode/v1/auth/web_handoff', as: :json
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  # The public GET /auth/oauth was removed (unhardened token-minting redirect).
+  # The site (levelcode.ai) performs the provider `authorize` step and calls this
+  # service-token-authed mint endpoint with the provider `code`.
+  describe 'POST /api/levelcode/v1/auth/callback (site -> backend mint)' do
+    let(:svc) { 'test-service-token' }
+    before { ENV['LEVELCODE_SITE_SERVICE_TOKEN'] = svc }
+    after { ENV.delete('LEVELCODE_SITE_SERVICE_TOKEN') }
+
+    it 'rejects a missing / invalid service token (403)' do
+      post '/api/levelcode/v1/auth/callback', params: { provider: 'github', code: 'gh_code', mode: 'web' }
+      expect(response).to have_http_status(:forbidden)
+      expect(json.dig('error', 'code')).to eq('forbidden')
+    end
+
+    context 'github (server-side code exchange stubbed)' do
+      before do
+        token_res = instance_double(Net::HTTPOK, body: { access_token: 'gh_tok' }.to_json)
+        allow(token_res).to receive(:is_a?).with(Net::HTTPSuccess).and_return(true)
+        user_res = instance_double(Net::HTTPOK, body: { id: 42, login: 'octocat', name: 'Octo Cat', email: nil }.to_json)
+        allow(user_res).to receive(:is_a?).with(Net::HTTPSuccess).and_return(true)
+        emails_res = instance_double(Net::HTTPOK, body: [ { email: 'octo@example.com', primary: true, verified: true } ].to_json)
+        allow(emails_res).to receive(:is_a?).with(Net::HTTPSuccess).and_return(true)
+        http = instance_double(Net::HTTP)
+        allow(Net::HTTP).to receive(:new).and_return(http)
+        allow(http).to receive(:use_ssl=)
+        allow(http).to receive(:request) do |req|
+          case req.path
+          when '/login/oauth/access_token' then token_res
+          when '/user/emails' then emails_res
+          else user_res
+          end
+        end
+      end
+
+      it 'web mode: exchanges the code, creates the user, returns a web SESSION + profile (not the gateway access token)' do
+        expect {
+          post '/api/levelcode/v1/auth/callback',
+               params: { provider: 'github', code: 'gh_code', redirect_uri: 'https://levelcode.ai/auth/callback', mode: 'web' },
+               headers: { 'X-Levelcode-Service-Token' => svc }
+        }.to change(User, :count).by(1)
+
+        expect(response).to have_http_status(:ok)
+        expect(json['session']).to be_present
+        # Security: web sign-in must NOT hand out the editor's ai:* access token.
+        expect(json['access']).to be_nil
+        expect(json.dig('profile', 'email')).to eq('octo@example.com')
+      end
+
+      it 'editor mode: returns a one-time code, not tokens' do
+        allow(Levelcode::OneTimeCode).to receive(:issue).and_return('one-time-code')
+
+        post '/api/levelcode/v1/auth/callback',
+             params: { provider: 'github', code: 'gh_code', mode: 'editor' },
+             headers: { 'X-Levelcode-Service-Token' => svc }
+
+        expect(response).to have_http_status(:ok)
+        expect(json['code']).to eq('one-time-code')
+        expect(json['access']).to be_nil
+      end
+    end
+
+    it 'rejects an unknown provider' do
+      post '/api/levelcode/v1/auth/callback',
+           params: { provider: 'myspace' },
+           headers: { 'X-Levelcode-Service-Token' => svc }
+      expect(response).to have_http_status(:bad_request)
+    end
+  end
+end

--- a/spec/requests/api/levelcode/v1/billings_spec.rb
+++ b/spec/requests/api/levelcode/v1/billings_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+RSpec.describe "Api::Levelcode::V1::Billings", type: :request do
+  BILLINGS_URL = "/api/levelcode/v1/billings"
+
+  let(:user) { create(:user, stripe_id: "cus_test123") }
+  let(:portal_session) { double(url: "https://billing.stripe.com/session/test_abc123") }
+
+  before do
+    allow(Stripe::Customer).to receive(:create).and_return(double(id: "cus_test123"))
+    allow_any_instance_of(Api::Levelcode::V1::BaseController).to receive(:authenticate_levelcode!).and_return(true)
+    allow_any_instance_of(Api::Levelcode::V1::BaseController).to receive(:current_user).and_return(user)
+  end
+
+  describe "POST /api/levelcode/v1/billings" do
+    it "creates a Stripe billing portal session and returns the URL" do
+      allow(Stripe::BillingPortal::Session).to receive(:create).and_return(portal_session)
+
+      post BILLINGS_URL
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["url"]).to eq("https://billing.stripe.com/session/test_abc123")
+    end
+
+    it "passes the user's stripe_id and returns to SITE_ORIGIN/account" do
+      allow(Stripe::BillingPortal::Session).to receive(:create).and_return(portal_session)
+
+      post BILLINGS_URL
+
+      expect(Stripe::BillingPortal::Session).to have_received(:create).with(
+        hash_including(customer: user.stripe_id, return_url: a_string_matching(%r{/account\z}))
+      )
+    end
+
+    it "returns 400 when Stripe raises an error" do
+      allow(Stripe::BillingPortal::Session).to receive(:create)
+        .and_raise(Stripe::StripeError.new("No such customer"))
+
+      post BILLINGS_URL
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body.dig("error", "message")).to include("No such customer")
+    end
+  end
+end

--- a/spec/requests/api/levelcode/v1/checkouts_spec.rb
+++ b/spec/requests/api/levelcode/v1/checkouts_spec.rb
@@ -1,0 +1,158 @@
+require "rails_helper"
+
+# rubocop:disable Metrics/BlockLength
+RSpec.describe "Api::Levelcode::V1::Checkouts", type: :request do
+  let(:checkout_url) { "/api/levelcode/v1/checkouts" }
+
+  let(:stripe_customer_id) { "cus_test123" }
+  let(:user) { create(:user, stripe_id: stripe_customer_id) }
+  let(:subscription) { user.subscriptions.find_by(product: "levelcode") || user.subscriptions.first! }
+
+  let(:pro_price_id)      { "price_orbits_pro" }
+  let(:pro_plus_price_id) { "price_orbits_pro_plus" }
+
+  let(:pro_price) do
+    double("Stripe::Price", id: pro_price_id, unit_amount: 2000, lookup_key: "orbits_pro")
+  end
+
+  let(:pro_plus_price) do
+    double("Stripe::Price", id: pro_plus_price_id, unit_amount: 4000, lookup_key: "orbits_pro_plus")
+  end
+
+  before do
+    allow(Stripe::Customer).to receive(:create).and_return(double(id: stripe_customer_id))
+    # Auth (BaseController#authenticate_levelcode!) is owned by the auth slice;
+    # stub it here so this slice's specs stay isolated.
+    allow_any_instance_of(Api::Levelcode::V1::BaseController).to receive(:authenticate_levelcode!).and_return(true)
+    allow_any_instance_of(Api::Levelcode::V1::BaseController).to receive(:current_user).and_return(user)
+  end
+
+  # ─── Helpers ──────────────────────────────────────────────────────────────
+
+  def stub_price_list(price)
+    allow(Stripe::Price).to receive(:list).and_return(double("price_list", data: [ price ]))
+  end
+
+  def stub_price_list_empty
+    allow(Stripe::Price).to receive(:list).and_return(double("price_list", data: []))
+  end
+
+  # ─── Tests ────────────────────────────────────────────────────────────────
+
+  describe "POST /api/levelcode/v1/checkouts" do
+    context "when the lookup key resolves no price" do
+      before { stub_price_list_empty }
+
+      it "returns 404 with the SPEC error shape" do
+        post checkout_url, params: { lookup_key: "nope" }
+        expect(response).to have_http_status(:not_found)
+        expect(response.parsed_body.dig("error", "code")).to eq("plan_not_found")
+      end
+    end
+
+    # ── First-time purchase ──────────────────────────────────────────────────
+    context "when the user has no active levelcode subscription" do
+      let(:checkout_session) { double("Stripe::Checkout::Session", url: "https://checkout.stripe.com/session123") }
+
+      before do
+        stub_price_list(pro_price)
+        allow(user).to receive(:subscriptions).and_return(
+          double("subs", find_by: nil)
+        )
+        allow(Stripe::Checkout::Session).to receive(:create).and_return(checkout_session)
+      end
+
+      it "creates a checkout session and returns the URL" do
+        post checkout_url, params: { lookup_key: "orbits_pro" }
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body["url"]).to eq("https://checkout.stripe.com/session123")
+      end
+
+      it "points success/cancel at SITE_ORIGIN/account" do
+        expect(Stripe::Checkout::Session).to receive(:create).with(
+          hash_including(
+            customer: stripe_customer_id,
+            mode: "subscription",
+            client_reference_id: user.id,
+            success_url: a_string_matching(%r{/account\?checkout=success}),
+            cancel_url: a_string_matching(%r{/account\?checkout=cancel})
+          )
+        ).and_return(checkout_session)
+
+        post checkout_url, params: { lookup_key: "orbits_pro" }
+      end
+    end
+
+    # ── Upgrade ──────────────────────────────────────────────────────────────
+    context "when the user upgrades to a pricier plan" do
+      let(:existing_sub) do
+        double("Subscription", subscription_id: "sub_existing", status: "active")
+      end
+      let(:stripe_sub) do
+        current_price = double("current_price", id: pro_price_id, unit_amount: 2000)
+        item = double("item", price: current_price, id: "si_item123")
+        double("Stripe::Subscription", id: "sub_existing", items: double("items", data: [ item ]), status: "active")
+      end
+
+      before do
+        stub_price_list(pro_plus_price)
+        allow(user).to receive(:subscriptions).and_return(double("subs", find_by: existing_sub))
+        allow(Stripe::Subscription).to receive(:retrieve).with("sub_existing").and_return(stripe_sub)
+        allow(Stripe::Subscription).to receive(:update).and_return(double("updated"))
+      end
+
+      it "prorates immediately and reports an upgrade" do
+        expect(Stripe::Subscription).to receive(:update).with(
+          "sub_existing",
+          hash_including(proration_behavior: "create_prorations", items: [ hash_including(price: pro_plus_price_id) ])
+        ).and_return(double("updated"))
+
+        post checkout_url, params: { lookup_key: "orbits_pro_plus" }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body["change_type"]).to eq("upgraded")
+      end
+    end
+
+    # ── Same-plan blocked ────────────────────────────────────────────────────
+    context "when the user re-buys the same plan" do
+      let(:existing_sub) do
+        double("Subscription", subscription_id: "sub_existing", status: "active")
+      end
+      let(:stripe_sub) do
+        current_price = double("current_price", id: pro_price_id, unit_amount: 2000)
+        item = double("item", price: current_price, id: "si_item123")
+        double("Stripe::Subscription", id: "sub_existing", items: double("items", data: [ item ]), status: "active")
+      end
+
+      before do
+        stub_price_list(pro_price)
+        allow(user).to receive(:subscriptions).and_return(double("subs", find_by: existing_sub))
+        allow(Stripe::Subscription).to receive(:retrieve).with("sub_existing").and_return(stripe_sub)
+      end
+
+      it "returns 422" do
+        post checkout_url, params: { lookup_key: "orbits_pro" }
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response.parsed_body.dig("error", "code")).to eq("already_subscribed")
+      end
+    end
+
+    # ── Stripe error ─────────────────────────────────────────────────────────
+    context "when Stripe raises" do
+      before do
+        stub_price_list(pro_price)
+        allow(user).to receive(:subscriptions).and_return(double("subs", find_by: nil))
+        allow(Stripe::Checkout::Session).to receive(:create)
+          .and_raise(Stripe::InvalidRequestError.new("Invalid price", "price"))
+      end
+
+      it "returns 400 with the error message" do
+        post checkout_url, params: { lookup_key: "orbits_pro" }
+        expect(response).to have_http_status(:bad_request)
+        expect(response.parsed_body.dig("error", "message")).to include("Invalid price")
+      end
+    end
+  end
+end
+# rubocop:enable Metrics/BlockLength

--- a/spec/requests/api/levelcode/v1/email_otp_spec.rb
+++ b/spec/requests/api/levelcode/v1/email_otp_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Passwordless email + one-time-code sign-in (Levelcode::EmailCode). Redis/mailer are
+# stubbed so the spec is hermetic; the OTP store itself is unit-tested separately.
+RSpec.describe "Api::Levelcode::V1 email OTP auth", type: :request do
+  let(:svc) { "test-service-token" }
+  let(:svc_headers) { { "X-Levelcode-Service-Token" => svc } }
+
+  before do
+    ENV["LEVELCODE_JWT_SECRET"] = "test-secret"
+    ENV["LEVELCODE_SITE_SERVICE_TOKEN"] = svc
+    # Verifying an OTP creates the user through the controller (not the factory),
+    # so the real create_stripe_customer callback fires — stub Stripe to stay hermetic.
+    allow(Stripe::Customer).to receive(:create).and_return(Stripe::Customer.construct_from(id: "cus_test"))
+    allow(Stripe::Customer).to receive(:retrieve).and_return(Stripe::Customer.construct_from(id: "cus_test"))
+  end
+
+  after do
+    ENV.delete("LEVELCODE_SITE_SERVICE_TOKEN")
+    ENV.delete("LEVELCODE_JWT_SECRET")
+  end
+
+  def json
+    response.parsed_body
+  end
+
+  describe "POST /api/levelcode/v1/auth/email/request" do
+    it "rejects a missing service token (403)" do
+      post "/api/levelcode/v1/auth/email/request", params: { email: "a@b.com" }
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "422s an invalid email" do
+      post "/api/levelcode/v1/auth/email/request", params: { email: "not-an-email" }, headers: svc_headers
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(json.dig("error", "code")).to eq("invalid_email")
+    end
+
+    it "issues a code and emails it (email normalized)" do
+      mail = instance_double(ActionMailer::MessageDelivery, deliver_now: true)
+      allow(Levelcode::EmailCode).to receive(:issue).with("user@example.com").and_return("123456")
+      allow(LevelcodeAuthMailer).to receive(:login_code).with("user@example.com", "123456").and_return(mail)
+
+      post "/api/levelcode/v1/auth/email/request", params: { email: "User@Example.com" }, headers: svc_headers
+
+      expect(response).to have_http_status(:ok)
+      expect(json["sent"]).to be(true)
+      expect(LevelcodeAuthMailer).to have_received(:login_code).with("user@example.com", "123456")
+    end
+
+    it "still 200s (sent:true) when the resend is throttled" do
+      allow(Levelcode::EmailCode).to receive(:issue).and_raise(Levelcode::EmailCode::RateLimited)
+      post "/api/levelcode/v1/auth/email/request", params: { email: "u@e.com" }, headers: svc_headers
+      expect(response).to have_http_status(:ok)
+      expect(json["sent"]).to be(true)
+    end
+  end
+
+  describe "POST /api/levelcode/v1/auth/email/verify" do
+    it "rejects an invalid / expired code (401)" do
+      allow(Levelcode::EmailCode).to receive(:verify).and_return(false)
+      post "/api/levelcode/v1/auth/email/verify", params: { email: "u@e.com", code: "000000" }, headers: svc_headers
+      expect(response).to have_http_status(:unauthorized)
+      expect(json.dig("error", "code")).to eq("invalid_code")
+    end
+
+    context "with a valid code" do
+      before { allow(Levelcode::EmailCode).to receive(:verify).and_return(true) }
+
+      it "web mode: creates the user and returns a web SESSION + profile (never the gateway access token)" do
+        expect {
+          post "/api/levelcode/v1/auth/email/verify",
+               params: { email: "new@example.com", code: "123456", mode: "web" }, headers: svc_headers
+        }.to change(User, :count).by(1)
+
+        expect(response).to have_http_status(:ok)
+        expect(json["session"]).to be_present
+        # Security: the web cookie session must NOT carry the editor's ai:* access token.
+        expect(json["access"]).to be_nil
+        expect(json.dig("profile", "email")).to eq("new@example.com")
+      end
+
+      it "editor mode: returns a one-time code, not tokens" do
+        allow(Levelcode::OneTimeCode).to receive(:issue).and_return("one-time")
+        post "/api/levelcode/v1/auth/email/verify",
+             params: { email: "e@example.com", code: "123456", mode: "editor" }, headers: svc_headers
+
+        expect(response).to have_http_status(:ok)
+        expect(json["code"]).to eq("one-time")
+        expect(json["access"]).to be_nil
+      end
+
+      it "reuses an existing user (no duplicate)" do
+        User.create!(email: "existing@example.com", password: "password123", terms_accepted: true)
+        expect {
+          post "/api/levelcode/v1/auth/email/verify",
+               params: { email: "existing@example.com", code: "123456", mode: "web" }, headers: svc_headers
+        }.not_to change(User, :count)
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+end

--- a/spec/requests/api/levelcode/v1/feedback_spec.rb
+++ b/spec/requests/api/levelcode/v1/feedback_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe "Api::Levelcode::V1::Feedback", type: :request do
+  let(:user) { create(:user) }
+
+  before do
+    allow_any_instance_of(Api::Levelcode::V1::BaseController).to receive(:authenticate_levelcode!).and_return(true)
+    allow_any_instance_of(Api::Levelcode::V1::BaseController).to receive(:current_levelcode_user).and_return(user)
+    allow_any_instance_of(Api::Levelcode::V1::BaseController).to receive(:current_user).and_return(user)
+  end
+
+  it "records a thumbs-up against the model" do
+    expect {
+      post "/api/levelcode/v1/feedback", params: { rating: "up", model: "moonshotai/kimi-k2.7-code" }, as: :json
+    }.to change(UsageFeedback, :count).by(1)
+
+    expect(response).to have_http_status(:ok)
+    fb = UsageFeedback.last
+    expect(fb.user_id).to eq(user.id)
+    expect(fb.rating).to eq("up")
+    expect(fb.model).to eq("moonshotai/kimi-k2.7-code")
+  end
+
+  it "rejects an invalid rating (422) without recording" do
+    expect {
+      post "/api/levelcode/v1/feedback", params: { rating: "meh", model: "x" }, as: :json
+    }.not_to change(UsageFeedback, :count)
+
+    expect(response).to have_http_status(:unprocessable_content)
+    expect(response.parsed_body.dig("error", "code")).to eq("invalid_rating")
+  end
+end

--- a/spec/requests/api/levelcode/v1/pricing_spec.rb
+++ b/spec/requests/api/levelcode/v1/pricing_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe "Api::Levelcode::V1::Pricing", type: :request do
+  PRICING_URL = "/api/levelcode/v1/pricing"
+
+  describe "GET /api/levelcode/v1/pricing" do
+    it "is public (no auth required) and returns 200" do
+      get PRICING_URL
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "serializes every Levelcode::PLANS tier with the SPEC §3 shape" do
+      get PRICING_URL
+
+      tiers = response.parsed_body["tiers"]
+      expect(tiers).to be_an(Array)
+      expect(tiers.length).to eq(Levelcode::PLANS.length)
+
+      first = tiers.first
+      expect(first.keys).to include(
+        "key", "name", "price_cents", "interval",
+        "input_cap", "output_cap", "turns", "features"
+      )
+    end
+
+    it "surfaces the server-side plan keys and caps verbatim" do
+      get PRICING_URL
+
+      plan = Levelcode::PLANS.first
+      tier = response.parsed_body["tiers"].find { |t| t["key"] == plan[:key] }
+
+      expect(tier).to be_present
+      expect(tier["price_cents"]).to eq(plan[:price_cents])
+      expect(tier["input_cap"]).to eq(plan[:input_cap])
+      expect(tier["output_cap"]).to eq(plan[:output_cap])
+    end
+  end
+end

--- a/spec/requests/api/v1/webhooks_spec.rb
+++ b/spec/requests/api/v1/webhooks_spec.rb
@@ -107,7 +107,10 @@ RSpec.describe "Api::V1::Webhooks", type: :request do
                                 plan_nickname: "Pro",
                                 price_nickname: "Pro Monthly")
     plan_double = double("stripe_plan", product: product_id, interval: interval, nickname: plan_nickname)
-    price_double = double("stripe_price", id: price_id, nickname: price_nickname, product: product_id)
+    # `lookup_key` is what Levelcode::WebhookSync (invoked on every webhook via the
+    # shared controller) reads to detect an LevelCode Cloud plan; shortener prices
+    # don't set one, so a real Stripe price returns nil here — mirror that.
+    price_double = double("stripe_price", id: price_id, nickname: price_nickname, product: product_id, lookup_key: nil)
     item_double = double("stripe_item",
                          plan:                 plan_double,
                          price:                price_double,

--- a/spec/requests/api/v1/webhooks_spec.rb
+++ b/spec/requests/api/v1/webhooks_spec.rb
@@ -1084,6 +1084,31 @@ RSpec.describe "Api::V1::Webhooks", type: :request do
           .to change(ProcessedStripeEvent, :count).by(1)
       end
     end
+
+    # ── Money-critical sync failure → release idempotency + retry ────────────
+    #
+    # A LevelCode wallet sync (teardown/provision) that fails AFTER idempotency is claimed must not be
+    # silently stranded — the claim is RELEASED and a non-2xx is returned so Stripe retries.
+    describe "when the LevelCode wallet sync fails" do
+      let(:obj)   { double("obj") }
+      let(:event) { build_event("customer.subscription.deleted", obj) }
+
+      before do
+        allow(Levelcode::WebhookSync).to receive(:call)
+          .and_raise(ActiveRecord::StatementInvalid, "connection lost")
+      end
+
+      it "returns a non-2xx so Stripe retries" do
+        post_stripe_webhook(event)
+        expect(response).to have_http_status(:internal_server_error)
+      end
+
+      it "releases the idempotency claim so the retry re-runs the sync" do
+        expect { post_stripe_webhook(event) }
+          .not_to change(ProcessedStripeEvent, :count) # claimed then released → net zero
+        expect(ProcessedStripeEvent.exists?(stripe_event_id: event.id)).to be(false)
+      end
+    end
   end
 end
 # rubocop:enable Metrics/BlockLength

--- a/spec/requests/api/v1/webhooks_spec.rb
+++ b/spec/requests/api/v1/webhooks_spec.rb
@@ -253,9 +253,9 @@ RSpec.describe "Api::V1::Webhooks", type: :request do
       end
     end
 
-    # ── Unhandled runtime exception ──────────────────────────────────────────
+    # ── Stripe API error during handle_event: transient → retry, permanent → ack ──
 
-    context "when an unexpected error occurs inside handle_event" do
+    context "when a TRANSIENT Stripe error occurs (network / rate-limit / 5xx)" do
       let(:event) { build_event("invoice.paid", build_invoice) }
 
       before do
@@ -265,12 +265,34 @@ RSpec.describe "Api::V1::Webhooks", type: :request do
           .and_raise(Stripe::APIConnectionError.new("network error"))
       end
 
-      it "still returns 200 (prevents Stripe infinite retries)" do
+      it "returns a non-2xx so Stripe retries the webhook" do
+        post_stripe_webhook(event)
+        expect(response).to have_http_status(:internal_server_error)
+      end
+
+      it "releases the idempotency claim so the retry re-runs the sync" do
+        expect { post_stripe_webhook(event) }
+          .not_to change(ProcessedStripeEvent, :count) # claimed then released → net zero
+        expect(ProcessedStripeEvent.exists?(stripe_event_id: event.id)).to be(false)
+      end
+    end
+
+    context "when a PERMANENT Stripe error occurs (bad request / auth)" do
+      let(:event) { build_event("invoice.paid", build_invoice) }
+
+      before do
+        user
+        subscription
+        allow(Stripe::Subscription).to receive(:retrieve)
+          .and_raise(Stripe::InvalidRequestError.new("no such subscription", "subscription"))
+      end
+
+      it "returns 200 (retrying can't help — don't churn Stripe's retry queue)" do
         post_stripe_webhook(event)
         expect(response).to have_http_status(:ok)
       end
 
-      it "still records the event (claim-first idempotency marks before handle_event)" do
+      it "records the event as processed (no retry)" do
         expect { post_stripe_webhook(event) }
           .to change(ProcessedStripeEvent, :count).by(1)
       end

--- a/spec/requests/levelcode/web_spec.rb
+++ b/spec/requests/levelcode/web_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'Levelcode::Web (SPA backend at /ai/*)', type: :request do
     host! 'www.example.com'
   end
 
-  let(:editor_uri) { 'atom-plus-plus://levelcode.atom-ai/auth/callback' }
+  let(:editor_uri) { 'levelcode://levelcode.levelcode-ai/auth/callback' }
   def json = JSON.parse(response.body)
 
   describe 'brand switch (StaticController#ui)' do
@@ -84,7 +84,7 @@ RSpec.describe 'Levelcode::Web (SPA backend at /ai/*)', type: :request do
 
       expect(response).to have_http_status(:ok)
       loc = URI.parse(json['redirect'])
-      expect(loc.scheme).to eq('atom-plus-plus')
+      expect(loc.scheme).to eq('levelcode')
       expect(Rack::Utils.parse_query(loc.query)['code']).to eq('one-time-code')
     end
 
@@ -113,7 +113,7 @@ RSpec.describe 'Levelcode::Web (SPA backend at /ai/*)', type: :request do
 
       expect(response).to have_http_status(:ok)
       loc = URI.parse(json['redirect'])
-      expect(loc.scheme).to eq('atom-plus-plus')
+      expect(loc.scheme).to eq('levelcode')
       q = Rack::Utils.parse_query(loc.query)
       expect(q['windowId']).to eq('1')
       expect(q['code']).to eq('one-time-code')
@@ -220,7 +220,7 @@ RSpec.describe 'Levelcode::Web (SPA backend at /ai/*)', type: :request do
 
       expect(response).to have_http_status(:ok)
       loc = URI.parse(json['redirect'])
-      expect(loc.scheme).to eq('atom-plus-plus')
+      expect(loc.scheme).to eq('levelcode')
       expect(Rack::Utils.parse_query(loc.query)['code']).to eq('bound-code')
     end
 

--- a/spec/requests/levelcode/web_spec.rb
+++ b/spec/requests/levelcode/web_spec.rb
@@ -1,0 +1,249 @@
+require 'rails_helper'
+
+# LevelCode Cloud account app server surface (Levelcode::WebController, mounted at /ai/*)
+# + the StaticController brand switch. The account PAGES are the onetime SPA; this
+# controller owns the JSON auth/session/billing flows the SPA delegates to.
+# EmailCode / OneTimeCode / ProviderOAuth / Stripe are stubbed.
+RSpec.describe 'Levelcode::Web (SPA backend at /ai/*)', type: :request do
+  around do |example|
+    prev = ENV['LEVELCODE_JWT_SECRET']
+    ENV['LEVELCODE_JWT_SECRET'] = 'test-levelcode-secret'
+    example.run
+  ensure
+    ENV['LEVELCODE_JWT_SECRET'] = prev
+  end
+
+  # User creation calls Stripe (before_validation :create_stripe_customer); stub it.
+  before do
+    allow(Stripe::Customer).to receive(:create).and_return(Stripe::Customer.construct_from(id: 'cus_test'))
+    allow(Stripe::Customer).to receive(:retrieve).and_return(Stripe::Customer.construct_from(id: 'cus_test'))
+    host! 'www.example.com'
+  end
+
+  let(:editor_uri) { 'atom-plus-plus://levelcode.atom-ai/auth/callback' }
+  def json = JSON.parse(response.body)
+
+  describe 'brand switch (StaticController#ui)' do
+    it 'serves the levelcode shell for /ai paths' do
+      get '/ai/login'
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('LevelCode Cloud')
+      expect(response.body).to include('id="root"')
+      # (csrf_meta_tags renders only when forgery protection is on — off in test env.)
+    end
+
+    it 'redirects a bare path on an levelcode host into /ai' do
+      host! 'levelcode.ai'
+      get '/pricing'
+      expect(response).to redirect_to('/ai/pricing')
+    end
+  end
+
+  describe 'POST /ai/auth/email' do
+    it 'issues + emails a code and returns JSON' do
+      allow(Levelcode::EmailCode).to receive(:issue).with('user@example.com').and_return('123456')
+      mail = instance_double(ActionMailer::MessageDelivery, deliver_now: true)
+      allow(LevelcodeAuthMailer).to receive(:login_code).with('user@example.com', '123456').and_return(mail)
+
+      post '/ai/auth/email', params: { email: 'user@example.com' }
+
+      expect(response).to have_http_status(:ok)
+      expect(json).to eq('sent' => true)
+      expect(LevelcodeAuthMailer).to have_received(:login_code).with('user@example.com', '123456')
+    end
+
+    it 'rejects an invalid address with a JSON error' do
+      post '/ai/auth/email', params: { email: 'not-an-email' }
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(json.dig('error', 'code')).to eq('invalid_email')
+    end
+  end
+
+  describe 'POST /ai/auth/verify' do
+    it 'web mode: signs in and returns { redirect: /ai/account }' do
+      allow(Levelcode::EmailCode).to receive(:verify).and_return(true)
+
+      expect {
+        post '/ai/auth/verify', params: { email: 'web@example.com', code: '123456' }
+      }.to change(User, :count).by(1)
+
+      expect(response).to have_http_status(:ok)
+      expect(json).to eq('redirect' => '/ai/account')
+
+      # Session persists — the account API now authenticates via the cookie.
+      get '/api/levelcode/v1/account/profile'
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'editor mode: returns { redirect: deep-link?code= } bound to the PKCE challenge' do
+      allow(Levelcode::EmailCode).to receive(:verify).and_return(true)
+      allow(Levelcode::OneTimeCode).to receive(:issue).and_return('one-time-code')
+
+      post '/ai/auth/verify',
+           params: { email: 'editor@example.com', code: '123456', redirect_uri: editor_uri, code_challenge: 'chal' }
+
+      expect(response).to have_http_status(:ok)
+      loc = URI.parse(json['redirect'])
+      expect(loc.scheme).to eq('atom-plus-plus')
+      expect(Rack::Utils.parse_query(loc.query)['code']).to eq('one-time-code')
+    end
+
+    it 'editor mode: preserves ?windowId on the deep-link (VS Code asExternalUri)' do
+      allow(Levelcode::EmailCode).to receive(:verify).and_return(true)
+      allow(Levelcode::OneTimeCode).to receive(:issue).and_return('one-time-code')
+
+      post '/ai/auth/verify',
+           params: { email: 'win@example.com', code: '123456',
+                     redirect_uri: "#{editor_uri}?windowId=1", code_challenge: 'chal' }
+
+      expect(response).to have_http_status(:ok)
+      q = Rack::Utils.parse_query(URI.parse(json['redirect']).query)
+      expect(q['windowId']).to eq('1')
+      expect(q['code']).to eq('one-time-code')
+    end
+
+    it 'editor mode: decodes a double-encoded deep-link redirect_uri (the reported sign-in bug)' do
+      allow(Levelcode::EmailCode).to receive(:verify).and_return(true)
+      allow(Levelcode::OneTimeCode).to receive(:issue).and_return('one-time-code')
+
+      # As it arrives after one Rack decode: the ?windowId tail is still %3F/%3D-encoded.
+      post '/ai/auth/verify',
+           params: { email: 'enc@example.com', code: '123456',
+                     redirect_uri: "#{editor_uri}%3FwindowId%3D1", code_challenge: 'chal' }
+
+      expect(response).to have_http_status(:ok)
+      loc = URI.parse(json['redirect'])
+      expect(loc.scheme).to eq('atom-plus-plus')
+      q = Rack::Utils.parse_query(loc.query)
+      expect(q['windowId']).to eq('1')
+      expect(q['code']).to eq('one-time-code')
+    end
+
+    it 'fails closed for an editor deep-link with no code_challenge (no unbound code)' do
+      allow(Levelcode::EmailCode).to receive(:verify).and_return(true)
+      expect(Levelcode::OneTimeCode).not_to receive(:issue)
+
+      post '/ai/auth/verify', params: { email: 'nc@example.com', code: '123456', redirect_uri: editor_uri }
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(json.dig('error', 'code')).to eq('link_expired')
+    end
+
+    it 'treats a same-host https redirect_uri as web (no open-redirect code handoff)' do
+      allow(Levelcode::EmailCode).to receive(:verify).and_return(true)
+      expect(Levelcode::OneTimeCode).not_to receive(:issue)
+
+      post '/ai/auth/verify',
+           params: { email: 'sh@example.com', code: '123456', redirect_uri: 'https://www.example.com/AbCdEfg' }
+
+      expect(response).to have_http_status(:ok)
+      expect(json).to eq('redirect' => '/ai/account')
+    end
+
+    it 'rejects an invalid code' do
+      allow(Levelcode::EmailCode).to receive(:verify).and_return(false)
+      post '/ai/auth/verify', params: { email: 'nope@example.com', code: '000000' }
+      expect(response).to have_http_status(:unauthorized)
+      expect(json.dig('error', 'code')).to eq('invalid_code')
+    end
+  end
+
+  describe 'OAuth' do
+    it 'GET /ai/auth/oauth/github 302s to the provider authorize URL' do
+      allow(Levelcode::ProviderOAuth).to receive(:authorize_url).and_return('https://github.test/authorize?state=x')
+      get '/ai/auth/oauth/github'
+      expect(response).to redirect_to('https://github.test/authorize?state=x')
+    end
+
+    it 'GET /ai/auth/callback rejects a mismatched state' do
+      get '/ai/auth/callback', params: { code: 'gh', state: 'forged' }
+      expect(response).to redirect_to('/ai/login?error=session_expired')
+    end
+
+    it 'GET /ai/auth/callback (valid state, web) signs in and 302s to /ai/account' do
+      allow(SecureRandom).to receive(:urlsafe_base64).and_return('teststate')
+      allow(Levelcode::ProviderOAuth).to receive(:authorize_url).and_return('https://github.test/authorize')
+      allow(Levelcode::ProviderOAuth).to receive(:github_user).and_return(User.create!(email: 'gh@example.com', password: 'x' * 20, terms_accepted: true))
+
+      get '/ai/auth/oauth/github' # stashes session state = teststate
+      get '/ai/auth/callback', params: { code: 'gh', state: 'teststate' }
+
+      expect(response).to redirect_to('/ai/account')
+    end
+  end
+
+  describe 'POST /ai/signout' do
+    it 'clears the session and returns JSON' do
+      post '/ai/signout'
+      expect(response).to have_http_status(:ok)
+      expect(json).to eq('ok' => true)
+    end
+  end
+
+  describe 'GET /ai/auth/handoff (editor -> browser SSO)' do
+    let(:user) { User.create!(email: 'handoff@example.com', password: 'password123', terms_accepted: true) }
+
+    it 'redeems a valid code, signs the browser in, and redirects to /ai/account' do
+      allow(Levelcode::OneTimeCode).to receive(:redeem).with('good-code').and_return(user)
+
+      get '/ai/auth/handoff', params: { code: 'good-code' }
+      expect(response).to redirect_to('/ai/account')
+
+      # Session established — the account API now authenticates via the cookie (no re-login).
+      get '/api/levelcode/v1/account/profile'
+      expect(response).to have_http_status(:ok)
+      expect(json['email']).to eq('handoff@example.com')
+    end
+
+    it 'redirects to /ai/login on an invalid or expired code' do
+      allow(Levelcode::OneTimeCode).to receive(:redeem).and_raise(Levelcode::OneTimeCode::InvalidCode, 'expired')
+
+      get '/ai/auth/handoff', params: { code: 'nope' }
+      expect(response).to redirect_to('/ai/login?error=link_expired')
+    end
+  end
+
+  describe 'POST /ai/authorize_editor (browser -> PKCE-bound editor code)' do
+    let(:user) { User.create!(email: 'launch@example.com', password: 'password123', terms_accepted: true) }
+
+    def sign_in_browser(code)
+      allow(Levelcode::OneTimeCode).to receive(:redeem).with(code).and_return(user)
+      get '/ai/auth/handoff', params: { code: code }
+      expect(response).to redirect_to('/ai/account')
+    end
+
+    it 'mints a PKCE-BOUND editor code for the signed-in browser session (no second login)' do
+      sign_in_browser('sess-a')
+      allow(Levelcode::OneTimeCode).to receive(:issue).with(user, 'chal').and_return('bound-code')
+
+      post '/ai/authorize_editor', params: { redirect_uri: editor_uri, code_challenge: 'chal' }
+
+      expect(response).to have_http_status(:ok)
+      loc = URI.parse(json['redirect'])
+      expect(loc.scheme).to eq('atom-plus-plus')
+      expect(Rack::Utils.parse_query(loc.query)['code']).to eq('bound-code')
+    end
+
+    it 'FAILS CLOSED without a code_challenge (an unbound code would be interceptable)' do
+      sign_in_browser('sess-b')
+
+      post '/ai/authorize_editor', params: { redirect_uri: editor_uri } # no challenge
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(json.dig('error', 'code')).to eq('invalid_request')
+    end
+
+    it 'rejects a non-editor redirect_uri (no open redirect)' do
+      sign_in_browser('sess-c')
+
+      post '/ai/authorize_editor', params: { redirect_uri: 'https://evil.example/steal', code_challenge: 'chal' }
+
+      expect(response).to have_http_status(:unprocessable_content)
+    end
+
+    it 'does not mint for an anonymous request' do
+      post '/ai/authorize_editor', params: { redirect_uri: editor_uri, code_challenge: 'chal' }, as: :json
+      expect(response).not_to have_http_status(:ok)
+    end
+  end
+end

--- a/spec/services/levelcode/webhook_sync_spec.rb
+++ b/spec/services/levelcode/webhook_sync_spec.rb
@@ -78,6 +78,32 @@ RSpec.describe Levelcode::WebhookSync do
     end
   end
 
+  describe "Stripe API errors during a subscription retrieve" do
+    let(:invoice) do
+      double("invoice",
+             parent: double("parent", subscription_details: double("sd", subscription: "sub_123")),
+             customer: "cus_test123")
+    end
+
+    it "re-raises a TRANSIENT error (APIConnectionError) as SyncError — worth a webhook retry" do
+      allow(Stripe::Subscription).to receive(:retrieve).and_raise(Stripe::APIConnectionError.new("net"))
+      expect { described_class.call(event("invoice.paid", invoice)) }
+        .to raise_error(Levelcode::WebhookSync::SyncError)
+    end
+
+    it "re-raises a Stripe-side 5xx (APIError) as SyncError" do
+      allow(Stripe::Subscription).to receive(:retrieve).and_raise(Stripe::APIError.new("stripe is down"))
+      expect { described_class.call(event("invoice.paid", invoice)) }
+        .to raise_error(Levelcode::WebhookSync::SyncError)
+    end
+
+    it "SWALLOWS a PERMANENT error (InvalidRequestError) — acked, not retried" do
+      allow(Stripe::Subscription).to receive(:retrieve)
+        .and_raise(Stripe::InvalidRequestError.new("no such subscription", "subscription"))
+      expect { described_class.call(event("invoice.paid", invoice)) }.not_to raise_error
+    end
+  end
+
   describe "customer.subscription.updated" do
     it "re-provisions caps for the new plan without zeroing usage mid-period" do
       CreditWallet.create!(

--- a/spec/services/levelcode/webhook_sync_spec.rb
+++ b/spec/services/levelcode/webhook_sync_spec.rb
@@ -1,0 +1,130 @@
+require "rails_helper"
+
+# rubocop:disable Metrics/BlockLength
+RSpec.describe Levelcode::WebhookSync do
+  let(:user) { create(:user, stripe_id: "cus_test123") }
+
+  before do
+    allow(Stripe::Customer).to receive(:create).and_return(double(id: "cus_test123"))
+    user # materialize
+  end
+
+  # A Stripe subscription double whose single item carries the given lookup_key.
+  def stripe_subscription(lookup_key:, period_start: 1_700_000_000, period_end: 1_702_678_400)
+    price = double("price", id: "price_#{lookup_key}", lookup_key: lookup_key)
+    item = double("item", price: price, current_period_start: period_start, current_period_end: period_end)
+    double("Stripe::Subscription", id: "sub_123", items: double("items", data: [ item ]))
+  end
+
+  def event(type, object)
+    double("Stripe::Event", type: type, data: double("data", object: object))
+  end
+
+  describe "checkout.session.completed" do
+    let(:session) { double("session", mode: "subscription", subscription: "sub_123", customer: "cus_test123") }
+
+    before do
+      allow(Stripe::Subscription).to receive(:retrieve).with("sub_123")
+        .and_return(stripe_subscription(lookup_key: "orbits_pro"))
+    end
+
+    it "provisions a CreditWallet with the plan's caps" do
+      expect {
+        described_class.call(event("checkout.session.completed", session))
+      }.to change { CreditWallet.where(user: user, product: "levelcode").count }.by(1)
+
+      wallet = CreditWallet.find_by(user: user, product: "levelcode")
+      plan = Levelcode.plan("orbits_pro")
+      expect(wallet.plan_key).to eq("orbits_pro")
+      expect(wallet.input_cap).to eq(plan[:input_cap])
+      expect(wallet.output_cap).to eq(plan[:output_cap])
+      expect(wallet.input_used).to eq(0)
+      expect(wallet.output_used).to eq(0)
+    end
+
+    it "ignores non-subscription checkout sessions" do
+      one_time = double("session", mode: "payment", subscription: nil, customer: "cus_test123")
+      expect {
+        described_class.call(event("checkout.session.completed", one_time))
+      }.not_to change(CreditWallet, :count)
+    end
+  end
+
+  describe "invoice.paid" do
+    let(:invoice) do
+      double("invoice",
+             parent: double("parent", subscription_details: double("sd", subscription: "sub_123")),
+             customer: "cus_test123")
+    end
+
+    before do
+      allow(Stripe::Subscription).to receive(:retrieve).with("sub_123")
+        .and_return(stripe_subscription(lookup_key: "orbits_pro"))
+    end
+
+    it "resets the used counters for the new period" do
+      CreditWallet.create!(
+        user: user, product: "levelcode", plan_key: "orbits_pro",
+        input_cap: 1, output_cap: 1, input_used: 999, output_used: 888,
+        period_start: 1.month.ago, period_end: 1.day.ago, overage_policy: "throttle"
+      )
+
+      described_class.call(event("invoice.paid", invoice))
+
+      wallet = CreditWallet.find_by(user: user, product: "levelcode")
+      expect(wallet.input_used).to eq(0)
+      expect(wallet.output_used).to eq(0)
+      expect(wallet.input_cap).to eq(Levelcode.plan("orbits_pro")[:input_cap])
+    end
+  end
+
+  describe "customer.subscription.updated" do
+    it "re-provisions caps for the new plan without zeroing usage mid-period" do
+      CreditWallet.create!(
+        user: user, product: "levelcode", plan_key: "orbits_pro",
+        input_cap: 10, output_cap: 10, input_used: 5, output_used: 5,
+        period_start: 1.day.ago, period_end: 1.month.from_now, overage_policy: "throttle"
+      )
+
+      sub = stripe_subscription(lookup_key: "orbits_pro_plus")
+      allow(sub).to receive(:customer).and_return("cus_test123")
+
+      described_class.call(event("customer.subscription.updated", sub))
+
+      wallet = CreditWallet.find_by(user: user, product: "levelcode")
+      expect(wallet.plan_key).to eq("orbits_pro_plus")
+      expect(wallet.input_cap).to eq(Levelcode.plan("orbits_pro_plus")[:input_cap])
+      expect(wallet.input_used).to eq(5)
+    end
+  end
+
+  describe "customer.subscription.deleted" do
+    it "tears the wallet down to free" do
+      CreditWallet.create!(
+        user: user, product: "levelcode", plan_key: "orbits_pro",
+        input_cap: 10, output_cap: 10, input_used: 5, output_used: 5,
+        period_start: 1.day.ago, period_end: 1.month.from_now, overage_policy: "throttle"
+      )
+
+      sub = double("Stripe::Subscription", customer: "cus_test123")
+      described_class.call(event("customer.subscription.deleted", sub))
+
+      wallet = CreditWallet.find_by(user: user, product: "levelcode")
+      expect(wallet.plan_key).to eq("free")
+      expect(wallet.input_cap).to eq(0)
+      expect(wallet.input_used).to eq(0)
+    end
+  end
+
+  describe "non-levelcode events" do
+    it "no-ops for a linkly-product subscription (unknown lookup_key)" do
+      sub = stripe_subscription(lookup_key: "creator_monthly")
+      allow(sub).to receive(:customer).and_return("cus_test123")
+
+      expect {
+        described_class.call(event("customer.subscription.updated", sub))
+      }.not_to change(CreditWallet, :count)
+    end
+  end
+end
+# rubocop:enable Metrics/BlockLength

--- a/spec/services/levelcode/webhook_sync_spec.rb
+++ b/spec/services/levelcode/webhook_sync_spec.rb
@@ -10,10 +10,10 @@ RSpec.describe Levelcode::WebhookSync do
   end
 
   # A Stripe subscription double whose single item carries the given lookup_key.
-  def stripe_subscription(lookup_key:, period_start: 1_700_000_000, period_end: 1_702_678_400)
+  def stripe_subscription(lookup_key:, period_start: 1_700_000_000, period_end: 1_702_678_400, status: "active")
     price = double("price", id: "price_#{lookup_key}", lookup_key: lookup_key)
     item = double("item", price: price, current_period_start: period_start, current_period_end: period_end)
-    double("Stripe::Subscription", id: "sub_123", items: double("items", data: [ item ]))
+    double("Stripe::Subscription", id: "sub_123", status: status, items: double("items", data: [ item ]))
   end
 
   def event(type, object)
@@ -95,6 +95,48 @@ RSpec.describe Levelcode::WebhookSync do
       expect(wallet.plan_key).to eq("orbits_pro_plus")
       expect(wallet.input_cap).to eq(Levelcode.plan("orbits_pro_plus")[:input_cap])
       expect(wallet.input_used).to eq(5)
+    end
+  end
+
+  describe "past_due / non-active subscription" do
+    it "does NOT (re)provision the paid budget — a failed renewal keeps no paying-tier credits" do
+      CreditWallet.create!(
+        user: user, product: "levelcode", plan_key: "orbits_pro",
+        input_cap: 10, output_cap: 10, input_used: 3, output_used: 3,
+        budget_micros: 5_000_000, spent_micros: 4_000_000,
+        period_start: 1.day.ago, period_end: 1.month.from_now, overage_policy: "throttle"
+      )
+      # A past_due event for a PRICIER plan would otherwise refill the wallet to the ultra budget.
+      sub = stripe_subscription(lookup_key: "orbits_ultra", status: "past_due")
+      allow(sub).to receive(:customer).and_return("cus_test123")
+
+      described_class.call(event("customer.subscription.updated", sub))
+
+      wallet = CreditWallet.find_by(user: user, product: "levelcode")
+      expect(wallet.plan_key).to eq("orbits_pro")   # unchanged — not upgraded on a delinquent sub
+      expect(wallet.budget_micros).to eq(5_000_000) # NOT refilled to the ultra budget
+      expect(wallet.spent_micros).to eq(4_000_000)  # spend not reset
+    end
+  end
+
+  describe "customer.subscription.updated with an ADVANCING period_end" do
+    it "resets spend when the billing period advances (treats it as a fresh period)" do
+      old_end = Time.at(1_700_000_000).to_datetime
+      CreditWallet.create!(
+        user: user, product: "levelcode", plan_key: "orbits_pro",
+        input_cap: 10, output_cap: 10, input_used: 7, output_used: 7,
+        budget_micros: 10_000_000, spent_micros: 9_000_000,
+        period_start: old_end - 1.month, period_end: old_end, overage_policy: "throttle"
+      )
+      # New period_end AFTER the stored one → a roll, so the prior period's spend must not carry over.
+      sub = stripe_subscription(lookup_key: "orbits_pro", period_start: 1_700_000_000, period_end: 1_705_000_000)
+      allow(sub).to receive(:customer).and_return("cus_test123")
+
+      described_class.call(event("customer.subscription.updated", sub))
+
+      wallet = CreditWallet.find_by(user: user, product: "levelcode")
+      expect(wallet.spent_micros).to eq(0)
+      expect(wallet.input_used).to eq(0)
     end
   end
 

--- a/spec/support/fake_redis.rb
+++ b/spec/support/fake_redis.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+# `Set` is used below; require it so the helper is self-contained across load orders.
+require "set"
+
 # Minimal in-memory Redis stand-in for hermetic specs. The app skips the real
 # `$redis` in test (config/initializers/redis.rb: `unless Rails.env.test?`), so
 # any code path that touches Redis — Levelcode::OneTimeCode (single-use codes),

--- a/spec/support/fake_redis.rb
+++ b/spec/support/fake_redis.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+# Minimal in-memory Redis stand-in for hermetic specs. The app skips the real
+# `$redis` in test (config/initializers/redis.rb: `unless Rails.env.test?`), so
+# any code path that touches Redis — Levelcode::OneTimeCode (single-use codes),
+# Levelcode::EditorToken (jti denylist), Levelcode::Metering (hot counters) — needs a
+# fake. This implements only the commands those services use.
+#
+# Usage (scoped, save/restore so it never leaks into unrelated specs):
+#   around { |ex| with_fake_redis { ex.run } }
+class FakeRedis
+  def initialize
+    @strings = {}   # key => value
+    @sets    = {}   # key => Set
+    @expires = {}   # key => monotonic-ish marker (unused for logic; TTLs are no-ops)
+  end
+
+  # -- strings ----------------------------------------------------------------
+  def set(key, val)
+    @strings[key.to_s] = val.to_s
+    "OK"
+  end
+
+  def setex(key, _ttl, val)
+    set(key, val)
+  end
+
+  def get(key)
+    @strings[key.to_s]
+  end
+
+  # Atomic get-and-delete — the property OneTimeCode relies on for single-use.
+  def getdel(key)
+    @strings.delete(key.to_s)
+  end
+
+  def del(*keys)
+    keys.flatten.count { |k| @strings.delete(k.to_s) || @sets.delete(k.to_s) }
+  end
+
+  def mget(*keys)
+    keys.flatten.map { |k| @strings[k.to_s] }
+  end
+
+  def incrby(key, by)
+    @strings[key.to_s] = (@strings[key.to_s].to_i + by.to_i).to_s
+    @strings[key.to_s].to_i
+  end
+
+  # -- sets -------------------------------------------------------------------
+  def sadd(key, member)
+    (@sets[key.to_s] ||= Set.new).add(member.to_s)
+    1
+  end
+
+  def sismember(key, member)
+    (@sets[key.to_s] || Set.new).include?(member.to_s)
+  end
+
+  # -- ttl (no-op; specs don't assert expiry timing) --------------------------
+  def expire(key, _ttl)
+    @expires[key.to_s] = true
+  end
+
+  # -- pipeline ---------------------------------------------------------------
+  # Metering.record wraps writes in `$redis.pipelined { |p| ... }`. The fake just
+  # yields itself so the buffered commands run inline.
+  def pipelined
+    yield self
+    []
+  end
+end
+
+module FakeRedisHelper
+  def with_fake_redis
+    prev = defined?($redis) ? $redis : nil
+    $redis = FakeRedis.new
+    yield
+  ensure
+    $redis = prev
+  end
+end
+
+RSpec.configure do |config|
+  config.include FakeRedisHelper
+end


### PR DESCRIPTION
LevelCode Cloud managed-hosting backend under the `/api/levelcode/v1` namespace, the internal Orbits → LevelCode rename, and a money-path correctness pass.

## What's here
- **Namespace + rename** — `/api/levelcode/v1`; internal `Orbits` → `LevelCode` modules/services.
- **Metering** — free tier (gpt-oss-120b), dollar-budget credit metering, model catalog + derived economics, roster / usage / activity endpoints, revenue-based plan budgets.
- **Editor↔browser SSO** — PKCE deep-link fix after the rename (host + scheme).
- **Correctness** — fixed the durable usage counter never bumping on a fractional-second `period_end`; hardened the money path: admission-time budget reservation (concurrent-overshoot guard), billing at the routed catalog model (dated-snapshot slugs no longer under-bill), routing-fee-inclusive cost, and Stripe lifecycle (status gate, period-roll reset, idempotency release + retry).

Backend suite: 808 examples, 0 failures. 8 commits. Base: `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)