### PR TITLE
Render LevelCode sign-in email without the thin.ly mailer layout

### DIFF
--- a/app/mailers/levelcode_auth_mailer.rb
+++ b/app/mailers/levelcode_auth_mailer.rb
@@ -3,6 +3,13 @@
 # LevelCode Cloud passwordless sign-in email. Kept separate from the link-shortener
 # mailers so its branding/from-address are independent (Levelcode::EmailCode).
 class LevelcodeAuthMailer < ApplicationMailer
+  # Render without ApplicationMailer's thin.ly-branded "mailer" layout: the
+  # LevelCode templates are fully self-contained (own LevelCode wordmark + inline
+  # styles), so inheriting that layout would wrap a LevelCode email in a thin.ly
+  # header/footer. Mirrors the self-contained approach used by the LevelCode
+  # billing mailer.
+  layout false
+
   def login_code(email, code)
     @code = code
     @ttl_minutes = (Levelcode::EmailCode::TTL / 60).to_i

--- a/spec/mailers/levelcode_auth_mailer_spec.rb
+++ b/spec/mailers/levelcode_auth_mailer_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe LevelcodeAuthMailer, type: :mailer do
+  describe "login_code" do
+    let(:code) { "123456" }
+    let(:mail) { described_class.login_code("user@example.com", code) }
+
+    it "renders the headers" do
+      expect(mail.subject).to eq("#{code} is your LevelCode sign-in code")
+      expect(mail.to).to eq([ "user@example.com" ])
+    end
+
+    it "renders a self-contained, LevelCode-branded body" do
+      expect(mail.body.encoded).to match("LevelCode")
+      expect(mail.body.encoded).to include(code)
+    end
+
+    # Regression: LevelcodeAuthMailer sets `layout false` so a LevelCode email is
+    # never wrapped in ApplicationMailer's thin.ly-branded "mailer" layout
+    # (thin.ly wordmark header + "© <year> thin.ly" footer with thin.ly links).
+    it "does not wrap the email in the thin.ly mailer layout" do
+      expect(mail.body.encoded).not_to match(/thin\.ly/i)
+    end
+  end
+end


### PR DESCRIPTION
## Problem

`LevelcodeAuthMailer` inherits `layout "mailer"` from `ApplicationMailer`. That layout (`app/views/layouts/mailer.html.erb`) is thin.ly-branded — it renders a **thin.ly** wordmark header and a **"© <year> thin.ly — Smart URL Shortener"** footer with Terms/Privacy/Support links pointing at thin.ly.

The LevelCode passwordless sign-in code email (`app/views/levelcode_auth_mailer/login_code.html.erb`) is a self-contained, LevelCode-branded template — so it currently renders **wrapped in thin.ly chrome**: a LevelCode email showing a thin.ly header + footer.

## Fix

Set `layout false` on `LevelcodeAuthMailer` so the LevelCode template renders on its own (it already ships its own LevelCode wordmark + inline styles), mirroring the self-contained approach used by the LevelCode billing mailer.

Because the template was already fully self-contained, `layout false` is sufficient — no template changes were needed.

## Test

Added `spec/mailers/levelcode_auth_mailer_spec.rb` asserting the sign-in email body contains `"LevelCode"` and does **not** match `/thin\.ly/i`. This is a genuine regression guard: with the inherited layout it fails (the thin.ly header/footer leaks into the body); with `layout false` it passes.

## Verification

- `bundle exec rspec spec/mailers` → **22 examples, 0 failures**
- Confirmed the new layout assertion **fails** when `layout false` is reverted (thin.ly footer leaks into the html part) and **passes** with the fix.
- `bundle exec rubocop app/mailers/levelcode_auth_mailer.rb spec/mailers/levelcode_auth_mailer_spec.rb` → **no offenses**

🤖 Generated with [Claude Code](https://claude.com/claude-code)