### PR TITLE
Pricing: reframe plan copy from dollar-credits to usage-that-resets

### DIFF
--- a/lib/levelcode.rb
+++ b/lib/levelcode.rb
@@ -29,7 +29,7 @@ module Levelcode
       stripe_lookup_key: "orbits_pro",
       features: [
         "~260 Kimi turns/mo · ~39 on Opus 4.8",
-        "$10/mo of AI credits (dollar-metered)",
+        "Usage that refreshes through your billing cycle",
         "Kimi K2.7 Code + Opus 4.8",
         "Bring-your-own-key always free"
       ]
@@ -45,7 +45,7 @@ module Levelcode
       stripe_lookup_key: "orbits_pro_plus",
       features: [
         "~520 Kimi turns/mo · ~78 on Opus 4.8",
-        "$20/mo of AI credits (dollar-metered)",
+        "Usage that refreshes through your billing cycle",
         "Kimi K2.7 Code + Opus 4.8",
         "Priority routing"
       ]
@@ -61,7 +61,7 @@ module Levelcode
       stripe_lookup_key: "orbits_max",
       features: [
         "~780 Kimi turns/mo · ~117 on Opus 4.8",
-        "$30/mo of AI credits (dollar-metered)",
+        "Usage that refreshes through your billing cycle",
         "Kimi K2.7 Code + Opus 4.8",
         "Priority routing"
       ]
@@ -77,7 +77,7 @@ module Levelcode
       stripe_lookup_key: "orbits_ultra",
       features: [
         "~1,300 Kimi turns/mo · ~195 on Opus 4.8",
-        "$50/mo of AI credits (dollar-metered)",
+        "Usage that refreshes through your billing cycle",
         "Kimi K2.7 Code + Opus 4.8",
         "Highest priority routing"
       ]


### PR DESCRIPTION
Phase 3 (framing). The plan feature copy advertised a **dollar credit figure** — *"\$10/mo of AI credits (dollar-metered)"* — on every tier. That's a problem now that budget enforcement is rolling-window based (PRs #342/#343): advertising a dollar amount you then meter in tranches is precisely the advertised-vs-enforced mismatch behind *Kahn v. Anthropic*.

**Change:** replace the dollar line on all four plans with *"Usage that refreshes through your billing cycle."* The concrete *"~N Kimi turns/mo · ~M on Opus 4.8"* estimate stays — that's the honest, tangible promise. No dollar credit figure is advertised anywhere.

These strings are server-truth (`GET /pricing` → the levelcode.ai pricing page renders them verbatim), so this is the only place to change.

⚠️ **Marketing/legal sign-off needed** on the exact wording before this goes live — I picked a reasonable draft, adjust as you see fit.

Not included (open decisions, no code needed): margin factor stays **0.50** (design recommendation), overage policy stays **throttle** (graceful degrade). Flip via ENV / provisioning if you decide otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)