### PR TITLE
feat(levelcode): show account-dashboard credits at the paid amount (not the cost budget)

### DIFF
--- a/app/controllers/api/levelcode/v1/account_controller.rb
+++ b/app/controllers/api/levelcode/v1/account_controller.rb
@@ -30,14 +30,17 @@ module Api
             plan: current_plan_name,
             model: ::Levelcode.gateway_model(wallet&.plan_key),
             # Credits (M14): the DOLLAR budget is the enforced allowance; token fields are informational.
-            # budget_micros is the full monthly allowance; credits_remaining_micros is measured against the
-            # currently-UNLOCKED ceiling (rolling usage windows) so the UI never shows more than
+            # These four figures are RETAIL micro-$ — what the customer PAID (cost ÷ margin), not the
+            # internal cost budget — so a $40 plan reads "$40" here while metering/enforcement stay in
+            # cost dollars and "≈ turns left" (below) is unaffected. See Levelcode.retail_micros.
+            # budget_micros is the full monthly allowance; credits_remaining_micros is measured against
+            # the currently-UNLOCKED ceiling (rolling usage windows) so the UI never shows more than
             # enforcement will actually serve. next_unlock_at is when more unlocks (nil if all is, or
             # tranching is off). With tranching disabled these equal the full-budget values as before.
-            budget_micros: state ? state[:full_micros] : 0,
-            ceiling_micros: state ? state[:ceiling_micros] : 0,
-            spent_micros: state ? state[:spent_micros] : 0,
-            credits_remaining_micros: state ? state[:remaining_micros] : 0,
+            budget_micros: state ? retail(state[:full_micros]) : 0,
+            ceiling_micros: state ? retail(state[:ceiling_micros]) : 0,
+            spent_micros: state ? retail(state[:spent_micros]) : 0,
+            credits_remaining_micros: state ? retail(state[:remaining_micros]) : 0,
             next_unlock_at: state ? state[:next_unlock_at] : nil,
             input_used: in_used,
             input_cap: wallet&.input_cap.to_i,
@@ -56,15 +59,18 @@ module Api
           wallet = current_wallet
           state = wallet ? ::Levelcode::Metering.tranche_state(wallet) : nil
           # turns-left is computed from what's usable NOW (the unlocked ceiling), not the full budget.
+          # Keep this in COST micro-$ — roster_for divides it by each model's real per-turn cost, so the
+          # turns are margin-independent. Only the customer-facing dollar figures are shown at RETAIL.
           remaining = state ? state[:remaining_micros] : 0
 
           render json: {
             plan: current_plan_name,
             default_model: ::Levelcode.default_model(current_plan_key),
-            budget_micros: state ? state[:full_micros] : 0,
-            ceiling_micros: state ? state[:ceiling_micros] : 0,
-            spent_micros: state ? state[:spent_micros] : 0,
-            credits_remaining_micros: remaining,
+            # Retail micro-$ (what the customer paid) — see #usage + Levelcode.retail_micros.
+            budget_micros: state ? retail(state[:full_micros]) : 0,
+            ceiling_micros: state ? retail(state[:ceiling_micros]) : 0,
+            spent_micros: state ? retail(state[:spent_micros]) : 0,
+            credits_remaining_micros: retail(remaining),
             next_unlock_at: state ? state[:next_unlock_at] : nil,
             models: ::Levelcode.roster_for(current_plan_key, remaining)
           }, status: :ok
@@ -89,6 +95,12 @@ module Api
 
         def current_plan_key
           current_wallet&.plan_key || "free"
+        end
+
+        # Present an internal COST micro-$ figure as the RETAIL amount the customer paid (cost ÷ margin
+        # for a paid plan; unchanged for free). See Levelcode.retail_micros.
+        def retail(cost_micros)
+          ::Levelcode.retail_micros(cost_micros, current_plan_key)
         end
 
         # Friendly plan label for display (e.g. "Pro") — the Levelcode plan NAME, not the

--- a/lib/levelcode.rb
+++ b/lib/levelcode.rb
@@ -309,6 +309,19 @@ module Levelcode
       (p[:price_cents] / 100.0 * CREDIT_COGS_RATIO * 1_000_000).round
     end
 
+    # Convert an internal COST-denominated micro-$ figure (the unit the wallet budget + metering are
+    # enforced in — what a request actually costs at the wire) into the RETAIL micro-$ the CUSTOMER
+    # sees, i.e. what they PAID. Because a paid plan's budget_micros == price × CREDIT_COGS_RATIO,
+    # dividing by the ratio yields the price; spent/remaining scale the same way, so the gross margin
+    # is preserved and "≈ turns left" (computed from the cost balance) is unchanged — only the dollar
+    # headline on the dashboard rises from the cost budget to the amount actually paid. The free tier
+    # has no price (its budget is a raw cost figure), so it is shown as-is.
+    def retail_micros(cost_micros, plan_key)
+      return cost_micros.to_i if plan_key.blank? || plan_key.to_s == FREE_PLAN_KEY || CREDIT_COGS_RATIO <= 0
+
+      (cost_micros.to_f / CREDIT_COGS_RATIO).round
+    end
+
     # The free tier's DOLLAR budget (micro-$): its token caps run on the open-weights engine
     # (worst case, no cache credit) — ~$0.30/mo. This is the hard ceiling free users burn.
     # FREE_MODEL is ENV-overridable, so fall back to the canonical gpt-oss rates if the override

--- a/spec/models/levelcode_model_catalog_spec.rb
+++ b/spec/models/levelcode_model_catalog_spec.rb
@@ -75,6 +75,26 @@ RSpec.describe "Levelcode credit economics (M14)" do
     end
   end
 
+  describe ".retail_micros — the dashboard denomination (what the customer PAID)" do
+    it "scales the cost budget back up to the plan PRICE (cost ÷ margin)" do
+      # budget_micros == price × 0.50, so retail(budget) == the full price the user paid.
+      { "orbits_pro" => 20_000_000, "orbits_pro_plus" => 40_000_000,
+        "orbits_max" => 60_000_000, "orbits_ultra" => 100_000_000 }.each do |key, price_micros|
+        expect(Levelcode.retail_micros(Levelcode.budget_micros(key), key)).to eq(price_micros)
+      end
+    end
+
+    it "scales spend by the same factor (preserving the spent/budget ratio, so % and turns-left hold)" do
+      cost = Levelcode.budget_micros("orbits_pro_plus")            # $20 cost
+      expect(Levelcode.retail_micros(cost / 2, "orbits_pro_plus")).to eq(20_000_000) # half the cost → half of $40
+    end
+
+    it "leaves the free tier (no price) untouched" do
+      expect(Levelcode.retail_micros(300_000, "free")).to eq(300_000)
+      expect(Levelcode.retail_micros(300_000, nil)).to eq(300_000)
+    end
+  end
+
   describe ".turns_for — equivalent turns a budget buys on a model" do
     it "reproduces the turn counts for the $10 Pro budget (50% of revenue)" do
       expect(Levelcode.turns_for("orbits_pro", "moonshotai/kimi-k2.7-code")).to be_within(2).of(260)

--- a/spec/requests/api/levelcode/v1/account_spec.rb
+++ b/spec/requests/api/levelcode/v1/account_spec.rb
@@ -120,9 +120,11 @@ RSpec.describe "Api::Levelcode::V1::Account", type: :request do
         expect(response).to have_http_status(:ok)
         body = response.parsed_body
         expect(body["plan"]).to eq("Pro") # friendly Levelcode name, not the raw "orbits_pro" key
-        expect(body["budget_micros"]).to eq(Levelcode.budget_micros("orbits_pro"))
-        expect(body["spent_micros"]).to eq(5_000_000)
-        expect(body["credits_remaining_micros"]).to eq(Levelcode.budget_micros("orbits_pro") - 5_000_000)
+        # Retail credits: the API shows what the user PAID — the $20 price — not the $10 cost budget.
+        expect(body["budget_micros"]).to eq(20_000_000)
+        expect(body["budget_micros"]).to eq(Levelcode.retail_micros(Levelcode.budget_micros("orbits_pro"), "orbits_pro"))
+        expect(body["spent_micros"]).to eq(Levelcode.retail_micros(5_000_000, "orbits_pro"))
+        expect(body["credits_remaining_micros"]).to eq(Levelcode.retail_micros(Levelcode.budget_micros("orbits_pro") - 5_000_000, "orbits_pro"))
         expect(body["input_used"]).to eq(1_234)
         expect(body["input_cap"]).to eq(15_000_000)
         expect(body["output_used"]).to eq(567)
@@ -150,9 +152,9 @@ RSpec.describe "Api::Levelcode::V1::Account", type: :request do
         get USAGE_URL
 
         body = response.parsed_body
-        expect(body["budget_micros"]).to eq(full)                 # full monthly allowance unchanged
-        expect(body["ceiling_micros"]).to eq(full / 3)            # only the first tranche is unlocked
-        expect(body["credits_remaining_micros"]).to eq(full / 3)  # remaining is vs the ceiling, NOT the full budget
+        expect(body["budget_micros"]).to eq(Levelcode.retail_micros(full, "orbits_pro"))          # full allowance, retail
+        expect(body["ceiling_micros"]).to eq(Levelcode.retail_micros(full / 3, "orbits_pro"))     # only the first tranche is unlocked
+        expect(body["credits_remaining_micros"]).to eq(Levelcode.retail_micros(full / 3, "orbits_pro")) # vs the ceiling, NOT the full budget
         expect(body["next_unlock_at"]).to be_present              # and we say when more unlocks
       end
     end


### PR DESCRIPTION
## Problem

The account dashboard showed **"compute credits: \$20 left this period"** for a **\$40 Pro+** plan. That \$20 is the internal **cost** budget — `budget_micros = price × CREDIT_COGS_RATIO` (0.50), i.e. the margin already removed. To a customer it reads as *"half my money is missing."*

## Fix

Show what the customer **paid**, and let the margin do the conversion.

- New `Levelcode.retail_micros(cost_micros, plan_key)` — for a paid plan, `cost ÷ ratio == the price` (since `budget_micros == price × ratio`); the **free tier has no price**, so it's returned unchanged.
- `GET /account/usage` and `GET /account/models` now render their four dollar fields — `budget_micros` / `ceiling_micros` / `spent_micros` / `credits_remaining_micros` — at **retail** via that helper.
- **Internal metering/enforcement are untouched** (the wallet still stores the cost budget), and **"≈ turns left" is unchanged** — it's computed from the *cost* `remaining` still passed to `roster_for`.

The elegant part: `%` used is `spent/ceiling` (ratio-invariant) and turns-left is server-computed from cost — so **no SPA change or rebuild is needed**. The client just divides micros by 1e6 for display and now shows the bigger number.

## Verified end-to-end (Pro+)

```
Pro+ header now: $40 credits (internal cost budget was $20)
turns-left unchanged: kimi=521 (1.0x), opus=78 (6.67x)
```

kimi=521 / opus=78 match the shipped dashboard exactly — only the dollar headline moved \$20 → \$40. Margin preserved.

## Tests

- `retail_micros` unit tests: each tier's retail == its **price** (\$20/\$40/\$60/\$100), spend scales by the same factor, free untouched.
- Account request specs updated to expect the retail figures (e.g. `budget_micros == 20_000_000` for Pro; tranched ceiling scaled too). The `turns_left ≈ 260` assertion is **unchanged** — the invariant holding is the proof.
- **94 levelcode request specs green**, rubocop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)