### PR TITLE
Metering: usage dashboard reflects the unlocked tranche ceiling + unlock date (Phase 2)

### DIFF
--- a/app/controllers/api/levelcode/v1/account_controller.rb
+++ b/app/controllers/api/levelcode/v1/account_controller.rb
@@ -24,16 +24,21 @@ module Api
           # Show the LIVE per-period spend/usage (the same counters enforcement uses),
           # not the async-lagged wallet columns.
           in_used, out_used = wallet ? ::Levelcode::Metering.usage(wallet) : [ 0, 0 ]
-          spent = wallet ? ::Levelcode::Metering.spent_micros(wallet) : 0
-          budget = wallet&.budget_micros.to_i
+          state = wallet ? ::Levelcode::Metering.tranche_state(wallet) : nil
 
           render json: {
             plan: current_plan_name,
             model: ::Levelcode.gateway_model(wallet&.plan_key),
             # Credits (M14): the DOLLAR budget is the enforced allowance; token fields are informational.
-            budget_micros: budget,
-            spent_micros: spent,
-            credits_remaining_micros: [ budget - spent, 0 ].max,
+            # budget_micros is the full monthly allowance; credits_remaining_micros is measured against the
+            # currently-UNLOCKED ceiling (rolling usage windows) so the UI never shows more than
+            # enforcement will actually serve. next_unlock_at is when more unlocks (nil if all is, or
+            # tranching is off). With tranching disabled these equal the full-budget values as before.
+            budget_micros: state ? state[:full_micros] : 0,
+            ceiling_micros: state ? state[:ceiling_micros] : 0,
+            spent_micros: state ? state[:spent_micros] : 0,
+            credits_remaining_micros: state ? state[:remaining_micros] : 0,
+            next_unlock_at: state ? state[:next_unlock_at] : nil,
             input_used: in_used,
             input_cap: wallet&.input_cap.to_i,
             output_used: out_used,
@@ -49,16 +54,18 @@ module Api
         # (confirmed-price models are selectable; staged ones are shown but not yet billable).
         def models
           wallet = current_wallet
-          budget = wallet&.budget_micros.to_i
-          spent = wallet ? ::Levelcode::Metering.spent_micros(wallet) : 0
-          remaining = [ budget - spent, 0 ].max
+          state = wallet ? ::Levelcode::Metering.tranche_state(wallet) : nil
+          # turns-left is computed from what's usable NOW (the unlocked ceiling), not the full budget.
+          remaining = state ? state[:remaining_micros] : 0
 
           render json: {
             plan: current_plan_name,
             default_model: ::Levelcode.default_model(current_plan_key),
-            budget_micros: budget,
-            spent_micros: spent,
+            budget_micros: state ? state[:full_micros] : 0,
+            ceiling_micros: state ? state[:ceiling_micros] : 0,
+            spent_micros: state ? state[:spent_micros] : 0,
             credits_remaining_micros: remaining,
+            next_unlock_at: state ? state[:next_unlock_at] : nil,
             models: ::Levelcode.roster_for(current_plan_key, remaining)
           }, status: :ok
         end

--- a/app/controllers/api/levelcode/v1/ai_controller.rb
+++ b/app/controllers/api/levelcode/v1/ai_controller.rb
@@ -285,16 +285,29 @@ module Api
         end
 
         def render_cap_reached(wallet)
-          free = wallet.plan_key.to_s == ::Levelcode::FREE_PLAN_KEY
+          free  = wallet.plan_key.to_s == ::Levelcode::FREE_PLAN_KEY
+          state = ::Levelcode::Metering.tranche_state(wallet)
+          # A rolling-window gate (more unlocks soon) is NOT the monthly cap — say so, and don't sell an
+          # upgrade for a wait. Only fires when tranching is on; otherwise it's the plain period message.
+          window_gated = state[:kind] == :window_exhausted && state[:next_unlock_at].present?
+
+          message =
+            if window_gated
+              "You've used the usage available right now. More unlocks #{state[:next_unlock_at].strftime('%b %-d')}."
+            elsif free
+              "You've reached this month's free compute limit. Upgrade to Pro to unlock Kimi K2.7 Code — a sharper coding model — and much higher limits, so you can keep building without interruption."
+            else
+              "You've reached your plan's usage limit for this billing period. It resets on your next renewal — or manage your plan to raise it."
+            end
+
           render json: {
             error: {
               code: "cap_reached",
-              message: free ?
-                "You've reached this month's free compute limit. Upgrade to Pro to unlock Kimi K2.7 Code — a sharper coding model — and much higher limits, so you can keep building without interruption." :
-                "You've reached your plan's usage limit for this billing period. It resets on your next renewal — or manage your plan to raise it.",
-              # The editor surfaces this as an "Upgrade" CTA on the free tier.
-              upgrade_url: (free ? "#{site_origin}/ai/pricing" : nil),
-              topup_url: topup_url_for(wallet)
+              message: message,
+              # The editor surfaces this as an "Upgrade" CTA on the free tier — but not for a rolling-window wait.
+              upgrade_url: (free && !window_gated ? "#{site_origin}/ai/pricing" : nil),
+              topup_url: topup_url_for(wallet),
+              next_unlock_at: (window_gated ? state[:next_unlock_at] : nil)
             }
           }, status: :payment_required
         end

--- a/app/services/levelcode/metering.rb
+++ b/app/services/levelcode/metering.rb
@@ -70,6 +70,46 @@ module Levelcode
       (full * k) / n                                    # integer micro-$; == full EXACTLY at k == n
     end
 
+    # Dashboard / deny-surface view of the wallet's budget position: pairs the ENFORCED ceiling with
+    # when more unlocks, so the UI shows what's usable NOW (not the full monthly budget) and never
+    # over-promises. With tranching disabled (N=1) ceiling == full and next_unlock_at is nil, so callers
+    # behave exactly as before. `kind`: :period_exhausted (monthly cap hit → renewal) / :window_exhausted
+    # (gated now, more unlocks at next_unlock_at) / :ok.
+    def tranche_state(wallet, now = Time.current)
+      full      = wallet.budget_micros.to_i
+      ceiling   = unlocked_budget_micros(wallet, now)
+      spent     = spent_micros(wallet)
+      remaining = [ ceiling - spent, 0 ].max
+      unlock_at = ceiling < full ? next_tranche_unlock_at(wallet, now) : nil
+
+      kind =
+        if full.positive? && spent >= full then :period_exhausted
+        elsif ceiling < full && spent >= ceiling then :window_exhausted
+        else :ok
+        end
+
+      { full_micros: full, ceiling_micros: ceiling, spent_micros: spent, remaining_micros: remaining,
+        tranched: ceiling < full, next_unlock_at: unlock_at, resets_at: wallet.period_end, kind: kind }
+    end
+
+    # When the NEXT tranche unlocks — or nil if tranching is off, already fully unlocked, or the period
+    # is unknown. Same window/k math as unlocked_budget_micros, but returns the boundary time.
+    def next_tranche_unlock_at(wallet, now = Time.current)
+      n = Levelcode::BUDGET_TRANCHES
+      return nil if n <= 1
+
+      start = wallet.period_start
+      fin   = wallet.period_end
+      return nil if start.blank? || fin.blank? || fin <= start
+
+      window = (fin - start).to_f / n
+      return nil if window <= 0
+
+      elapsed = [ (now - start).to_f, 0.0 ].max
+      k = (1 + (elapsed / window).floor).clamp(1, n)
+      k < n ? start + (k * window) : nil # nil in the last window — nothing more unlocks
+    end
+
     # True when this period's spend has reached the currently-unlocked dollar ceiling.
     def over_budget?(spent, wallet)
       spent >= unlocked_budget_micros(wallet)

--- a/spec/requests/api/levelcode/v1/account_spec.rb
+++ b/spec/requests/api/levelcode/v1/account_spec.rb
@@ -132,6 +132,31 @@ RSpec.describe "Api::Levelcode::V1::Account", type: :request do
       end
     end
 
+    context "with rolling usage windows active (LEVELCODE_BUDGET_TRANCHES=3)" do
+      let!(:wallet) do
+        CreditWallet.create!(
+          user: user, product: "levelcode", plan_key: "orbits_pro",
+          input_cap: 15_000_000, output_cap: 2_000_000,
+          budget_micros: Levelcode.budget_micros("orbits_pro"), spent_micros: 0,
+          period_start: Time.current, period_end: 1.month.from_now, overage_policy: "throttle"
+        )
+      end
+
+      it "reports remaining against the UNLOCKED ceiling (budget/3), not the full budget, with an unlock date" do
+        stub_const("Levelcode::BUDGET_TRANCHES", 3)
+        allow(Levelcode::Metering).to receive(:spent_micros).and_return(0)
+        full = Levelcode.budget_micros("orbits_pro")
+
+        get USAGE_URL
+
+        body = response.parsed_body
+        expect(body["budget_micros"]).to eq(full)                 # full monthly allowance unchanged
+        expect(body["ceiling_micros"]).to eq(full / 3)            # only the first tranche is unlocked
+        expect(body["credits_remaining_micros"]).to eq(full / 3)  # remaining is vs the ceiling, NOT the full budget
+        expect(body["next_unlock_at"]).to be_present              # and we say when more unlocks
+      end
+    end
+
     context "when the user has no wallet yet (M11 free tier)" do
       it "provisions the free tier — gpt-oss engine, free caps, hard-cap policy" do
         get USAGE_URL

--- a/spec/requests/api/levelcode/v1/ai_spec.rb
+++ b/spec/requests/api/levelcode/v1/ai_spec.rb
@@ -109,12 +109,13 @@ RSpec.describe "Api::Levelcode::V1::Ai", type: :request do
     it "returns 402 cap_reached for a topup wallet" do
       topup_wallet = instance_double(
         "CreditWallet", user_id: user.id, plan_key: "orbits_pro", input_cap: 1, output_cap: 1,
-        input_used: 5, output_used: 5, period_start: Time.current, period_end: Time.current,
-        overage_policy: "topup"
+        input_used: 5, output_used: 5, budget_micros: 10_000_000,
+        period_start: Time.current, period_end: Time.current, overage_policy: "topup"
       )
       allow(Levelcode::FreeTier).to receive(:wallet_for).and_return(topup_wallet)
       allow(Levelcode::Metering).to receive(:check!)
         .and_return(Levelcode::Metering::Decision.new(allowed: false, throttle: false, policy: "topup"))
+      allow(Levelcode::Metering).to receive(:spent_micros).with(topup_wallet).and_return(10_000_000)
 
       post "/api/levelcode/v1/ai/chat", params: body, as: :json
 
@@ -122,6 +123,28 @@ RSpec.describe "Api::Levelcode::V1::Ai", type: :request do
       json = JSON.parse(response.body)
       expect(json.dig("error", "code")).to eq("cap_reached")
       expect(json.dig("error", "topup_url")).to be_present
+    end
+
+    it "says 'more unlocks soon' (not the monthly-cap message) when a rolling-window gate is hit" do
+      stub_const("Levelcode::BUDGET_TRANCHES", 3)
+      full = Levelcode.budget_micros("orbits_pro") # $10
+      gated = instance_double(
+        "CreditWallet", user_id: user.id, plan_key: "orbits_pro", budget_micros: full,
+        period_start: Time.current, period_end: 1.month.from_now, overage_policy: "stop"
+      )
+      allow(Levelcode::FreeTier).to receive(:wallet_for).and_return(gated)
+      allow(Levelcode::Metering).to receive(:check!)
+        .and_return(Levelcode::Metering::Decision.new(allowed: false, throttle: false, policy: "stop"))
+      allow(Levelcode::Metering).to receive(:spent_micros).with(gated).and_return(full / 2) # past the $3.33 tranche, under $10
+
+      post "/api/levelcode/v1/ai/chat", params: body, as: :json
+
+      expect(response).to have_http_status(:payment_required)
+      json = JSON.parse(response.body)
+      expect(json.dig("error", "code")).to eq("cap_reached")
+      expect(json.dig("error", "message")).to match(/more unlocks/i)
+      expect(json.dig("error", "next_unlock_at")).to be_present
+      expect(json.dig("error", "upgrade_url")).to be_nil # don't sell an upgrade for a wait
     end
   end
 
@@ -256,7 +279,7 @@ RSpec.describe "Api::Levelcode::V1::Ai", type: :request do
   describe "POST /api/levelcode/v1/ai/chat on the FREE tier (M11)" do
     let(:free_wallet) do
       instance_double(
-        "CreditWallet", user_id: user.id, plan_key: "free",
+        "CreditWallet", user_id: user.id, plan_key: "free", budget_micros: 300_000,
         input_cap: Levelcode::FREE_INPUT_CAP, output_cap: Levelcode::FREE_OUTPUT_CAP,
         input_used: 0, output_used: 0, period_start: Time.current, period_end: 1.month.from_now,
         overage_policy: "stop"
@@ -303,6 +326,7 @@ RSpec.describe "Api::Levelcode::V1::Ai", type: :request do
     it "402s cap_reached with an upgrade_url when the free monthly cap is hit" do
       allow(Levelcode::Metering).to receive(:check!)
         .and_return(Levelcode::Metering::Decision.new(allowed: false, throttle: false, policy: "stop"))
+      allow(Levelcode::Metering).to receive(:spent_micros).with(free_wallet).and_return(300_000)
 
       post "/api/levelcode/v1/ai/chat", params: { model: "x", stream: true, messages: [] }, as: :json
 

--- a/spec/services/levelcode/metering_spec.rb
+++ b/spec/services/levelcode/metering_spec.rb
@@ -117,4 +117,54 @@ RSpec.describe Levelcode::Metering do
       expect(described_class.reserve!(paid, 4_000_000).ok).to be(false)
     end
   end
+
+  # Phase 2: the dashboard/deny view — pairs the enforced ceiling with when more unlocks so the UI
+  # matches enforcement (never shows more than will be served).
+  describe ".tranche_state" do
+    def state_for(wal, now, spent:)
+      allow(described_class).to receive(:spent_micros).with(wal).and_return(spent)
+      described_class.tranche_state(wal, now)
+    end
+
+    context "with tranching disabled (N=1)" do
+      it "reports the full budget as the ceiling, no unlock date — identical to pre-tranche behavior" do
+        s = state_for(wallet, t0, spent: 1_000_000)
+        expect(s).to include(full_micros: full, ceiling_micros: full, tranched: false, next_unlock_at: nil, kind: :ok)
+        expect(s[:remaining_micros]).to eq(full - 1_000_000)
+      end
+    end
+
+    context "with tranching enabled (N=3)" do
+      before { stub_const("Levelcode::BUDGET_TRANCHES", 3) }
+      let(:window) { (fin - t0) / 3 }
+
+      it "first window: ceiling budget/3, remaining vs the ceiling, unlock date set, kind :ok" do
+        s = state_for(wallet, t0, spent: 0)
+        expect(s[:ceiling_micros]).to eq(full / 3)
+        expect(s[:remaining_micros]).to eq(full / 3)
+        expect(s[:tranched]).to be(true)
+        expect(s[:next_unlock_at]).to eq(t0 + window)
+        expect(s[:kind]).to eq(:ok)
+      end
+
+      it "kind :window_exhausted when spend is past the ceiling but under the full budget" do
+        s = state_for(wallet, t0, spent: full / 2) # $5 spent vs the $3.33 first tranche
+        expect(s[:kind]).to eq(:window_exhausted)
+        expect(s[:remaining_micros]).to eq(0)
+        expect(s[:next_unlock_at]).to eq(t0 + window)
+      end
+
+      it "kind :period_exhausted once spend reaches the full budget" do
+        s = state_for(wallet, t0 + (2 * window), spent: full)
+        expect(s[:kind]).to eq(:period_exhausted)
+      end
+
+      it "next_unlock_at is nil in the last window (nothing more unlocks)" do
+        s = state_for(wallet, t0 + (2 * window), spent: 0)
+        expect(s[:ceiling_micros]).to eq(full)
+        expect(s[:tranched]).to be(false)
+        expect(s[:next_unlock_at]).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
Phase 2 of rolling usage limits. Makes the dashboard tell the **same story as enforcement** — the gate that was blocking activation. Still **inert by default**.

## Why

Phase 1 made the enforced ceiling rise in tranches, but `/account/usage` + `/account/models` still reported `credits_remaining` against the **full** monthly budget. Once tranching is on, a first-window user would see "~\$8 left / N turns" yet get 402'd at \$3.33 — the advertised-vs-enforced mismatch behind the *Kahn v. Anthropic* theory. This PR closes it.

## Changes

- **`Metering.tranche_state(wallet, now)`** — pairs the enforced `ceiling_micros` with `remaining_micros` (vs the ceiling), `next_unlock_at`, `resets_at`, and a `kind` (`:ok` / `:window_exhausted` / `:period_exhausted`). Plus `next_tranche_unlock_at` for the unlock boundary.
- **`/account/usage` + `/account/models`** now report `credits_remaining_micros` against the **unlocked ceiling** (not the full budget), and expose `ceiling_micros` + `next_unlock_at`. `budget_micros` still carries the full monthly allowance. Turns-left in the roster is computed from the ceiling-based remaining, so it's honest.
- **`render_cap_reached`** branches: a rolling-window gate → *"You've used the usage available right now. More unlocks Jul 17."* (no upgrade CTA — don't sell an upgrade for a wait); the true monthly cap keeps the *"resets on renewal"* message. Adds `next_unlock_at` to the payload.

## Inert by default

With `LEVELCODE_BUDGET_TRANCHES=1`, `ceiling == full` and `next_unlock_at` is nil, so every endpoint returns exactly the pre-tranche values. Ships as a no-op. **With Phase 1 (#342) + this merged, display and enforcement agree — so tranching can be safely activated by setting the ENV to `3`.**

## Tests

`tranche_state` (disabled + the three kinds + last-window), `usage` reports ceiling-based remaining with an unlock date, and a window-gated `cap_reached` message. **128 levelcode specs green** (full request + service dirs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)