### PR TITLE
Gateway: sanitize upstream provider errors (stop raw OpenRouter text leaking to the editor)

### DIFF
--- a/app/controllers/api/levelcode/v1/ai_controller.rb
+++ b/app/controllers/api/levelcode/v1/ai_controller.rb
@@ -114,8 +114,9 @@ module Api
             @captured_model ||= result&.model
             write_raw("data: [DONE]\n\n")
           rescue ::Levelcode::OpenRouterAdapter::UpstreamError => e
-            Rails.logger.warn("[Api::Levelcode::V1::AiController] upstream #{e.status}: #{e.body.to_s[0, 800]}")
-            write_sse(upstream_error_json(e))
+            klass = classify_upstream(e)
+            log_upstream(e, klass)
+            write_sse(upstream_error_json(klass))
           rescue IOError, ActionController::Live::ClientDisconnected
             # Client hung up mid-stream; nothing more to write.
             Rails.logger.info("[Api::Levelcode::V1::AiController] client disconnected mid-stream")
@@ -206,9 +207,9 @@ module Api
           render json: upstream, status: :ok
         rescue ::Levelcode::OpenRouterAdapter::UpstreamError => e
           ::Levelcode::Metering.settle!(wallet, reservation, 0, 0, 0) unless settled # no generation → release
-          Rails.logger.warn("[Api::Levelcode::V1::AiController] upstream #{e.status}: #{e.body.to_s[0, 800]}")
-          render json: { error: { code: "upstream_error", message: upstream_message(e) } },
-                 status: :bad_gateway
+          klass = classify_upstream(e)
+          log_upstream(e, klass)
+          render json: { error: { code: klass[:code], message: klass[:message] } }, status: klass[:http]
         rescue => e
           # Any OTHER failure (timeout, connection reset, malformed upstream JSON) before meter! settled
           # would STRAND the reservation (spend over-counted) — release it. `settled` guards against a
@@ -308,19 +309,58 @@ module Api
           ENV["SITE_ORIGIN"].presence || "https://levelcode.ai"
         end
 
-        def upstream_error_json(error)
-          { error: { code: "upstream_error", status: error.status, message: upstream_message(error) } }.to_json
+        def upstream_error_json(klass)
+          { error: { code: klass[:code], message: klass[:message] } }.to_json
         end
 
-        # Surface the REAL upstream reason (the OpenRouter error message) instead of
-        # a generic label — e.g. "moonshotai/kimi-k2.6 is not a valid model ID" or
-        # "No auth credentials found" — so failures are diagnosable in the editor.
-        def upstream_message(error)
-          parsed = JSON.parse(error.body.to_s)
-          msg = parsed.dig("error", "message") || parsed["message"]
-          msg.presence || "Upstream returned #{error.status}"
-        rescue JSON::ParserError, TypeError
-          "Upstream returned #{error.status}"
+        # User-facing copy for upstream failures. Deliberately generic — NO provider name,
+        # token math, credits URL, or upstream status number ever reaches the client.
+        SERVICE_UNAVAILABLE_MSG =
+          "The AI service is temporarily unavailable. This is on our side — not your " \
+          "account or your usage. Please try again in a moment.".freeze
+        SERVICE_BUSY_MSG =
+          "The AI service is busy right now. Please wait a moment and try again.".freeze
+        INPUT_FLAGGED_MSG =
+          "This request was blocked by the model's content filter. Try rephrasing your " \
+          "prompt and send again.".freeze
+        CONTEXT_LENGTH_MSG =
+          "This conversation is too long for the model's context window. Start a new chat, " \
+          "remove some pinned files, or switch to a larger-context model.".freeze
+
+        # Map a raw UpstreamError to a SAFE, classified editor error. The raw body is read
+        # here ONLY to classify + log — it is NEVER returned to the client. Anything not
+        # positively identified as a user-side condition is treated as an our-side outage
+        # (fail safe), so a new/unknown upstream error can never leak internal structure.
+        def classify_upstream(error)
+          status = error.status.to_i
+          low    = error.body.to_s.downcase
+
+          if status == 403 && low.include?("flag") # content moderation (user-side)
+            return { code: "input_flagged", message: INPUT_FLAGGED_MSG, http: :bad_request, alert: false }
+          end
+          if status == 400 && low.match?(/context (length|window)|maximum context/) # user-side
+            return { code: "context_length", message: CONTEXT_LENGTH_MSG, http: :bad_request, alert: false }
+          end
+          if status == 429 # upstream throttle (transient)
+            return { code: "service_busy", message: SERVICE_BUSY_MSG, http: :service_unavailable, alert: false }
+          end
+
+          # credits(402) / auth(401) / bad-model-id(404) / provider outage / unknown → one
+          # generic ops-safe message. ALERT only on the classes that mean PAID AI is globally
+          # down (platform balance, bad key, bad model id) — not on client-malformed 400s.
+          { code: "service_unavailable", message: SERVICE_UNAVAILABLE_MSG, http: :service_unavailable,
+            alert: [401, 402, 404].include?(status) }
+        end
+
+        # Log the raw upstream detail for us (never sent to the client). Page-worthy classes
+        # go to error with a greppable [LEVELCODE_ALERT] tag; user-side/transient stay at warn.
+        def log_upstream(error, klass)
+          detail = "upstream #{error.status} -> #{klass[:code]}: #{error.body.to_s[0, 800]}"
+          if klass[:alert]
+            Rails.logger.error("[LEVELCODE_ALERT] [Api::Levelcode::V1::AiController] #{detail}")
+          else
+            Rails.logger.warn("[Api::Levelcode::V1::AiController] #{detail}")
+          end
         end
 
         # Mint a fresh SERVER-side idempotency/billing id per turn. Deriving it from request.request_id

--- a/app/controllers/api/levelcode/v1/ai_controller.rb
+++ b/app/controllers/api/levelcode/v1/ai_controller.rb
@@ -349,7 +349,7 @@ module Api
           # generic ops-safe message. ALERT only on the classes that mean PAID AI is globally
           # down (platform balance, bad key, bad model id) — not on client-malformed 400s.
           { code: "service_unavailable", message: SERVICE_UNAVAILABLE_MSG, http: :service_unavailable,
-            alert: [401, 402, 404].include?(status) }
+            alert: [ 401, 402, 404 ].include?(status) }
         end
 
         # Log the raw upstream detail for us (never sent to the client). Page-worthy classes

--- a/app/services/levelcode/open_router_adapter.rb
+++ b/app/services/levelcode/open_router_adapter.rb
@@ -69,6 +69,14 @@ module Levelcode
             next if payload.empty?
             break if payload == "[DONE]"
 
+            # A terminal error frame can arrive MID-STREAM, after the 200 OK (provider
+            # outage, upstream rate-limit, mid-generation credit exhaustion). Raise the
+            # SAME UpstreamError as a pre-stream non-200 so the controller sanitizes it
+            # through one boundary and aborts — the raw frame is NEVER teed to the client.
+            if (code = error_frame_status(payload))
+              raise UpstreamError.new(code, payload)
+            end
+
             usage = extract_usage(payload) || usage
             on_chunk.call(payload)
           end
@@ -140,6 +148,18 @@ module Levelcode
       parsed = JSON.parse(payload)
       parsed["usage"]
     rescue JSON::ParserError
+      nil
+    end
+
+    # If a chunk is a terminal error frame (`{"error":{...}}`), return its numeric
+    # status (or 0 when none — the controller's classifier maps 0 to the generic
+    # our-side message). Returns nil for a normal content chunk.
+    def error_frame_status(payload)
+      parsed = JSON.parse(payload)
+      return nil unless parsed.is_a?(Hash) && parsed["error"].present?
+
+      parsed.dig("error", "code").to_i
+    rescue JSON::ParserError, TypeError
       nil
     end
 

--- a/spec/requests/api/levelcode/v1/ai_spec.rb
+++ b/spec/requests/api/levelcode/v1/ai_spec.rb
@@ -125,6 +125,93 @@ RSpec.describe "Api::Levelcode::V1::Ai", type: :request do
     end
   end
 
+  describe "upstream error sanitization (no raw provider error ever reaches the editor)" do
+    # The exact leaky OpenRouter 402 body from the field report.
+    let(:leaky_402) do
+      '{"error":{"message":"This request requires more credits, or fewer max_tokens. ' \
+      "You requested up to 8192 tokens, but can only afford 4675. To increase, visit " \
+      'https://openrouter.ai/settings/credits and add more credits","code":402}}'
+    end
+    let(:leak_terms) { [ /openrouter/i, /credits/i, /max_tokens/i, /8192/ ] }
+
+    def upstream(status, body)
+      Levelcode::OpenRouterAdapter::UpstreamError.new(status, body)
+    end
+
+    before do
+      allow(Levelcode::Metering).to receive(:check!)
+        .and_return(Levelcode::Metering::Decision.new(allowed: true, throttle: false, policy: "throttle"))
+    end
+
+    context "non-streaming" do
+      let(:body) { { model: "moonshotai/kimi-k2.6", stream: false, messages: [ { role: "user", content: "hi" } ] } }
+
+      it "maps an upstream 402 (platform credits exhausted) to a safe 503 with no leaked internals" do
+        allow_any_instance_of(Levelcode::OpenRouterAdapter).to receive(:complete).and_raise(upstream(402, leaky_402))
+
+        post "/api/levelcode/v1/ai/chat", params: body, as: :json
+
+        expect(response).to have_http_status(:service_unavailable)
+        json = JSON.parse(response.body)
+        expect(json.dig("error", "code")).to eq("service_unavailable")
+        expect(json.dig("error", "status")).to be_nil # the upstream status number must not leak
+        leak_terms.each { |t| expect(response.body).not_to match(t) }
+      end
+
+      it "maps an upstream 429 to service_busy" do
+        allow_any_instance_of(Levelcode::OpenRouterAdapter).to receive(:complete)
+          .and_raise(upstream(429, '{"error":{"message":"rate limited"}}'))
+
+        post "/api/levelcode/v1/ai/chat", params: body, as: :json
+
+        expect(response).to have_http_status(:service_unavailable)
+        expect(JSON.parse(response.body).dig("error", "code")).to eq("service_busy")
+      end
+
+      it "maps a context-length 400 to a user-fixable context_length/400" do
+        allow_any_instance_of(Levelcode::OpenRouterAdapter).to receive(:complete)
+          .and_raise(upstream(400, '{"error":{"message":"maximum context length is 200000 tokens"}}'))
+
+        post "/api/levelcode/v1/ai/chat", params: body, as: :json
+
+        expect(response).to have_http_status(:bad_request)
+        expect(JSON.parse(response.body).dig("error", "code")).to eq("context_length")
+      end
+    end
+
+    context "streaming" do
+      let(:body) do
+        { model: "moonshotai/kimi-k2.6", stream: true, stream_options: { include_usage: true },
+          messages: [ { role: "user", content: "hi" } ] }
+      end
+
+      it "sanitizes a pre-stream upstream error into a safe SSE frame (no status field, no leak)" do
+        allow_any_instance_of(Levelcode::OpenRouterAdapter).to receive(:stream).and_raise(upstream(402, leaky_402))
+
+        post "/api/levelcode/v1/ai/chat", params: body, as: :json
+
+        expect(response).to have_http_status(:ok) # 200 + event-stream already committed
+        expect(response.body).to include("service_unavailable")
+        expect(response.body).not_to include('"status"')
+        leak_terms.each { |t| expect(response.body).not_to match(t) }
+      end
+
+      it "sanitizes a MID-stream error after good content (regression for the primary leak)" do
+        good = '{"choices":[{"delta":{"content":"partial "}}]}'
+        allow_any_instance_of(Levelcode::OpenRouterAdapter).to receive(:stream) do |_a, _b, on_chunk:|
+          on_chunk.call(good)              # 200 committed + content already flowed to the client
+          raise upstream(402, leaky_402)   # what the adapter now raises on a mid-stream error frame
+        end
+
+        post "/api/levelcode/v1/ai/chat", params: body, as: :json
+
+        expect(response.body).to include("data: #{good}\n\n") # the good content still reached the user
+        expect(response.body).to include("service_unavailable") # followed by the sanitized error
+        leak_terms.each { |t| expect(response.body).not_to match(t) }
+      end
+    end
+  end
+
   describe "scope enforcement (ai:chat vs ai:agent)" do
     before do
       allow(Levelcode::Metering).to receive(:check!)

--- a/spec/services/levelcode/open_router_adapter_spec.rb
+++ b/spec/services/levelcode/open_router_adapter_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Levelcode::OpenRouterAdapter do
+  subject(:adapter) { described_class.new(api_key: "test-key") }
+
+  # The stream loop raises UpstreamError on a terminal error frame so an in-stream
+  # failure (after the 200 OK) is sanitized through the same controller boundary as a
+  # pre-stream non-200 — the raw frame is never teed to the editor.
+  describe "#error_frame_status (a private stream-loop helper)" do
+    def status_of(payload) = adapter.send(:error_frame_status, payload)
+
+    it "returns the numeric code of a terminal error frame" do
+      expect(status_of('{"error":{"message":"credits exhausted","code":402}}')).to eq(402)
+    end
+
+    it "returns 0 for an error frame with no numeric code (falls through to the generic message)" do
+      expect(status_of('{"error":{"message":"boom"}}')).to eq(0)
+    end
+
+    it "returns nil for a normal content chunk so a good chunk is never mistaken for an error" do
+      expect(status_of('{"choices":[{"delta":{"content":"hi"}}]}')).to be_nil
+    end
+
+    it "returns nil for malformed / non-object payloads" do
+      expect(status_of("not json")).to be_nil
+      expect(status_of('["an","array"]')).to be_nil
+      expect(status_of('{"usage":{"total_tokens":9}}')).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
## Problem

When the platform's upstream OpenRouter balance hit \$0, a paid-model request returned OpenRouter's raw 402 **verbatim** to the LevelCode editor:

> This request requires more credits, or fewer max_tokens. You requested up to 8192 tokens, but can only afford 4675. To increase, visit https://openrouter.ai/settings/credits and add more credits

That leaks (a) that we proxy OpenRouter, (b) the internal `max_tokens` math, and (c) the **platform's own** `openrouter.ai/settings/credits` URL — and it blames the user for an ops outage on our side.

## Fix

Classify every upstream error at the controller boundary into safe, generic copy. The raw body is read **only** to classify + log; it never reaches any client envelope.

| Class | Upstream | Client `code` | HTTP | Message |
|---|---|---|---|---|
| credits / auth / bad-model / provider-down / unknown | 402/401/404/5xx/? | `service_unavailable` | 503 | "temporarily unavailable — on our side, not your account" |
| upstream rate-limit | 429 | `service_busy` | 503 | "busy right now, try again" |
| moderation | 403 + flagged | `input_flagged` | 400 | "blocked by the content filter, rephrase" |
| context too long | 400 + context | `context_length` | 400 | "conversation too long, start a new chat" |

- **Fail-safe**: anything not positively identified as user-side → generic our-side message. A new/unknown upstream error can never leak structure.
- **Alerting**: page-worthy classes (platform balance, bad key, bad model id) log `[LEVELCODE_ALERT]` at error; user-side/transient stay at warn.
- **Not the cap card**: our-side outages return `service_unavailable`/503 with no `upgrade_url`, so the editor's `cap_reached` (402) upgrade card never misfires for an outage. `render_cap_reached` is untouched.
- **Mid-stream leak sealed**: an error frame arriving *after* the 200 OK (provider outage, mid-generation credit exhaustion) previously bypassed the classifier and was teed out raw. The adapter now detects terminal error frames and raises `UpstreamError`, routing them through the same single sanitization boundary.

## Tests

New: request-level pre-stream, **mid-stream** (regression for the primary leak), non-stream, 429, and context-length; plus adapter unit tests for the mid-stream frame detector. Each asserts the response contains none of `openrouter` / `credits` / `max_tokens` / `8192`. Full `ai_spec` green (39 examples, 0 failures).

## Editor side (separate)

The editor gets a neutral "service temporarily unavailable" card (vs the red error / upgrade card) in a follow-up on the `levelcode` repo — but note the gateway message is already safe, so no raw leak reaches the editor regardless of the client change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)