### PR TITLE
Add LevelCode Cloud welcome email on first paid purchase

### DIFF
--- a/app/mailers/levelcode_billing_mailer.rb
+++ b/app/mailers/levelcode_billing_mailer.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# LevelCode Cloud transactional (billing) email. Kept separate from SubscriptionMailer — the link
+# shortener's mailer — so its branding and from-address are LevelCode's, not thin.ly's. Renders
+# WITHOUT the shared thin.ly `mailer` layout (`layout false`); the templates are fully self-contained
+# and inline-styled, so no thin.ly chrome leaks into a LevelCode email. Mirrors LevelcodeAuthMailer.
+class LevelcodeBillingMailer < ApplicationMailer
+  layout false
+
+  # The one Rails host serves the account SPA under /ai (see StaticController::LEVELCODE_HOSTS).
+  LEVELCODE_SITE = "https://levelcode.ai"
+
+  # LevelCode-branded sender, overriding the thin.ly default. Point LEVELCODE_MAIL_FROM at a verified
+  # levelcode.ai address once the domain is set up (same knob LevelcodeAuthMailer uses).
+  LEVELCODE_FROM = (ENV["LEVELCODE_MAIL_FROM"].presence || "LevelCode <notifications@thin.ly>").freeze
+
+  # Sent ONCE, on a user's first paid LevelCode Cloud purchase — enqueued best-effort from
+  # Levelcode::WebhookSync#provision_from_stripe_subscription. Plan-centric (no invoice PDF), so the
+  # money-critical webhook path adds no extra Stripe API calls.
+  #
+  # Params (via .with): user:, plan: (a Levelcode::PLANS hash), plan_key:, period_end: (DateTime).
+  def welcome
+    @user        = params[:user]
+    @plan        = params[:plan] || {}
+    @plan_name   = @plan[:name].presence || "Cloud"
+    @price       = format_price(@plan[:price_cents])
+    @turns       = @plan[:turns]
+    @renews_on   = params[:period_end]&.strftime("%B %-d, %Y")
+    @account_url = "#{LEVELCODE_SITE}/ai/account"
+    @pricing_url = "#{LEVELCODE_SITE}/ai/pricing"
+    @download_url = LEVELCODE_SITE
+    @provider_setting = "levelcode.ai.providerMode"
+
+    mail(
+      to: @user.email,
+      from: LEVELCODE_FROM,
+      subject: "Welcome to LevelCode Cloud — your #{@plan_name} plan is active"
+    )
+  end
+
+  private
+
+  def format_price(cents)
+    return nil if cents.blank?
+
+    "$#{cents.to_i / 100}/mo"
+  end
+end

--- a/app/services/levelcode/webhook_sync.rb
+++ b/app/services/levelcode/webhook_sync.rb
@@ -162,7 +162,7 @@ module Levelcode
       ).welcome.deliver_later
       Rails.logger.info("[Levelcode::WebhookSync] Welcome email queued for #{user.email} (plan=#{lookup_key})")
     rescue StandardError => e
-      Rails.logger.error("[Levelcode::WebhookSync] Welcome email enqueue failed for #{user.email}: #{e.message}")
+      Rails.logger.error("[Levelcode::WebhookSync] Welcome email enqueue failed for #{user.email}: #{e.class}: #{e.message}")
     end
 
     def teardown(customer_id)

--- a/app/services/levelcode/webhook_sync.rb
+++ b/app/services/levelcode/webhook_sync.rb
@@ -113,6 +113,13 @@ module Levelcode
 
       wallet = CreditWallet.find_or_initialize_by(user: user, product: PRODUCT)
 
+      # First-ever PAID purchase = the wallet is new OR still on the free plan. FreeTier may have
+      # already created a free wallet the first time this user hit the gateway, so new_record? alone
+      # would miss the common free→paid upgrade. Captured BEFORE update! flips plan_key. Renewals
+      # (invoice.paid subscription_cycle) and upgrades (subscription.updated) see an already-paid key →
+      # false → the welcome email fires exactly once, never on renewal, never duplicated.
+      first_paid_purchase = wallet.new_record? || wallet.plan_key.to_s == Levelcode::FREE_PLAN_KEY
+
       # Treat an ADVANCING period_end as a fresh billing period (roll) and reset the metered counters —
       # even on customer.subscription.updated — so the prior period's spend can't enforce against the
       # new one. A same-period update (card change, cancel toggle) leaves spend untouched.
@@ -140,6 +147,22 @@ module Levelcode
       # otherwise resurrect the pre-reset spend via max(Redis, durable).
       Levelcode::Metering.clear!(wallet) if did_reset
       Rails.logger.info("[Levelcode::WebhookSync] Wallet synced for #{user.email} (plan=#{lookup_key}, reset=#{did_reset})")
+
+      deliver_welcome_email(user, plan, lookup_key, period_end) if first_paid_purchase
+    end
+
+    # Best-effort LevelCode Cloud welcome on the first paid purchase. This MUST NOT raise out of call():
+    # a mailer/enqueue failure is not a Stripe::StripeError, so it would escape WebhookSync, get re-raised
+    # as SyncError by the controller, release Stripe idempotency, and return 500 — making Stripe RETRY a
+    # perfectly healthy paid provision purely because an email couldn't enqueue. So swallow everything and
+    # only log. deliver_later (never deliver_now) keeps SMTP off the webhook request path entirely.
+    def deliver_welcome_email(user, plan, lookup_key, period_end)
+      LevelcodeBillingMailer.with(
+        user: user, plan: plan, plan_key: lookup_key, period_end: period_end
+      ).welcome.deliver_later
+      Rails.logger.info("[Levelcode::WebhookSync] Welcome email queued for #{user.email} (plan=#{lookup_key})")
+    rescue StandardError => e
+      Rails.logger.error("[Levelcode::WebhookSync] Welcome email enqueue failed for #{user.email}: #{e.message}")
     end
 
     def teardown(customer_id)

--- a/app/views/levelcode_billing_mailer/welcome.html.erb
+++ b/app/views/levelcode_billing_mailer/welcome.html.erb
@@ -1,0 +1,147 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="color-scheme" content="light">
+  <title>Welcome to LevelCode Cloud</title>
+</head>
+<body style="margin:0;padding:0;background-color:#f4f1ea;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:#f4f1ea;">
+    <tr>
+      <td align="center" style="padding:32px 16px;">
+        <table role="presentation" width="560" cellpadding="0" cellspacing="0" style="width:560px;max-width:100%;background-color:#ffffff;border:1px solid #e2ddd0;border-radius:14px;overflow:hidden;">
+
+          <!-- Header -->
+          <tr>
+            <td style="padding:28px 40px 20px;border-bottom:1px solid #efe9dc;">
+              <span style="font-family:'Space Grotesk',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Inter,Helvetica,Arial,sans-serif;font-size:20px;font-weight:700;letter-spacing:-0.02em;color:#1b1a17;">LevelCode</span>
+              <span style="font-family:'Space Grotesk',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Inter,Helvetica,Arial,sans-serif;font-size:20px;font-weight:500;letter-spacing:-0.02em;color:#807a6b;">&nbsp;Cloud</span>
+            </td>
+          </tr>
+
+          <!-- Body -->
+          <tr>
+            <td style="padding:36px 40px 8px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Inter,Helvetica,Arial,sans-serif;color:#1b1a17;">
+
+              <h1 style="margin:0 0 14px;font-size:24px;line-height:1.25;font-weight:700;letter-spacing:-0.02em;color:#1b1a17;">
+                Your <%= @plan_name %> plan is active
+                <span style="color:#7C5CD6;">&#10003;</span>
+              </h1>
+
+              <p style="margin:0 0 22px;font-size:15px;line-height:1.6;color:#3f3c34;">
+                Hi <%= @user.email %>, thanks for subscribing. You&rsquo;re on <strong>LevelCode Cloud <%= @plan_name %></strong> —
+                metered access to the flagship coding models straight inside the editor, no API keys to juggle. Here&rsquo;s your plan and how to switch it on.
+              </p>
+
+              <!-- Plan summary -->
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:#faf8f3;border:1px solid #e9e3d6;border-radius:10px;margin:0 0 28px;">
+                <tr>
+                  <td style="padding:18px 20px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Inter,Helvetica,Arial,sans-serif;">
+                    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="font-size:14px;">
+                      <tr>
+                        <td style="padding:5px 0;color:#807a6b;width:130px;">Plan</td>
+                        <td style="padding:5px 0;color:#1b1a17;font-weight:600;">LevelCode Cloud <%= @plan_name %></td>
+                      </tr>
+                      <% if @price.present? %>
+                      <tr>
+                        <td style="padding:5px 0;color:#807a6b;">Price</td>
+                        <td style="padding:5px 0;color:#1b1a17;font-weight:600;"><%= @price %></td>
+                      </tr>
+                      <% end %>
+                      <% if @turns.present? %>
+                      <tr>
+                        <td style="padding:5px 0;color:#807a6b;">Monthly usage</td>
+                        <td style="padding:5px 0;color:#1b1a17;">~<%= @turns %> model turns / month</td>
+                      </tr>
+                      <% end %>
+                      <% if @renews_on.present? %>
+                      <tr>
+                        <td style="padding:5px 0;color:#807a6b;">Renews</td>
+                        <td style="padding:5px 0;color:#1b1a17;"><%= @renews_on %></td>
+                      </tr>
+                      <% end %>
+                    </table>
+                  </td>
+                </tr>
+              </table>
+
+              <!-- Activation steps -->
+              <h2 style="margin:0 0 16px;font-size:16px;font-weight:700;color:#1b1a17;">Switch it on in the editor</h2>
+
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Inter,Helvetica,Arial,sans-serif;">
+                <tr>
+                  <td valign="top" style="width:30px;padding:0 12px 18px 0;">
+                    <div style="width:24px;height:24px;border-radius:12px;background-color:#7C5CD6;color:#ffffff;font-size:13px;font-weight:700;text-align:center;line-height:24px;">1</div>
+                  </td>
+                  <td valign="top" style="padding:0 0 18px;font-size:14px;line-height:1.55;color:#3f3c34;">
+                    <strong style="color:#1b1a17;">Install LevelCode for macOS.</strong>
+                    Grab the latest build from <a href="<%= @download_url %>" style="color:#6847B8;text-decoration:underline;">levelcode.ai</a> if you haven&rsquo;t already.
+                  </td>
+                </tr>
+                <tr>
+                  <td valign="top" style="width:30px;padding:0 12px 18px 0;">
+                    <div style="width:24px;height:24px;border-radius:12px;background-color:#7C5CD6;color:#ffffff;font-size:13px;font-weight:700;text-align:center;line-height:24px;">2</div>
+                  </td>
+                  <td valign="top" style="padding:0 0 18px;font-size:14px;line-height:1.55;color:#3f3c34;">
+                    <strong style="color:#1b1a17;">Sign in.</strong>
+                    In LevelCode, run <em>&ldquo;Sign in to LevelCode&rdquo;</em> from the AI chat. A browser opens, you sign in, and the editor connects to your account automatically.
+                  </td>
+                </tr>
+                <tr>
+                  <td valign="top" style="width:30px;padding:0 12px 18px 0;">
+                    <div style="width:24px;height:24px;border-radius:12px;background-color:#7C5CD6;color:#ffffff;font-size:13px;font-weight:700;text-align:center;line-height:24px;">3</div>
+                  </td>
+                  <td valign="top" style="padding:0 0 18px;font-size:14px;line-height:1.55;color:#3f3c34;">
+                    <strong style="color:#1b1a17;">Turn on your plan.</strong>
+                    Open Settings and set <code style="background-color:#f0ecff;color:#6847B8;padding:2px 6px;border-radius:5px;font-family:'JetBrains Mono',ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:12.5px;"><%= @provider_setting %></code> to <code style="background-color:#f0ecff;color:#6847B8;padding:2px 6px;border-radius:5px;font-family:'JetBrains Mono',ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:12.5px;">gateway</code>. This is the switch that moves AI from your own key over to your metered LevelCode plan.
+                  </td>
+                </tr>
+                <tr>
+                  <td valign="top" style="width:30px;padding:0 12px 4px 0;">
+                    <div style="width:24px;height:24px;border-radius:12px;background-color:#7C5CD6;color:#ffffff;font-size:13px;font-weight:700;text-align:center;line-height:24px;">4</div>
+                  </td>
+                  <td valign="top" style="padding:0 0 4px;font-size:14px;line-height:1.55;color:#3f3c34;">
+                    <strong style="color:#1b1a17;">Pick a model.</strong>
+                    Run <em>&ldquo;LevelCode: AI: Select Model&hellip;&rdquo;</em> — your plan unlocks the full roster (the free tier is limited to the open-weights engine).
+                  </td>
+                </tr>
+              </table>
+
+              <!-- CTA -->
+              <table role="presentation" cellpadding="0" cellspacing="0" style="margin:30px 0 8px;">
+                <tr>
+                  <td style="border-radius:9px;background-color:#7C5CD6;">
+                    <a href="<%= @account_url %>" style="display:inline-block;padding:12px 26px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Inter,Helvetica,Arial,sans-serif;font-size:15px;font-weight:600;color:#ffffff;text-decoration:none;">View your usage &amp; billing</a>
+                  </td>
+                </tr>
+              </table>
+
+              <p style="margin:14px 0 4px;font-size:13px;line-height:1.55;color:#807a6b;">
+                Track usage, download invoices, or cancel anytime from your
+                <a href="<%= @account_url %>" style="color:#6847B8;text-decoration:underline;">account dashboard</a>.
+              </p>
+
+            </td>
+          </tr>
+
+          <!-- Footer -->
+          <tr>
+            <td style="padding:22px 40px 30px;border-top:1px solid #efe9dc;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Inter,Helvetica,Arial,sans-serif;">
+              <p style="margin:0 0 10px;font-size:13px;line-height:1.55;color:#807a6b;">
+                Questions? Just reply to this email — we read every one.
+              </p>
+              <p style="margin:0;font-size:12px;color:#a49d8c;">
+                &copy; <%= Date.today.year %> LevelCode &middot;
+                <a href="https://levelcode.ai/terms" style="color:#807a6b;text-decoration:underline;">Terms</a> &middot;
+                <a href="https://levelcode.ai/privacy" style="color:#807a6b;text-decoration:underline;">Privacy</a>
+              </p>
+            </td>
+          </tr>
+
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/app/views/levelcode_billing_mailer/welcome.text.erb
+++ b/app/views/levelcode_billing_mailer/welcome.text.erb
@@ -1,0 +1,34 @@
+Welcome to LevelCode Cloud
+
+Hi <%= @user.email %>, thanks for subscribing. You're on LevelCode Cloud <%= @plan_name %> —
+metered access to the flagship coding models straight inside the editor, no API keys to juggle.
+
+YOUR PLAN
+  Plan:   LevelCode Cloud <%= @plan_name %>
+<% if @price.present? -%>
+  Price:  <%= @price %>
+<% end -%>
+<% if @turns.present? -%>
+  Usage:  ~<%= @turns %> model turns / month
+<% end -%>
+<% if @renews_on.present? -%>
+  Renews: <%= @renews_on %>
+<% end -%>
+
+SWITCH IT ON IN THE EDITOR
+  1. Install LevelCode for macOS — get the latest build at <%= @download_url %>
+  2. Sign in — in LevelCode, run "Sign in to LevelCode" from the AI chat; a browser
+     opens, you sign in, and the editor connects to your account automatically.
+  3. Turn on your plan — open Settings and set  <%= @provider_setting %>  to  gateway .
+     This is the switch that moves AI from your own key over to your metered LevelCode plan.
+  4. Pick a model — run "LevelCode: AI: Select Model..." to unlock your plan's full roster.
+
+View your usage & billing:
+  <%= @account_url %>
+
+Track usage, download invoices, or cancel anytime from your account dashboard.
+
+Questions? Just reply to this email — we read every one.
+
+© <%= Date.today.year %> LevelCode
+Terms: https://levelcode.ai/terms  ·  Privacy: https://levelcode.ai/privacy

--- a/app/views/levelcode_billing_mailer/welcome.text.erb
+++ b/app/views/levelcode_billing_mailer/welcome.text.erb
@@ -19,7 +19,7 @@ SWITCH IT ON IN THE EDITOR
   1. Install LevelCode for macOS — get the latest build at <%= @download_url %>
   2. Sign in — in LevelCode, run "Sign in to LevelCode" from the AI chat; a browser
      opens, you sign in, and the editor connects to your account automatically.
-  3. Turn on your plan — open Settings and set  <%= @provider_setting %>  to  gateway .
+  3. Turn on your plan — open Settings and set <%= @provider_setting %> to gateway.
      This is the switch that moves AI from your own key over to your metered LevelCode plan.
   4. Pick a model — run "LevelCode: AI: Select Model..." to unlock your plan's full roster.
 

--- a/spec/mailers/levelcode_billing_mailer_spec.rb
+++ b/spec/mailers/levelcode_billing_mailer_spec.rb
@@ -1,0 +1,58 @@
+require "rails_helper"
+
+RSpec.describe LevelcodeBillingMailer, type: :mailer do
+  describe "#welcome" do
+    let(:user) { double("user", email: "dev@example.com") }
+    let(:plan) { Levelcode.plan("orbits_pro") } # real PLANS hash: name "Pro", $20/mo, ~260 turns
+    let(:mail) do
+      described_class.with(
+        user: user, plan: plan, plan_key: "orbits_pro",
+        period_end: Time.utc(2026, 8, 1).to_datetime
+      ).welcome
+    end
+
+    it "sends to the buyer with a LevelCode-branded subject and from-address" do
+      expect(mail.to).to eq([ "dev@example.com" ])
+      expect(mail.subject).to eq("Welcome to LevelCode Cloud — your Pro plan is active")
+      expect(mail[:from].to_s).to include("LevelCode") # display name, not thin.ly's default
+    end
+
+    it "is multipart (html + text)" do
+      expect(mail.html_part).to be_present
+      expect(mail.text_part).to be_present
+    end
+
+    context "the HTML part" do
+      subject(:body) { mail.html_part.body.to_s }
+
+      it "shows the plan, price, and renewal date" do
+        expect(body).to include("LevelCode Cloud Pro")
+        expect(body).to include("$20/mo")
+        expect(body).to include("August 1, 2026")
+      end
+
+      it "gives the verified activation step (providerMode → gateway)" do
+        expect(body).to include("levelcode.ai.providerMode")
+        expect(body).to include("gateway")
+      end
+
+      it "links the account dashboard and carries no thin.ly chrome" do
+        expect(body).to include("https://levelcode.ai/ai/account")
+        expect(body).not_to match(/thin\.ly/i)
+      end
+    end
+
+    it "renders a plain-text alternative with the same activation guidance" do
+      text = mail.text_part.body.to_s
+      expect(text).to include("SWITCH IT ON IN THE EDITOR")
+      expect(text).to include("levelcode.ai.providerMode")
+      expect(text).to include("https://levelcode.ai/ai/account")
+    end
+
+    it "renders gracefully when optional plan fields are missing" do
+      m = described_class.with(user: user, plan: {}, plan_key: "orbits_pro", period_end: nil).welcome
+      expect { m.html_part.body.to_s }.not_to raise_error
+      expect(m.subject).to include("Cloud plan is active") # @plan_name defaults to "Cloud"
+    end
+  end
+end

--- a/spec/services/levelcode/webhook_sync_spec.rb
+++ b/spec/services/levelcode/webhook_sync_spec.rb
@@ -7,6 +7,10 @@ RSpec.describe Levelcode::WebhookSync do
   before do
     allow(Stripe::Customer).to receive(:create).and_return(double(id: "cus_test123"))
     user # materialize
+    # Stub the LevelCode welcome mailer so provisioning tests neither render nor enqueue a real email;
+    # the dedicated block below asserts exactly when it fires.
+    @welcome_delivery = double("delivery", deliver_later: true)
+    allow(LevelcodeBillingMailer).to receive(:with).and_return(double("mailer", welcome: @welcome_delivery))
   end
 
   # A Stripe subscription double whose single item carries the given lookup_key.
@@ -211,6 +215,69 @@ RSpec.describe Levelcode::WebhookSync do
       expect {
         described_class.call(event("customer.subscription.updated", sub))
       }.not_to change(CreditWallet, :count)
+    end
+  end
+
+  describe "LevelCode Cloud welcome email (fires once, on first paid purchase)" do
+    let(:session) { double("session", mode: "subscription", subscription: "sub_123", customer: "cus_test123") }
+
+    before do
+      allow(Stripe::Subscription).to receive(:retrieve).with("sub_123")
+        .and_return(stripe_subscription(lookup_key: "orbits_pro"))
+    end
+
+    def paid_wallet!(plan_key: "orbits_pro", period_end: 1.month.from_now)
+      CreditWallet.create!(
+        user: user, product: "levelcode", plan_key: plan_key,
+        input_cap: 10, output_cap: 10, period_start: 1.day.ago, period_end: period_end, overage_policy: "throttle"
+      )
+    end
+
+    it "queues the welcome on a brand-new wallet (checkout.session.completed)" do
+      described_class.call(event("checkout.session.completed", session))
+
+      expect(LevelcodeBillingMailer).to have_received(:with).with(hash_including(plan_key: "orbits_pro"))
+      expect(@welcome_delivery).to have_received(:deliver_later)
+    end
+
+    it "queues the welcome on a free→paid upgrade (a FREE wallet already exists)" do
+      CreditWallet.create!(
+        user: user, product: "levelcode", plan_key: Levelcode::FREE_PLAN_KEY,
+        input_cap: 0, output_cap: 0, budget_micros: 0,
+        period_start: 2.days.ago, period_end: 1.day.ago, overage_policy: "throttle"
+      )
+
+      described_class.call(event("checkout.session.completed", session))
+
+      expect(LevelcodeBillingMailer).to have_received(:with).with(hash_including(plan_key: "orbits_pro"))
+    end
+
+    it "does NOT queue a welcome on a renewal (already-paid wallet, invoice.paid)" do
+      paid_wallet!(period_end: 1.day.ago)
+      invoice = double("invoice",
+                       parent: double("parent", subscription_details: double("sd", subscription: "sub_123")),
+                       customer: "cus_test123")
+
+      described_class.call(event("invoice.paid", invoice))
+
+      expect(LevelcodeBillingMailer).not_to have_received(:with)
+    end
+
+    it "does NOT queue a welcome on a plan change (already-paid wallet, subscription.updated)" do
+      paid_wallet!
+      sub = stripe_subscription(lookup_key: "orbits_pro_plus")
+      allow(sub).to receive(:customer).and_return("cus_test123")
+
+      described_class.call(event("customer.subscription.updated", sub))
+
+      expect(LevelcodeBillingMailer).not_to have_received(:with)
+    end
+
+    it "is best-effort: an email enqueue failure never escapes as SyncError, and provisioning still commits" do
+      allow(LevelcodeBillingMailer).to receive(:with).and_raise(StandardError, "queue down")
+
+      expect { described_class.call(event("checkout.session.completed", session)) }.not_to raise_error
+      expect(CreditWallet.find_by(user: user, product: "levelcode").plan_key).to eq("orbits_pro")
     end
   end
 end


### PR DESCRIPTION
Closes the loop from #353: a LevelCode purchase now correctly *skips* the thin.ly welcome email, but had nothing to replace it — buyers got only Stripe's receipt, no app-side onboarding. This adds a LevelCode-branded welcome.

## What
`LevelcodeBillingMailer#welcome` — a self-contained, `layout false` email (no thin.ly chrome) with:
- Plan summary (name, price, ~monthly turns, renewal date) — all from `Levelcode::PLANS`, zero extra Stripe calls.
- The **verified** activation steps: install → sign in → **set `levelcode.ai.providerMode` = `gateway`** (the real switch from BYOK to the metered plan — confirmed against the editor; nothing flips it automatically, so the email must say so) → pick a model.
- CTA to the account dashboard (`levelcode.ai/ai/account`), reply-to for support, Terms/Privacy.

## Where it fires
From `Levelcode::WebhookSync#provision_from_stripe_subscription`, gated on a `first_paid_purchase` flag = *wallet is new **or** still on the free plan*. `new_record?` alone would miss the common **free→paid** upgrade (FreeTier pre-creates a free wallet). Both `checkout.session.completed` and `invoice.paid(subscription_create)` funnel through this method, so the welcome fires **exactly once** and never on renewals/upgrades — no `billing_reason` special-casing needed.

**Best-effort:** `deliver_later` + a local `rescue`, so a mailer/enqueue failure can never escape as `SyncError` and trigger a money-critical webhook retry.

## Rendered
Visually verified in a browser (Pro + Max):

| | |
|---|---|
| Branding | "LevelCode Cloud" wordmark, brand-violet (#7C5CD6) accents |
| Steps | numbered, with `providerMode`/`gateway` code chips |
| Footer | reply-to, © LevelCode, Terms/Privacy — **no thin.ly** |

## Tests
New mailer spec (branding, plan, activation copy, no thin.ly, graceful with missing fields) + `WebhookSync` specs proving fire-once on new + free→paid, and NOT on renewal/upgrade, and that an enqueue failure never raises. **126 examples, 0 failures; rubocop clean.**

## Config
`LEVELCODE_MAIL_FROM` (already used by `LevelcodeAuthMailer`) sets the from-address — point it at `notifications@levelcode.ai` once the domain is verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)