### PR TITLE
CI: fix rubocop on Ruby 4.0.x (whitequark parser engine)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,13 @@
 inherit_gem: { rubocop-rails-omakase: rubocop.yml }
 
 AllCops:
+  # Ruby 4.0's bundled prism (1.9) dropped the versioned parser file that rubocop-ast (1.48) still
+  # `require`s (prism/translation/parser35), so the default prism engine LoadErrors on 4.0.x. Use the
+  # whitequark `parser` gem instead (already in the bundle) and pin the target to 3.4 — the parser
+  # gem's ceiling; the codebase is 3.x-compatible. Drop this once rubocop ships Ruby 4.0 / prism 1.9
+  # support and revert TargetRubyVersion to the runtime.
+  ParserEngine: parser_whitequark
+  TargetRubyVersion: 3.4
   Exclude:
     - 'blog/vendor/bundle/**/*'
     - 'vendor/bundle/**/*'


### PR DESCRIPTION
## Problem

The `.ruby-version` bump to **4.0.5** (in #332) turned the **rubocop** CI job red on `develop` — and broke local `bin/rubocop`. Ruby 4.0's bundled **prism 1.9** dropped `prism/translation/parser35`, which the pinned **rubocop-ast 1.48** still `require`s, so the default prism parser engine `LoadError`s.

The app itself runs fine on 4.0.5 — `test` and `brakeman` stay green; only rubocop's parser is behind.

## Fix

Switch the rubocop parser to the **whitequark `parser` gem** (already in the bundle), and pin `TargetRubyVersion: 3.4` (the parser gem's ceiling; the codebase is 3.x-compatible):

```yaml
AllCops:
  ParserEngine: parser_whitequark
  TargetRubyVersion: 3.4
```

There's no newer rubocop/rubocop-ast that supports Ruby 4.0 / prism 1.9 yet, so whitequark is the correct bridge. Revert once upstream catches up.

## Verification

`bin/rubocop` on Ruby 4.0.5 → **311 files inspected, 0 offenses** — identical to the last green run on 3.4.1. No rule changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)