### PR TITLE
Pricing: Max as a decoy tier ($80, budget pinned)

### DIFF
--- a/lib/levelcode.rb
+++ b/lib/levelcode.rb
@@ -53,11 +53,16 @@ module Levelcode
     {
       key: "orbits_max",
       name: "Max",
-      price_cents: 6_000,
+      price_cents: 8_000,
       interval: "month",
       input_cap: 55_000_000,
       output_cap: 7_000_000,
       turns: 780,
+      # DECOY tier (asymmetric dominance): priced ABOVE its value line — $80 for the ~780-turn /
+      # $30-budget allowance of the old $60 Max — so it's dominated by Pro+ ($40) and Ultra ($100)
+      # and steers buyers to those. budget_micros is PINNED (NOT price × CREDIT_COGS_RATIO) to keep
+      # it a genuine worse-value anchor and hold margin. See Levelcode.budget_micros.
+      budget_micros: 30_000_000,
       stripe_lookup_key: "orbits_max",
       features: [
         "~780 Kimi turns/mo · ~117 on Opus 4.8",
@@ -302,6 +307,11 @@ module Levelcode
     def budget_micros(plan_key)
       p = plan(plan_key)
       return 0 unless p
+
+      # A plan may PIN an explicit budget, decoupling it from price — used by the Max "decoy" tier,
+      # which is priced above its value line to anchor buyers toward Pro+/Ultra (see PLANS). Its
+      # allowance stays at the pre-decoy level while the price rises, so it's a genuine worse-value tier.
+      return p[:budget_micros].to_i if p[:budget_micros]
 
       # Revenue-based (Cursor-style): the monthly credit allowance is a fixed fraction of the plan's
       # price, so gross margin = 1 - CREDIT_COGS_RATIO regardless of which models the user picks.

--- a/spec/models/levelcode_plans_spec.rb
+++ b/spec/models/levelcode_plans_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe Levelcode do
       expected = {
         'orbits_pro'      => { price_cents: 2_000,  input_cap: 15_000_000, output_cap: 2_000_000 },
         'orbits_pro_plus' => { price_cents: 4_000,  input_cap: 35_000_000, output_cap: 4_500_000 },
-        'orbits_max'      => { price_cents: 6_000,  input_cap: 55_000_000, output_cap: 7_000_000 },
+        'orbits_max'      => { price_cents: 8_000,  input_cap: 55_000_000, output_cap: 7_000_000 }, # decoy tier
+
         'orbits_ultra'    => { price_cents: 10_000, input_cap: 95_000_000, output_cap: 12_000_000 }
       }
 
@@ -25,6 +26,19 @@ RSpec.describe Levelcode do
         expect(plan[:stripe_lookup_key]).to eq(plan[:key])
         expect(plan[:features]).to be_an(Array).and be_present
       end
+    end
+
+    it 'keeps Max a DECOY: priced $80 but its budget is pinned below the price × ratio line' do
+      # Asymmetric-dominance pricing — Max is intentionally worse value than Pro+ and Ultra so buyers
+      # pick $40 or $100. Its budget is PINNED (not price × CREDIT_COGS_RATIO), so don't "fix" the gap.
+      max = Levelcode.plan('orbits_max')
+      expect(max[:price_cents]).to eq(8_000)
+      expect(max[:budget_micros]).to eq(30_000_000)                       # pinned, decoupled from price
+      expect(Levelcode.budget_micros('orbits_max')).to eq(30_000_000)     # override honored
+      # Value ratio (budget ÷ price) is strictly worse than both neighbors → dominated → decoy.
+      ratio = ->(k) { Levelcode.budget_micros(k) / (Levelcode.plan(k)[:price_cents] * 10_000.0) }
+      expect(ratio.call('orbits_max')).to be < ratio.call('orbits_pro_plus')
+      expect(ratio.call('orbits_max')).to be < ratio.call('orbits_ultra')
     end
   end
 


### PR DESCRIPTION
Reprices **Max $60 → $80** as an asymmetric-dominance **decoy** so buyers self-sort to Pro+ ($40) or Ultra ($100).

## How
Max keeps its capacity (55M/7M, ~780 turns) but its price rises to $80, and its compute budget is **pinned at the pre-decoy $30** (new per-plan `budget_micros` override, decoupled from the `price × CREDIT_COGS_RATIO` default). That drops Max's value ratio to **38%** while Pro/Pro+/Ultra stay **50%** — so Max is worse value than *both* neighbors:

| | price | ~turns | $/turn |
|---|---|---|---|
| Pro+ | $40 | 520 | $0.077 |
| **Max** | **$80** | **780** | **$0.103** ← dominated |
| Ultra | $100 | 1,300 | $0.077 |

Light users take Pro+; heavy users see "$20 more → 67% more" and take Ultra. Honest — every shown number is real; Max is simply priced above its value line to anchor (the Economist's middle-tier trick), not a dark pattern.

## Timing
Land this **before** creating the new LevelCode-account Stripe prices — the price-sync snippet reads `PLANS[:price_cents]`, so Max gets created at $80 automatically.

A `budget_micros`-override lock test documents the intentional mismatch so no one "fixes" it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)