### PR TITLE
Fix webhook coupling: route Stripe events by product key

### DIFF
--- a/app/controllers/api/v1/webhooks_controller.rb
+++ b/app/controllers/api/v1/webhooks_controller.rb
@@ -80,7 +80,7 @@ class Api::V1::WebhooksController < ApplicationController
 
     when "checkout.session.async_payment_failed"
       # Delayed payment method failed after checkout.
-      handle_payment_failed(obj.customer)
+      handle_payment_failed(obj.customer, subscription_id: obj.subscription)
 
     # ── Invoice Events ───────────────────────────────────────────
     when "invoice.paid"
@@ -96,7 +96,7 @@ class Api::V1::WebhooksController < ApplicationController
 
     when "invoice.payment_failed"
       # A payment attempt on an invoice failed.
-      handle_payment_failed(obj.customer)
+      handle_payment_failed(obj.customer, subscription_id: invoice_subscription_id(obj))
 
     when "invoice.payment_action_required"
       # Customer needs to complete an action (e.g. 3D Secure authentication).
@@ -155,11 +155,7 @@ class Api::V1::WebhooksController < ApplicationController
   # ─── Invoice Handlers ──────────────────────────────────────────
 
   def handle_invoice_paid(invoice)
-    # Stripe API 2024-12-18 moved subscription to invoice.parent.subscription_details,
-    # but older events (replays, test clocks) and some edge cases still use invoice.subscription.
-    # Try the modern path first, fall back to legacy, and only skip if both are blank.
-    subscription_id = invoice.parent&.subscription_details&.subscription
-    subscription_id = invoice.try(:subscription) if subscription_id.blank?
+    subscription_id = invoice_subscription_id(invoice)
 
     unless subscription_id.present?
       Rails.logger.info("[Stripe Webhook] invoice.paid is not subscription-related, skipping")
@@ -196,6 +192,8 @@ class Api::V1::WebhooksController < ApplicationController
   end
 
   def handle_payment_action_required(invoice)
+    return if skip_levelcode_id?(invoice_subscription_id(invoice), "payment_action_required #{invoice.id}")
+
     user = find_user_by_stripe_id(invoice.customer)
     return unless user
 
@@ -287,7 +285,9 @@ class Api::V1::WebhooksController < ApplicationController
 
   # ─── Shared Helpers ─────────────────────────────────────────────
 
-  def handle_payment_failed(customer_id)
+  def handle_payment_failed(customer_id, subscription_id: nil)
+    return if skip_levelcode_id?(subscription_id, "payment_failed")
+
     user = find_user_by_stripe_id(customer_id)
     return unless user
 
@@ -347,6 +347,26 @@ class Api::V1::WebhooksController < ApplicationController
 
     Rails.logger.info("[Stripe Webhook] #{context}: LevelCode Cloud subscription — owned by Levelcode::WebhookSync, skipping shortener sync")
     true
+  end
+
+  # Same guard for handlers that only hold a subscription id (the payment-failure / action-required
+  # paths). Retrieves the subscription to read its lookup_key. Fails OPEN to the shortener path on a
+  # missing id or any Stripe error — a possibly-misbranded dunning email beats dropping the notice.
+  def skip_levelcode_id?(subscription_id, context)
+    return false if subscription_id.blank?
+
+    skip_levelcode?(Stripe::Subscription.retrieve(subscription_id), context)
+  rescue Stripe::StripeError => e
+    Rails.logger.warn("[Stripe Webhook] #{context}: could not resolve product for #{subscription_id} (#{e.message}); treating as shortener")
+    false
+  end
+
+  # The subscription id on an invoice. Stripe API 2024-12-18 moved it to
+  # parent.subscription_details.subscription; older/replayed events still carry invoice.subscription.
+  def invoice_subscription_id(invoice)
+    id = invoice.parent&.subscription_details&.subscription
+    id = invoice.try(:subscription) if id.blank?
+    id
   end
 
   def sync_subscription(subscription, stripe_subscription)

--- a/app/controllers/api/v1/webhooks_controller.rb
+++ b/app/controllers/api/v1/webhooks_controller.rb
@@ -133,6 +133,8 @@ class Api::V1::WebhooksController < ApplicationController
     return unless user
 
     stripe_subscription = Stripe::Subscription.retrieve(subscription_id)
+    return if skip_levelcode?(stripe_subscription, "checkout #{session.id}")
+
     subscription = Subscription.find_by(subscription_id: stripe_subscription.id) ||
                    Subscription.find_by(customer_id: user.stripe_id)
 
@@ -168,6 +170,8 @@ class Api::V1::WebhooksController < ApplicationController
     return unless user
 
     stripe_subscription = Stripe::Subscription.retrieve(subscription_id)
+    return if skip_levelcode?(stripe_subscription, "invoice #{invoice.id}")
+
     subscription = Subscription.find_by(customer_id: user.stripe_id)
     unless subscription
       Rails.logger.error("[Stripe Webhook] Subscription not found for customer: #{user.stripe_id}")
@@ -207,6 +211,8 @@ class Api::V1::WebhooksController < ApplicationController
   # ─── Subscription Handlers ─────────────────────────────────────
 
   def handle_subscription_updated(stripe_subscription)
+    return if skip_levelcode?(stripe_subscription, "subscription.updated #{stripe_subscription.id}")
+
     user = find_user_by_stripe_id(stripe_subscription.customer)
     return unless user
 
@@ -243,6 +249,8 @@ class Api::V1::WebhooksController < ApplicationController
   end
 
   def handle_subscription_deleted(stripe_subscription)
+    return if skip_levelcode?(stripe_subscription, "subscription.deleted #{stripe_subscription.id}")
+
     user = find_user_by_stripe_id(stripe_subscription.customer)
     return unless user
 
@@ -265,6 +273,8 @@ class Api::V1::WebhooksController < ApplicationController
   end
 
   def handle_trial_will_end(stripe_subscription)
+    return if skip_levelcode?(stripe_subscription, "trial_will_end #{stripe_subscription.id}")
+
     user = find_user_by_stripe_id(stripe_subscription.customer)
     return unless user
 
@@ -313,6 +323,30 @@ class Api::V1::WebhooksController < ApplicationController
       Rails.logger.error("[Stripe Webhook] User not found for stripe customer: #{stripe_customer_id}")
     end
     user
+  end
+
+  # ─── Product-key routing ────────────────────────────────────────
+  #
+  # One Stripe account can host BOTH products (the link shortener AND LevelCode Cloud).
+  # Levelcode::WebhookSync runs first on every event and owns LevelCode subscriptions
+  # (it provisions the CreditWallet). The shortener handlers below MUST skip those — a
+  # LevelCode price carries a Levelcode::PLANS lookup_key, whereas shortener prices don't.
+  # Without this guard a LevelCode purchase's checkout/invoice/subscription events resolve
+  # to the user's link-shortener Subscription row and, because LevelCode products carry no
+  # links/qr_codes metadata, sync_subscription would zero the shortener Plan
+  # (metadata["links"].to_i => 0). Mirror image of Levelcode::WebhookSync#levelcode_plan?.
+  def levelcode_subscription?(stripe_subscription)
+    lookup_key = stripe_subscription&.items&.data&.first&.price&.lookup_key
+    lookup_key.present? && Levelcode.plan(lookup_key).present?
+  end
+
+  # `return if skip_levelcode?(sub, context)` — logs and short-circuits a shortener handler
+  # when the event actually belongs to LevelCode Cloud (owned by Levelcode::WebhookSync).
+  def skip_levelcode?(stripe_subscription, context)
+    return false unless levelcode_subscription?(stripe_subscription)
+
+    Rails.logger.info("[Stripe Webhook] #{context}: LevelCode Cloud subscription — owned by Levelcode::WebhookSync, skipping shortener sync")
+    true
   end
 
   def sync_subscription(subscription, stripe_subscription)

--- a/app/services/levelcode/webhook_sync.rb
+++ b/app/services/levelcode/webhook_sync.rb
@@ -49,7 +49,11 @@ module Levelcode
       when "customer.subscription.updated"
         provision_from_stripe_subscription(@object, @object.customer)
       when "customer.subscription.deleted"
-        teardown(@object.customer)
+        # Only a LevelCode subscription's cancellation tears the wallet down. In a shared Stripe
+        # account the same user may ALSO hold a link-shortener subscription — deleting THAT must not
+        # zero the LevelCode CreditWallet. Guard on the deleted subscription's price lookup_key, the
+        # same filter the provision_* paths already apply via levelcode_plan?.
+        teardown(@object.customer) if levelcode_plan?(lookup_key_for(@object))
       end
     rescue Stripe::StripeError => e
       Rails.logger.error("[Levelcode::WebhookSync] Stripe error on #{@event.type}: #{e.class}: #{e.message}")

--- a/spec/requests/api/v1/webhooks_spec.rb
+++ b/spec/requests/api/v1/webhooks_spec.rb
@@ -105,12 +105,14 @@ RSpec.describe "Api::V1::Webhooks", type: :request do
                                 cancel_at_period_end: false,
                                 price_id: "price_test123",
                                 plan_nickname: "Pro",
-                                price_nickname: "Pro Monthly")
+                                price_nickname: "Pro Monthly",
+                                lookup_key: nil)
     plan_double = double("stripe_plan", product: product_id, interval: interval, nickname: plan_nickname)
-    # `lookup_key` is what Levelcode::WebhookSync (invoked on every webhook via the
-    # shared controller) reads to detect an LevelCode Cloud plan; shortener prices
-    # don't set one, so a real Stripe price returns nil here — mirror that.
-    price_double = double("stripe_price", id: price_id, nickname: price_nickname, product: product_id, lookup_key: nil)
+    # `lookup_key` is what both Levelcode::WebhookSync AND the shortener handlers read to
+    # tell the two products apart. Shortener prices don't set one (nil); a LevelCode Cloud
+    # price carries a Levelcode::PLANS key (e.g. "orbits_pro"). Pass `lookup_key:` to
+    # simulate a LevelCode subscription reaching this shared webhook.
+    price_double = double("stripe_price", id: price_id, nickname: price_nickname, product: product_id, lookup_key: lookup_key)
     item_double = double("stripe_item",
                          plan:                 plan_double,
                          price:                price_double,
@@ -1081,6 +1083,86 @@ RSpec.describe "Api::V1::Webhooks", type: :request do
         it "returns 200 without raising" do
           post_stripe_webhook(event)
           expect(response).to have_http_status(:ok)
+        end
+      end
+    end
+
+    # ── Product-key routing: LevelCode Cloud events must NOT touch the shortener ──
+    #
+    # One Stripe account hosts both products. Levelcode::WebhookSync owns LevelCode
+    # subscriptions (price lookup_key ∈ Levelcode::PLANS) and provisions the CreditWallet.
+    # The shortener handlers must skip them — otherwise a LevelCode purchase resolves to the
+    # user's link-shortener Subscription row and its empty links/qr_codes metadata zeroes the
+    # shortener Plan. Here WebhookSync is stubbed (its own behavior lives in webhook_sync_spec);
+    # we assert only that the SHORTENER side leaves the Plan/Subscription untouched and sends
+    # no shortener email.
+    describe "LevelCode Cloud subscriptions (product-key routing)" do
+      let(:levelcode_sub) { build_stripe_subscription(lookup_key: "orbits_pro") }
+
+      before do
+        user
+        subscription # active shortener subscription
+        plan
+        # Give the shortener Plan distinctive values so we can prove they are NOT modified.
+        plan.update_columns(name: "Shortener Pro", links: 200, qr_codes: 100, brand_pages: 10)
+        allow(Levelcode::WebhookSync).to receive(:call) # isolate the shortener side
+        ActionMailer::Base.deliveries.clear
+      end
+
+      context "checkout.session.completed" do
+        let(:obj)   { build_checkout_session(customer: user.stripe_id) }
+        let(:event) { build_event("checkout.session.completed", obj) }
+
+        before { allow(Stripe::Subscription).to receive(:retrieve).and_return(levelcode_sub) }
+
+        it "returns 200, leaves the shortener Plan intact, and sends no shortener email" do
+          post_stripe_webhook(event)
+          expect(response).to have_http_status(:ok)
+          expect(plan.reload.name).to eq("Shortener Pro")
+          expect(plan.links).to eq(200)
+          expect(ActionMailer::Base.deliveries).to be_empty
+        end
+      end
+
+      context "invoice.paid" do
+        let(:invoice) { build_invoice(billing_reason: "subscription_cycle") }
+        let(:event)   { build_event("invoice.paid", invoice) }
+
+        before { allow(Stripe::Subscription).to receive(:retrieve).and_return(levelcode_sub) }
+
+        it "returns 200, does not zero the shortener Plan, and sends no shortener email" do
+          post_stripe_webhook(event)
+          expect(response).to have_http_status(:ok)
+          expect(plan.reload.links).to eq(200)
+          expect(subscription.reload.status).to eq("active")
+          expect(ActionMailer::Base.deliveries).to be_empty
+        end
+      end
+
+      context "customer.subscription.updated" do
+        let(:event) { build_event("customer.subscription.updated", levelcode_sub) }
+
+        it "returns 200 and does not touch the shortener Subscription/Plan" do
+          post_stripe_webhook(event)
+          expect(response).to have_http_status(:ok)
+          expect(plan.reload.links).to eq(200)
+          expect(subscription.reload.status).to eq("active")
+          expect(ActionMailer::Base.deliveries).to be_empty
+        end
+      end
+
+      context "customer.subscription.deleted (even when the Stripe sub id matches the shortener row)" do
+        # Worst case: the ids collide. The lookup_key guard must still protect the shortener —
+        # a LevelCode cancellation must not reset the shortener Plan to Free or cancel its sub.
+        let(:levelcode_sub) { build_stripe_subscription(id: stripe_subscription_id, lookup_key: "orbits_pro") }
+        let(:event) { build_event("customer.subscription.deleted", levelcode_sub) }
+
+        it "returns 200 and does NOT cancel the shortener sub or reset its Plan to Free" do
+          post_stripe_webhook(event)
+          expect(response).to have_http_status(:ok)
+          expect(subscription.reload.status).to eq("active")
+          expect(plan.reload.name).to eq("Shortener Pro")
+          expect(ActionMailer::Base.deliveries).to be_empty
         end
       end
     end

--- a/spec/requests/api/v1/webhooks_spec.rb
+++ b/spec/requests/api/v1/webhooks_spec.rb
@@ -403,6 +403,10 @@ RSpec.describe "Api::V1::Webhooks", type: :request do
     # ── checkout.session.async_payment_failed ────────────────────────────────
 
     describe "checkout.session.async_payment_failed" do
+      # The failure handler now resolves the subscription's product before emailing; stub the
+      # retrieve so skip_levelcode_id? sees a shortener price (lookup_key nil) and proceeds normally.
+      before { allow(Stripe::Subscription).to receive(:retrieve).and_return(build_stripe_subscription) }
+
       context "when the user exists" do
         let(:obj)   { build_checkout_session(customer: user.stripe_id) }
         let(:event) { build_event("checkout.session.async_payment_failed", obj) }
@@ -693,6 +697,10 @@ RSpec.describe "Api::V1::Webhooks", type: :request do
     # ── invoice.payment_failed ───────────────────────────────────────────────
 
     describe "invoice.payment_failed" do
+      # The handler resolves the invoice's subscription product before emailing; stub the retrieve
+      # so skip_levelcode_id? sees a shortener price (lookup_key nil) and proceeds normally.
+      before { allow(Stripe::Subscription).to receive(:retrieve).and_return(build_stripe_subscription) }
+
       context "when the user exists" do
         let(:invoice) { build_invoice(customer: user.stripe_id) }
         let(:event)   { build_event("invoice.payment_failed", invoice) }
@@ -735,6 +743,10 @@ RSpec.describe "Api::V1::Webhooks", type: :request do
     # ── invoice.payment_action_required ─────────────────────────────────────
 
     describe "invoice.payment_action_required" do
+      # The handler resolves the invoice's subscription product before emailing; stub the retrieve
+      # so skip_levelcode_id? sees a shortener price (lookup_key nil) and proceeds normally.
+      before { allow(Stripe::Subscription).to receive(:retrieve).and_return(build_stripe_subscription) }
+
       context "when the user exists" do
         let(:invoice) { build_invoice(customer: user.stripe_id) }
         let(:event)   { build_event("invoice.payment_action_required", invoice) }
@@ -1162,6 +1174,32 @@ RSpec.describe "Api::V1::Webhooks", type: :request do
           expect(response).to have_http_status(:ok)
           expect(subscription.reload.status).to eq("active")
           expect(plan.reload.name).to eq("Shortener Pro")
+          expect(ActionMailer::Base.deliveries).to be_empty
+        end
+      end
+
+      context "invoice.payment_failed for a LevelCode subscription" do
+        let(:invoice) { build_invoice(customer: user.stripe_id) }
+        let(:event)   { build_event("invoice.payment_failed", invoice) }
+
+        before { allow(Stripe::Subscription).to receive(:retrieve).and_return(levelcode_sub) }
+
+        it "returns 200 and does NOT send a shortener-branded payment-failed email" do
+          post_stripe_webhook(event)
+          expect(response).to have_http_status(:ok)
+          expect(ActionMailer::Base.deliveries).to be_empty
+        end
+      end
+
+      context "invoice.payment_action_required for a LevelCode subscription" do
+        let(:invoice) { build_invoice(customer: user.stripe_id) }
+        let(:event)   { build_event("invoice.payment_action_required", invoice) }
+
+        before { allow(Stripe::Subscription).to receive(:retrieve).and_return(levelcode_sub) }
+
+        it "returns 200 and does NOT send a shortener-branded action-required email" do
+          post_stripe_webhook(event)
+          expect(response).to have_http_status(:ok)
           expect(ActionMailer::Base.deliveries).to be_empty
         end
       end

--- a/spec/services/levelcode/webhook_sync_spec.rb
+++ b/spec/services/levelcode/webhook_sync_spec.rb
@@ -167,20 +167,39 @@ RSpec.describe Levelcode::WebhookSync do
   end
 
   describe "customer.subscription.deleted" do
-    it "tears the wallet down to free" do
+    it "tears the wallet down to free when a LEVELCODE subscription is canceled" do
       CreditWallet.create!(
         user: user, product: "levelcode", plan_key: "orbits_pro",
         input_cap: 10, output_cap: 10, input_used: 5, output_used: 5,
         period_start: 1.day.ago, period_end: 1.month.from_now, overage_policy: "throttle"
       )
 
-      sub = double("Stripe::Subscription", customer: "cus_test123")
+      sub = stripe_subscription(lookup_key: "orbits_pro")
+      allow(sub).to receive(:customer).and_return("cus_test123")
       described_class.call(event("customer.subscription.deleted", sub))
 
       wallet = CreditWallet.find_by(user: user, product: "levelcode")
       expect(wallet.plan_key).to eq("free")
       expect(wallet.input_cap).to eq(0)
       expect(wallet.input_used).to eq(0)
+    end
+
+    it "does NOT tear down the LevelCode wallet when a SHORTENER subscription is canceled (shared account)" do
+      CreditWallet.create!(
+        user: user, product: "levelcode", plan_key: "orbits_pro",
+        input_cap: 10, output_cap: 10, input_used: 5, output_used: 5,
+        period_start: 1.day.ago, period_end: 1.month.from_now, overage_policy: "throttle"
+      )
+
+      # A link-shortener price carries a non-Levelcode lookup_key.
+      sub = stripe_subscription(lookup_key: "creator_monthly")
+      allow(sub).to receive(:customer).and_return("cus_test123")
+      described_class.call(event("customer.subscription.deleted", sub))
+
+      wallet = CreditWallet.find_by(user: user, product: "levelcode")
+      expect(wallet.plan_key).to eq("orbits_pro") # untouched — the paid LevelCode wallet survives
+      expect(wallet.input_cap).to eq(10)
+      expect(wallet.input_used).to eq(5)
     end
   end
 


### PR DESCRIPTION
Prereq for hosting **both products on one rebranded Stripe account** — and a latent bug **today**.

## The bug
One Stripe account can host both the link shortener and LevelCode Cloud. `Levelcode::WebhookSync` already self-filters to LevelCode prices (`lookup_key` ∈ `Levelcode::PLANS`) and provisions the `CreditWallet`. But the **shortener handlers matched purely by `customer_id`** (`webhooks_controller.rb` `fulfill_checkout_subscription` / `handle_invoice_paid` / `handle_subscription_updated` / `handle_subscription_deleted`). So a **LevelCode purchase's** `checkout.session.completed` / `invoice.paid` events resolved to the user's *shortener* `Subscription` row and, since LevelCode products carry no `links`/`qr_codes` metadata, `sync_subscription` ran `metadata["links"].to_i => 0` and **zeroed the shortener Plan**. A LevelCode cancellation could likewise reset the shortener Plan to Free. Your test LevelCode Pro+ purchase already trips this.

## The fix
A `levelcode_subscription?` guard (mirror of `WebhookSync#levelcode_plan?`) that reads the subscription's price `lookup_key`, plus a `skip_levelcode?` short-circuit at the top of **every** shortener handler (`checkout.session.completed`, `invoice.paid`, `customer.subscription.updated`, `customer.subscription.deleted`, `trial_will_end`). LevelCode events → owned by `WebhookSync`; shortener events → unchanged. One webhook, cleanly routed by product key.

## Tests
New `LevelCode Cloud subscriptions (product-key routing)` block proves each shortener handler leaves the Plan/Subscription untouched and sends no shortener email for a LevelCode sub — including the worst case where the Stripe subscription id collides with the shortener row. **111 examples, 0 failures** across the webhook + `WebhookSync` specs.

Safe to ship independently of the account rebrand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)