### PR TITLE
Add editor update feed — fixes 'Check for Updates' invalid-response error

### DIFF
--- a/app/controllers/api/updates_controller.rb
+++ b/app/controllers/api/updates_controller.rb
@@ -20,8 +20,12 @@ class Api::UpdatesController < ApplicationController
     response.set_header("Cache-Control", "no-store")
 
     rel = latest_release(params[:target], params[:quality])
-    # Nothing published for this target/quality, or the running build is already the latest → up to date.
-    return head(:no_content) if rel.blank? || rel[:commit].blank? || rel[:commit] == params[:commit]
+    # 204 (up to date) when there's nothing published, the entry is INCOMPLETE (missing a field the updater
+    # needs to install — a 200 with null url/version would re-trigger the "invalid response"), or the
+    # running build is already the latest.
+    return head(:no_content) if rel.blank? ||
+                                rel[:commit].blank? || rel[:url].blank? || rel[:product_version].blank? ||
+                                rel[:commit] == params[:commit]
 
     render json: {
       version: rel[:commit], # the latest build's commit — the editor compares this to the running commit
@@ -51,7 +55,10 @@ class Api::UpdatesController < ApplicationController
 
   def parsed_feed
     raw = ENV["LEVELCODE_UPDATE_FEED"].presence
-    raw ? JSON.parse(raw) : {}
+    parsed = raw ? JSON.parse(raw) : {}
+    # Valid JSON that isn't an object (e.g. `null`, `[]`, a scalar) → treat as empty, so `latest_release`
+    # never hits a NoMethodError on `dig` and gets shunted to the rescue path. Keeps behavior deterministic.
+    parsed.is_a?(Hash) ? parsed : {}
   rescue JSON::ParserError => e
     Rails.logger.warn("[Api::Updates] bad LEVELCODE_UPDATE_FEED JSON: #{e.message}")
     {}

--- a/app/controllers/api/updates_controller.rb
+++ b/app/controllers/api/updates_controller.rb
@@ -1,0 +1,59 @@
+# LevelCode editor update feed — the Code-OSS update contract the desktop editor speaks.
+#
+# The editor GETs  /api/update/:target/:quality/:commit  (e.g. darwin-arm64/stable/<sha>) and expects:
+#   • 204 No Content  → up to date (no error, no notification)
+#   • 200 { version, productVersion, url, sha256hash, timestamp, releaseNotesUrl }  → a newer build exists
+#     (`version` is the LATEST build's commit; the editor notifies when it differs from the running commit).
+#
+# Today this returns 204 (up to date): it makes the editor's "Check for Updates" report "Up to Date"
+# instead of "The server sent an invalid response" (the old 404 that broke both the native Squirrel updater
+# and the levelcode-updater extension). Real in-app updates on macOS need a Developer-ID-signed .zip feed
+# asset (Squirrel.Mac auto-installs + verifies the signature) — until that ships, users update via the
+# download page and this feed stays quiet. Populate LEVELCODE_UPDATE_FEED to switch it on.
+#
+# FAIL-SAFE: this endpoint must NEVER return 5xx or HTML — the native updater and the extension both treat
+# anything that isn't 204/valid-JSON as an error. Any exception or unknown release resolves to 204.
+class Api::UpdatesController < ApplicationController
+  RELEASE_NOTES_FALLBACK = "https://github.com/levelcodeai/levelcode/releases/latest".freeze
+
+  def show
+    response.set_header("Cache-Control", "no-store")
+
+    rel = latest_release(params[:target], params[:quality])
+    # Nothing published for this target/quality, or the running build is already the latest → up to date.
+    return head(:no_content) if rel.blank? || rel[:commit].blank? || rel[:commit] == params[:commit]
+
+    render json: {
+      version: rel[:commit], # the latest build's commit — the editor compares this to the running commit
+      productVersion: rel[:product_version],
+      url: rel[:url],        # signed .zip feed asset (Squirrel.Mac downloads + installs it)
+      sha256hash: rel[:sha256hash],
+      timestamp: rel[:timestamp] || 0,
+      releaseNotesUrl: rel[:release_notes_url].presence || RELEASE_NOTES_FALLBACK
+    }
+  rescue StandardError => e
+    Rails.logger.warn("[Api::Updates] #{e.class}: #{e.message} — serving 204 (up to date)")
+    head :no_content
+  end
+
+  private
+
+  # The latest published build for a target/quality, or nil. Config-driven (LEVELCODE_UPDATE_FEED, a JSON
+  # map) so the feed is fast and can't be rate-limited; absent/empty → nil → 204 (the notify-via-site state).
+  #   LEVELCODE_UPDATE_FEED = {"darwin-arm64":{"stable":{"commit":"…","product_version":"0.4.0",
+  #                            "url":"…signed.zip","sha256hash":"…","timestamp":0,"release_notes_url":"…"}}}
+  def latest_release(target, quality)
+    return nil if target.blank? || quality.blank?
+
+    entry = parsed_feed.dig(target.to_s, quality.to_s)
+    entry.is_a?(Hash) ? entry.symbolize_keys : nil
+  end
+
+  def parsed_feed
+    raw = ENV["LEVELCODE_UPDATE_FEED"].presence
+    raw ? JSON.parse(raw) : {}
+  rescue JSON::ParserError => e
+    Rails.logger.warn("[Api::Updates] bad LEVELCODE_UPDATE_FEED JSON: #{e.message}")
+    {}
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,11 @@ Rails.application.routes.draw do
   # root "posts#index"
 
   namespace :api, defaults: { format: :json } do
+    # LevelCode editor update feed (Code-OSS contract): GET /api/update/:target/:quality/:commit
+    # → 204 up-to-date (default) or 200 update JSON. Public, no auth. Kept a sibling of the namespaces
+    # so it matches before the "*path" catch-all; the /api/ prefix keeps it off the SPA HTML funnel.
+    get "update/:target/:quality/:commit", to: "updates#show", constraints: { commit: %r{[^/]+} }
+
     namespace :v1 do
       resources :links, only: %i[index show create update destroy], param: :lookup_code do
         collection do

--- a/spec/requests/api/updates_spec.rb
+++ b/spec/requests/api/updates_spec.rb
@@ -82,5 +82,35 @@ RSpec.describe "Api::Updates", type: :request do
         expect(response.content_type.to_s).not_to include("text/html")
       end
     end
+
+    context "FAIL-SAFE — an INCOMPLETE feed entry is treated as unpublished (never a 200 with null fields)" do
+      it "returns 204 when the entry is missing url" do
+        set_feed("darwin-arm64" => { "stable" => { "commit" => "def456newsha", "product_version" => "0.5.0" } })
+        get UPDATE_URL
+        expect(response).to have_http_status(:no_content)
+      end
+
+      it "returns 204 when the entry is missing product_version" do
+        set_feed("darwin-arm64" => { "stable" => { "commit" => "def456newsha", "url" => "https://x/z.zip" } })
+        get UPDATE_URL
+        expect(response).to have_http_status(:no_content)
+      end
+    end
+
+    context "FAIL-SAFE — valid JSON that isn't an object (null / array / scalar)" do
+      it "returns 204 deterministically, without hitting the exception rescue path" do
+        allow(Rails.logger).to receive(:warn)
+        ENV["LEVELCODE_UPDATE_FEED"] = "null"
+        get UPDATE_URL
+        expect(response).to have_http_status(:no_content)
+        expect(Rails.logger).not_to have_received(:warn).with(/Api::Updates/)
+      end
+
+      it "returns 204 for a JSON array too" do
+        ENV["LEVELCODE_UPDATE_FEED"] = "[]"
+        get UPDATE_URL
+        expect(response).to have_http_status(:no_content)
+      end
+    end
   end
 end

--- a/spec/requests/api/updates_spec.rb
+++ b/spec/requests/api/updates_spec.rb
@@ -1,0 +1,86 @@
+require "rails_helper"
+
+# The LevelCode editor update feed (Code-OSS contract). See Api::UpdatesController.
+RSpec.describe "Api::Updates", type: :request do
+  UPDATE_URL = "/api/update/darwin-arm64/stable/abc123runningsha".freeze
+
+  after { ENV.delete("LEVELCODE_UPDATE_FEED") }
+
+  def set_feed(map)
+    ENV["LEVELCODE_UPDATE_FEED"] = map.to_json
+  end
+
+  describe "GET /api/update/:target/:quality/:commit" do
+    context "with no feed configured (the current notify-via-site state)" do
+      it "returns 204 up-to-date (so 'Check for Updates' no longer errors) with no-store" do
+        get UPDATE_URL
+        expect(response).to have_http_status(:no_content)
+        expect(response.body).to eq("")
+        expect(response.headers["Cache-Control"]).to include("no-store")
+      end
+
+      it "is public — never 401/redirect (the updater sends no credentials)" do
+        get UPDATE_URL
+        expect(response).to have_http_status(:no_content)
+      end
+    end
+
+    context "when the running commit already matches the latest build" do
+      before do
+        set_feed("darwin-arm64" => { "stable" => { "commit" => "abc123runningsha", "product_version" => "0.4.0", "url" => "https://x/z.zip" } })
+      end
+
+      it "returns 204 (up to date)" do
+        get UPDATE_URL
+        expect(response).to have_http_status(:no_content)
+      end
+    end
+
+    context "when a NEWER build exists for this target/quality" do
+      before do
+        set_feed("darwin-arm64" => { "stable" => {
+          "commit" => "def456newsha", "product_version" => "0.5.0",
+          "url" => "https://dl.levelcode.ai/LevelCode-arm64.zip", "sha256hash" => "deadbeef",
+          "timestamp" => 1_720_000_000, "release_notes_url" => "https://github.com/levelcodeai/levelcode/releases/tag/v0.5.0"
+        } })
+      end
+
+      it "returns 200 JSON in the exact Code-OSS feed shape" do
+        get UPDATE_URL
+        expect(response).to have_http_status(:ok)
+        body = response.parsed_body
+        expect(body["version"]).to eq("def456newsha") # editor notifies because != running commit
+        expect(body["productVersion"]).to eq("0.5.0")
+        expect(body["url"]).to eq("https://dl.levelcode.ai/LevelCode-arm64.zip")
+        expect(body["sha256hash"]).to eq("deadbeef")
+        expect(body["timestamp"]).to eq(1_720_000_000)
+        expect(body["releaseNotesUrl"]).to eq("https://github.com/levelcodeai/levelcode/releases/tag/v0.5.0")
+      end
+
+      it "falls back to the GitHub releases page when the feed omits release_notes_url" do
+        set_feed("darwin-arm64" => { "stable" => { "commit" => "def456newsha", "product_version" => "0.5.0", "url" => "https://x/z.zip" } })
+        get UPDATE_URL
+        expect(response.parsed_body["releaseNotesUrl"]).to eq("https://github.com/levelcodeai/levelcode/releases/latest")
+      end
+    end
+
+    context "when nothing is published for the requested target" do
+      before { set_feed("win32-x64" => { "stable" => { "commit" => "zzz" } }) }
+
+      it "returns 204 (darwin-arm64 has no entry)" do
+        get UPDATE_URL
+        expect(response).to have_http_status(:no_content)
+      end
+    end
+
+    context "FAIL-SAFE — malformed feed must never 5xx or return HTML" do
+      before { ENV["LEVELCODE_UPDATE_FEED"] = "{not valid json" }
+
+      it "returns 204, not 500 or an HTML error page" do
+        get UPDATE_URL
+        expect(response).to have_http_status(:no_content)
+        expect(response.content_type.to_s).not_to include("text/html")
+      end
+    end
+  end
+end


### PR DESCRIPTION
The LevelCode editor's **Check for Updates** failed with *"The server sent an invalid response. Try again later."* because `levelcode.ai` had **no `/api/update` handler** — the request 404'd, and both the native Squirrel.Mac updater and the `levelcode-updater` extension treat any non-204/JSON response as an error.

## Fix
`Api::UpdatesController#show` speaks the Code-OSS update-feed contract at `GET /api/update/:target/:quality/:commit`:
- **204 No Content** → up to date (default) → the editor shows **"Up to Date"** instead of erroring.
- **200 JSON** `{version, productVersion, url, sha256hash, timestamp, releaseNotesUrl}` when a newer build exists — config-driven via `LEVELCODE_UPDATE_FEED`.
- **FAIL-SAFE:** any exception / bad config / unknown release → **204**, never 5xx or HTML (the updater treats those as errors).

Placed as a sibling of the `api` namespaces so it matches before the SPA `*path` catch-all; the `/api/` prefix keeps it off the SPA HTML funnel. Public, no auth (the updater sends no credentials).

## macOS note
Real in-app auto-*install* still needs a **Developer-ID-signed `.zip`** feed asset (Squirrel.Mac downloads + installs and verifies the signature). Until that ships, this quietly reports up-to-date and users update via the download page. Flip it on by setting `LEVELCODE_UPDATE_FEED` (a JSON map of `target → quality → {commit, product_version, url, …}`).

**7 request specs, 0 failures; rubocop clean.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)