### PR TITLE
fix(levelcode): keep the higher tier's entitlement until period end on downgrade

### DIFF
--- a/app/controllers/api/levelcode/v1/checkouts_controller.rb
+++ b/app/controllers/api/levelcode/v1/checkouts_controller.rb
@@ -24,7 +24,7 @@ module Api
 
           # ── User already has an active levelcode subscription → upgrade / downgrade ──
           if active_stripe_sub.present? && subscription&.status&.in?(%w[active trialing past_due])
-            handle_plan_change(subscription, active_stripe_sub, new_price)
+            handle_plan_change(active_stripe_sub, new_price)
           else
             # ── First purchase: create a Checkout Session ──
             create_checkout_session(new_price)
@@ -35,49 +35,20 @@ module Api
 
         private
 
-        def handle_plan_change(subscription, active_stripe_sub, new_price)
-          stripe_sub = Stripe::Subscription.retrieve(active_stripe_sub)
-          current_price_id = stripe_sub.items.data[0].price.id
-
-          # ── Block same-plan purchase ──
-          if current_price_id == new_price.id
-            return render json: { error: { code: "already_subscribed", message: "You are already subscribed to this plan" } }, status: :unprocessable_content
-          end
-
-          # Determine if this is an upgrade or downgrade by comparing unit amounts
-          current_amount = stripe_sub.items.data[0].price.unit_amount
-          new_amount = new_price.unit_amount
-          upgrading =
-            if current_amount.nil? || new_amount.nil?
-              # If either price has no unit_amount, avoid treating this as an upgrade based on a bogus comparison.
-              false
-            else
-              new_amount > current_amount
-            end
-
-          # ── Upgrade: prorate immediately, Stripe auto-charges the payment method on file.
-          #    If 3DS is needed, Stripe sends the customer an email to confirm.
-          #    The webhook (customer.subscription.updated / invoice.paid) handles all state changes.
-          # ── Downgrade: apply at end of current period so the customer keeps
-          #    their higher-tier access until the period they already paid for ends.
-          Stripe::Subscription.update(
-            active_stripe_sub,
-            items: [ {
-              id: stripe_sub.items.data[0].id,
-              price: new_price.id
-            } ],
-            proration_behavior: upgrading ? "create_prorations" : "none",
-            payment_behavior: "allow_incomplete"
+        # Upgrade → immediate prorated swap; downgrade → a subscription schedule that keeps the current,
+        # higher tier until period end (see Levelcode::PlanChange for why). The webhook syncs the wallet and
+        # announces the immediate upgrade; the service announces the scheduled downgrade.
+        def handle_plan_change(active_stripe_sub, new_price)
+          result = ::Levelcode::PlanChange.call(
+            user: current_user, subscription_id: active_stripe_sub, new_price: new_price
           )
-
-          change_type = upgrading ? "upgraded" : "downgraded"
           render json: {
             status: "plan_changed",
-            change_type: change_type,
-            message: upgrading ?
-              "Your plan has been upgraded. New limits are effective immediately." :
-              "Your plan has been downgraded. Changes take effect at the end of the current billing period."
+            change_type: result.change_type,
+            message: result.message
           }, status: :ok
+        rescue ::Levelcode::PlanChange::SamePlanError
+          render json: { error: { code: "already_subscribed", message: "You are already subscribed to this plan" } }, status: :unprocessable_content
         end
 
         def create_checkout_session(price)

--- a/app/controllers/levelcode/web_controller.rb
+++ b/app/controllers/levelcode/web_controller.rb
@@ -174,10 +174,10 @@ module Levelcode
     # POST /ai/checkout  (JSON, authenticate_user!) — start a subscription, or change plan in place.
     #
     # First purchase → a Stripe Checkout Session; returns { url } for the SPA to redirect to.
-    # Existing active levelcode subscription → change the plan on the SAME Stripe subscription so
-    # Stripe PRORATES (upgrade: immediate prorated charge for the difference; downgrade: applied at
-    # period end, so the customer keeps the tier they already paid for). Returns
-    # { status: "plan_changed", … } with no url. Mirrors
+    # Existing active levelcode subscription → change the plan on the SAME Stripe subscription via
+    # Levelcode::PlanChange (upgrade: immediate prorated charge for the difference; downgrade: a Stripe
+    # subscription schedule that keeps the current, higher tier until period end, so the customer keeps the
+    # allowance they already paid for). Returns { status: "plan_changed", … } with no url. Mirrors
     # Api::Levelcode::V1::CheckoutsController#handle_plan_change. Previously this ALWAYS opened a new
     # Checkout Session, which charged the full new price and could leave a duplicate subscription.
     def checkout
@@ -377,38 +377,17 @@ module Levelcode
       render json: { error: { code: code, message: message } }, status: status
     end
 
-    # Change the plan on an existing levelcode subscription IN PLACE so Stripe prorates, instead of
-    # opening a second full-price Checkout Session. Upgrade → create_prorations (Stripe charges the
-    # prorated difference now on the payment method on file; a 3DS step is emailed by Stripe if
-    # needed). Downgrade → none (the switch applies at period end). The webhook
-    # (customer.subscription.updated / invoice.paid) syncs the wallet + sends the plan-change email.
+    # Change the plan on an existing levelcode subscription IN PLACE (via Levelcode::PlanChange) instead of
+    # opening a second full-price Checkout Session. Upgrade → immediate prorated swap; downgrade → a
+    # subscription schedule that defers the switch to period end (see the service for why). Stripe errors
+    # bubble to #checkout's rescue; a same-plan re-purchase is a 422 already_subscribed.
     def change_levelcode_plan(stripe_sub_id, new_price)
-stripe_sub = Stripe::Subscription.retrieve(stripe_sub_id)
-item = stripe_sub.items&.data&.first
-return render_error("stripe_error", "Could not change plan. Please try again.", :bad_gateway) unless item&.price
-      if item.price.id == new_price.id
-        return render_error("already_subscribed", "You're already on this plan.", :unprocessable_content)
-      end
-
-      current_amount = item.price.unit_amount
-      new_amount = new_price.unit_amount
-      # Only treat it as an upgrade on a real numeric increase — never prorate-charge off a nil price.
-      upgrading = !current_amount.nil? && !new_amount.nil? && new_amount > current_amount
-
-      Stripe::Subscription.update(
-        stripe_sub_id,
-        items: [ { id: item.id, price: new_price.id } ],
-        proration_behavior: upgrading ? "create_prorations" : "none",
-        payment_behavior: "allow_incomplete"
+      result = Levelcode::PlanChange.call(
+        user: current_user, subscription_id: stripe_sub_id, new_price: new_price
       )
-
-      render json: {
-        status: "plan_changed",
-        change_type: upgrading ? "upgraded" : "downgraded",
-        message: upgrading ?
-          "Your plan is upgraded — the new limits are effective now, and you were charged only the prorated difference." :
-          "Your plan will change at the end of your current billing period. You keep your current plan until then."
-      }
+      render json: { status: "plan_changed", change_type: result.change_type, message: result.message }
+    rescue Levelcode::PlanChange::SamePlanError
+      render_error("already_subscribed", "You're already on this plan.", :unprocessable_content)
     end
   end
 end

--- a/app/mailers/levelcode_billing_mailer.rb
+++ b/app/mailers/levelcode_billing_mailer.rb
@@ -38,8 +38,10 @@ class LevelcodeBillingMailer < ApplicationMailer
     )
   end
 
-  # Sent when an existing subscriber moves between paid plans (upgrade or downgrade) — enqueued
-  # best-effort from Levelcode::WebhookSync#provision_from_stripe_subscription on a paid→paid change.
+  # Sent when an existing subscriber moves between paid plans.
+  #   upgrade   — enqueued best-effort from Levelcode::WebhookSync, which observes the immediate flip.
+  #   downgrade — enqueued best-effort from Levelcode::PlanChange when the change is SCHEDULED, since the
+  #               switch itself is deferred to period end and the webhook only sees it a month later.
   #
   # Params (via .with): user:, from_plan: (old PLANS hash), plan: (new PLANS hash), plan_key:,
   #   direction: "upgrade" | "downgrade", period_end: (DateTime — the current period's end).
@@ -52,7 +54,9 @@ class LevelcodeBillingMailer < ApplicationMailer
     @plan_name   = plan_name(@plan)
     @price       = format_price(@plan[:price_cents])
     @turns       = @plan[:turns]
-    # Downgrades apply at period end (proration_behavior "none"); upgrades are immediate/prorated.
+    # A downgrade is deferred to the period boundary by a Stripe subscription schedule, so this date is BOTH
+    # when the new rate starts AND when the current (higher) plan's limits stop — the customer keeps the
+    # tier they already paid for until then. Upgrades are immediate/prorated, so it's just the renewal date.
     @effective_on = params[:period_end]&.strftime("%B %-d, %Y")
     @account_url = "#{LEVELCODE_SITE}/ai/account"
 

--- a/app/services/levelcode/plan_change.rb
+++ b/app/services/levelcode/plan_change.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+module Levelcode
+  # Change the plan on an EXISTING levelcode Stripe subscription (upgrade or downgrade), shared by the two
+  # checkout entry points (Levelcode::WebController#checkout and Api::Levelcode::V1::CheckoutsController).
+  # Both used to duplicate this logic; the downgrade path below is subtle enough that it must not drift
+  # between them, so it lives here.
+  #
+  # UPGRADE (new price > current): swap the item price IMMEDIATELY with create_prorations — Stripe charges
+  # the prorated difference on the payment method on file (Stripe emails a 3DS step if needed) and the
+  # customer.subscription.updated webhook re-provisions the wallet UP right away. Levelcode::WebhookSync
+  # sends the upgrade email, because it observes the change actually landing.
+  #
+  # DOWNGRADE (new price <= current): do NOT swap the item price now. Swapping immediately — even with
+  # proration_behavior "none", which only defers the *charge* — drops the item to the cheaper price on the
+  # Stripe object AT ONCE. customer.subscription.updated then fires and WebhookSync re-provisions the wallet
+  # DOWN mid-period, so a customer who already paid for Ultra loses Ultra's allowance the moment they click
+  # "downgrade" (and plan_key gates the model roster too, not just the caps). Instead we attach a Stripe
+  # SubscriptionSchedule: the CURRENT (higher) price runs until the period they already paid for ends, then
+  # the new price takes over at the boundary. The subscription keeps reporting the higher price until then,
+  # so every mid-period webhook sees the higher plan and the wallet keeps its full entitlement — no webhook
+  # guard or pending-downgrade state required. Because the downgrade is DEFERRED and scheduled HERE (the
+  # webhook never observes it as an immediate flip), this service announces it to the customer.
+  class PlanChange
+    # Raised when the requested price is the plan the subscription is already on — the controllers turn this
+    # into a 422 already_subscribed. Everything else that can go wrong is a Stripe::StripeError, which the
+    # controllers already rescue.
+    SamePlanError = Class.new(StandardError)
+
+    Result = Struct.new(:change_type, :message, keyword_init: true)
+
+    UPGRADE_MESSAGE =
+      "Your plan is upgraded — the new limits are effective now, and you were charged only the " \
+      "prorated difference for the rest of this billing period."
+    DOWNGRADE_MESSAGE =
+      "Your plan will change at the end of your current billing period. You keep your current plan " \
+      "and its limits until then."
+
+    def self.call(...)
+      new(...).call
+    end
+
+    # user:            the buyer (for the downgrade notification email)
+    # subscription_id: the Stripe subscription to modify (the caller already checked it's active)
+    # new_price:       the target Stripe::Price (id, unit_amount, lookup_key)
+    def initialize(user:, subscription_id:, new_price:)
+      @user = user
+      @subscription_id = subscription_id
+      @new_price = new_price
+    end
+
+    def call
+      stripe_sub = Stripe::Subscription.retrieve(@subscription_id)
+      item = stripe_sub.items&.data&.first
+      current_price = item&.price
+      raise Stripe::InvalidRequestError.new("Subscription has no price item to change", "items") unless current_price
+
+      raise SamePlanError if current_price.id == @new_price.id
+
+      if upgrade?(current_price.unit_amount, @new_price.unit_amount)
+        apply_upgrade(stripe_sub, item)
+        Result.new(change_type: "upgraded", message: UPGRADE_MESSAGE)
+      else
+        effective_on = schedule_downgrade(stripe_sub, current_price)
+        notify_downgrade(current_price.lookup_key, effective_on)
+        Result.new(change_type: "downgraded", message: DOWNGRADE_MESSAGE)
+      end
+    end
+
+    private
+
+    # Only a real numeric increase is an upgrade — never prorate-charge off a nil price.
+    def upgrade?(current_amount, new_amount)
+      !current_amount.nil? && !new_amount.nil? && new_amount > current_amount
+    end
+
+    # Immediate, prorated swap on the same subscription (Stripe charges the difference now).
+    def apply_upgrade(stripe_sub, item)
+      Stripe::Subscription.update(
+        stripe_sub.id,
+        items: [ { id: item.id, price: @new_price.id } ],
+        proration_behavior: "create_prorations",
+        payment_behavior: "allow_incomplete"
+      )
+    end
+
+    # Attach (or reuse) a subscription schedule so the current price runs to period end and the new (lower)
+    # price takes over at the boundary. Returns the DateTime the downgrade takes effect — the end of the
+    # period the customer already paid for — for the notification email.
+    def schedule_downgrade(stripe_sub, current_price)
+      schedule = existing_schedule(stripe_sub) || Stripe::SubscriptionSchedule.create(from_subscription: stripe_sub.id)
+      phase = current_phase(schedule)
+
+      Stripe::SubscriptionSchedule.update(
+        schedule.id,
+        # "release" hands the subscription back to normal billing once the schedule is done; NEVER "cancel",
+        # which would end the subscription at the boundary instead of downgrading it.
+        end_behavior: "release",
+        proration_behavior: "none",
+        phases: [
+          {
+            items: [ { price: current_price.id, quantity: 1 } ],
+            start_date: phase.start_date,
+            end_date: phase.end_date
+          },
+          {
+            # No start_date → begins exactly when the current phase ends (the paid-through boundary), and no
+            # end_date → runs on indefinitely at the new price.
+            items: [ { price: @new_price.id, quantity: 1 } ]
+          }
+        ]
+      )
+
+      Time.at(phase.end_date).to_datetime
+    end
+
+    # The subscription may already carry a schedule (e.g. a prior deferred downgrade) — reuse it, since
+    # Stripe rejects a second schedule on the same subscription.
+    def existing_schedule(stripe_sub)
+      sched = stripe_sub.respond_to?(:schedule) ? stripe_sub.schedule : nil
+      return nil if sched.blank?
+
+      Stripe::SubscriptionSchedule.retrieve(sched.is_a?(String) ? sched : sched.id)
+    end
+
+    # The phase covering "now" — for a fresh from_subscription schedule that's the only phase; for a reused
+    # one it's whichever phase is currently active (never a completed phase, whose end_date is in the past
+    # and which Stripe would reject as a phase boundary).
+    def current_phase(schedule)
+      now = Time.current.to_i
+      schedule.phases.find { |ph| ph.start_date <= now && (ph.end_date.nil? || now < ph.end_date) } ||
+        schedule.phases.first
+    end
+
+    # Best-effort downgrade notice from the request path. Best-effort for the same reason WebhookSync's
+    # mailers are: a mailer/enqueue hiccup must not fail an otherwise-successful plan change. deliver_later
+    # keeps SMTP off the request path.
+    def notify_downgrade(current_lookup_key, effective_on)
+      LevelcodeBillingMailer.with(
+        user: @user,
+        from_plan: Levelcode.plan(current_lookup_key),
+        plan: Levelcode.plan(@new_price.lookup_key),
+        plan_key: @new_price.lookup_key,
+        direction: "downgrade",
+        period_end: effective_on
+      ).plan_changed.deliver_later
+      Rails.logger.info("[Levelcode::PlanChange] Downgrade email queued for #{@user.email} " \
+                        "(#{current_lookup_key}→#{@new_price.lookup_key}, effective #{effective_on})")
+    rescue StandardError => e
+      Rails.logger.error("[Levelcode::PlanChange] Downgrade email enqueue failed for #{@user.email}: " \
+                         "#{e.class}: #{e.message}")
+    end
+  end
+end

--- a/app/services/levelcode/plan_change.rb
+++ b/app/services/levelcode/plan_change.rb
@@ -9,7 +9,9 @@ module Levelcode
   # UPGRADE (new price > current): swap the item price IMMEDIATELY with create_prorations — Stripe charges
   # the prorated difference on the payment method on file (Stripe emails a 3DS step if needed) and the
   # customer.subscription.updated webhook re-provisions the wallet UP right away. Levelcode::WebhookSync
-  # sends the upgrade email, because it observes the change actually landing.
+  # sends the upgrade email, because it observes the change actually landing. Any attached schedule (a
+  # pending deferred downgrade) is RELEASED first, so it can't reject the update or flip the price back
+  # down at the boundary.
   #
   # DOWNGRADE (new price <= current): do NOT swap the item price now. Swapping immediately — even with
   # proration_behavior "none", which only defers the *charge* — drops the item to the cheaper price on the
@@ -61,7 +63,7 @@ module Levelcode
         apply_upgrade(stripe_sub, item)
         Result.new(change_type: "upgraded", message: UPGRADE_MESSAGE)
       else
-        effective_on = schedule_downgrade(stripe_sub, current_price)
+        effective_on = schedule_downgrade(stripe_sub, item, current_price)
         notify_downgrade(current_price.lookup_key, effective_on)
         Result.new(change_type: "downgraded", message: DOWNGRADE_MESSAGE)
       end
@@ -76,6 +78,7 @@ module Levelcode
 
     # Immediate, prorated swap on the same subscription (Stripe charges the difference now).
     def apply_upgrade(stripe_sub, item)
+      release_schedule(stripe_sub)
       Stripe::Subscription.update(
         stripe_sub.id,
         items: [ { id: item.id, price: @new_price.id } ],
@@ -84,12 +87,30 @@ module Levelcode
       )
     end
 
+    # A previously scheduled (deferred) downgrade must not survive an upgrade: with the schedule still
+    # attached, Stripe either rejects the direct Subscription.update or lets the schedule flip the price
+    # at the boundary anyway — silently undoing the upgrade the customer just paid a proration for.
+    # RELEASE (never cancel) detaches the schedule and leaves the subscription running on its current
+    # item, which the update above then upgrades immediately.
+    def release_schedule(stripe_sub)
+      sched = stripe_sub.respond_to?(:schedule) ? stripe_sub.schedule : nil
+      return if sched.blank?
+
+      Stripe::SubscriptionSchedule.release(sched.is_a?(String) ? sched : sched.id)
+    end
+
     # Attach (or reuse) a subscription schedule so the current price runs to period end and the new (lower)
     # price takes over at the boundary. Returns the DateTime the downgrade takes effect — the end of the
     # period the customer already paid for — for the notification email.
-    def schedule_downgrade(stripe_sub, current_price)
+    def schedule_downgrade(stripe_sub, item, current_price)
       schedule = existing_schedule(stripe_sub) || Stripe::SubscriptionSchedule.create(from_subscription: stripe_sub.id)
       phase = current_phase(schedule)
+      # The paid-through boundary. A fresh from_subscription schedule stamps it on the phase, but a
+      # REUSED schedule's active phase can be OPEN-ENDED (our own final phase carries no end_date, so
+      # once a first scheduled downgrade rolls past its boundary that phase is the active one) — the
+      # item's current_period_end is the authoritative boundary either way. Time.at(nil) must never
+      # happen here, and an end_date-less first phase would be an invalid schedule update.
+      boundary = (phase && phase.end_date) || item.current_period_end
 
       Stripe::SubscriptionSchedule.update(
         schedule.id,
@@ -100,18 +121,21 @@ module Levelcode
         phases: [
           {
             items: [ { price: current_price.id, quantity: 1 } ],
-            start_date: phase.start_date,
-            end_date: phase.end_date
+            start_date: (phase && phase.start_date) || item.current_period_start,
+            end_date: boundary
           },
           {
-            # No start_date → begins exactly when the current phase ends (the paid-through boundary), and no
-            # end_date → runs on indefinitely at the new price.
+            # No start_date → begins exactly when the current phase ends (the paid-through boundary). We pass
+            # no end_date either, but Stripe still gives this final phase ONE billing cycle and then, per
+            # end_behavior, RELEASES the subscription back to normal billing at the new price — where it goes
+            # on renewing indefinitely. So "no end_date" means "one cycle, then released", not "runs forever
+            # on the schedule". Verified against Stripe test mode with a test clock.
             items: [ { price: @new_price.id, quantity: 1 } ]
           }
         ]
       )
 
-      Time.at(phase.end_date).to_datetime
+      Time.at(boundary).to_datetime
     end
 
     # The subscription may already carry a schedule (e.g. a prior deferred downgrade) — reuse it, since

--- a/app/services/levelcode/webhook_sync.rb
+++ b/app/services/levelcode/webhook_sync.rb
@@ -181,16 +181,24 @@ module Levelcode
       Rails.logger.error("[Levelcode::WebhookSync] Welcome email enqueue failed for #{user.email}: #{e.class}: #{e.message}")
     end
 
-    # Best-effort upgrade/downgrade notice on a paid→paid change. Best-effort for the same reason as the
-    # welcome — a mailer failure must not fail an otherwise-healthy provision and trigger a Stripe retry.
+    # Best-effort notice on a paid→paid change. Best-effort for the same reason as the welcome — a mailer
+    # failure must not fail an otherwise-healthy provision and trigger a Stripe retry.
+    #
+    # UPGRADES ONLY. An upgrade lands immediately, so this webhook is where it's first observed and is the
+    # right place to announce it. A downgrade is DEFERRED to period end by Levelcode::PlanChange (a Stripe
+    # subscription schedule), which announces it at request time — when the customer can still act on it.
+    # The wallet therefore only sees the paid→cheaper transition later, when the schedule rolls the
+    # subscription at the boundary; announcing it *there* would be a duplicate, a month late, and would read
+    # as news when the customer already knows. So the webhook stays silent on downgrades.
     def deliver_plan_change_email(user, from_key, plan, plan_key, period_end)
       from_plan = Levelcode.plan(from_key)
-      direction = plan[:price_cents].to_i > from_plan[:price_cents].to_i ? "upgrade" : "downgrade"
+      return if plan[:price_cents].to_i <= from_plan[:price_cents].to_i
+
       LevelcodeBillingMailer.with(
         user: user, from_plan: from_plan, plan: plan, plan_key: plan_key,
-        direction: direction, period_end: period_end
+        direction: "upgrade", period_end: period_end
       ).plan_changed.deliver_later
-      Rails.logger.info("[Levelcode::WebhookSync] Plan-change (#{direction}) email queued for #{user.email} (#{from_key}→#{plan_key})")
+      Rails.logger.info("[Levelcode::WebhookSync] Plan-change (upgrade) email queued for #{user.email} (#{from_key}→#{plan_key})")
     rescue StandardError => e
       Rails.logger.error("[Levelcode::WebhookSync] Plan-change email enqueue failed for #{user.email}: #{e.class}: #{e.message}")
     end

--- a/app/views/levelcode_billing_mailer/plan_changed.html.erb
+++ b/app/views/levelcode_billing_mailer/plan_changed.html.erb
@@ -34,11 +34,15 @@
               </h1>
 
               <p style="margin:0 0 22px;font-size:15px;line-height:1.6;color:#3f3c34;">
-                Hi <%= @user.email %>, your LevelCode Cloud plan changed from
-                <strong><%= @from_name %></strong> to <strong><%= @plan_name %></strong>.
                 <% if @downgrade %>
-                  Your new rate<%= @price.present? ? " (#{@price})" : "" %> starts at your next billing date<%= @effective_on.present? ? ", #{@effective_on}" : "" %>. Your plan details are below.
+                  Hi <%= @user.email %>, your LevelCode Cloud plan will change from
+                  <strong><%= @from_name %></strong> to <strong><%= @plan_name %></strong><%= @effective_on.present? ? " on #{@effective_on}" : " at the end of your current billing period" %>.
+                  Nothing changes today &mdash; you keep your <%= @from_name %> limits for the rest of the billing
+                  period you&rsquo;ve already paid for. Your new rate<%= @price.present? ? " (#{@price})" : "" %> starts
+                  <%= @effective_on.present? ? "on #{@effective_on}" : "then" %>.
                 <% else %>
+                  Hi <%= @user.email %>, your LevelCode Cloud plan changed from
+                  <strong><%= @from_name %></strong> to <strong><%= @plan_name %></strong>.
                   The higher limits are active right away, and you were charged only the prorated difference for the rest of this billing period.
                 <% end %>
               </p>

--- a/app/views/levelcode_billing_mailer/plan_changed.text.erb
+++ b/app/views/levelcode_billing_mailer/plan_changed.text.erb
@@ -6,10 +6,13 @@ YOUR PLAN WILL CHANGE TO <%= @plan_name.upcase %>
 YOU'RE NOW ON <%= @plan_name.upcase %>
 <% end -%>
 
-Hi <%= @user.email %>, your LevelCode Cloud plan changed from <%= @from_name %> to <%= @plan_name %>.
 <% if @downgrade -%>
-Your new rate<%= @price.present? ? " (#{@price})" : "" %> starts at your next billing date<%= @effective_on.present? ? ", #{@effective_on}" : "" %>. Your plan details are below.
+Hi <%= @user.email %>, your LevelCode Cloud plan will change from <%= @from_name %> to <%= @plan_name %><%= @effective_on.present? ? " on #{@effective_on}" : " at the end of your current billing period" %>.
+
+Nothing changes today - you keep your <%= @from_name %> limits for the rest of the billing period you've already paid for. Your new rate<%= @price.present? ? " (#{@price})" : "" %> starts <%= @effective_on.present? ? "on #{@effective_on}" : "then" %>.
 <% else -%>
+Hi <%= @user.email %>, your LevelCode Cloud plan changed from <%= @from_name %> to <%= @plan_name %>.
+
 The higher limits are active right away, and you were charged only the prorated difference for the rest of this billing period.
 <% end -%>
 

--- a/spec/mailers/levelcode_billing_mailer_spec.rb
+++ b/spec/mailers/levelcode_billing_mailer_spec.rb
@@ -78,16 +78,34 @@ RSpec.describe LevelcodeBillingMailer, type: :mailer do
       expect(body).not_to match(/thin\.ly/i)
     end
 
-    it "downgrade: period-end framing with the effective date" do
+    # The downgrade is deferred to the boundary by a Stripe subscription schedule (Levelcode::PlanChange), so
+    # the copy may now promise the customer keeps their CURRENT limits until then. That claim would have been
+    # FALSE before the schedule fix, when the entitlement dropped the moment they clicked downgrade.
+    it "downgrade: future-dated framing that promises the current tier's limits until the boundary" do
       mail = described_class.with(
         user: user, from_plan: pro_plus, plan: pro, plan_key: "orbits_pro",
         direction: "downgrade", period_end: Time.utc(2026, 8, 1).to_datetime
       ).plan_changed
 
       expect(mail.subject).to eq("Your LevelCode Cloud plan will change to Pro")
-      expect(mail.html_part.body.to_s).to match(/next billing date/i)
-      expect(mail.html_part.body.to_s).to include("August 1, 2026")
-      expect(mail.text_part.body.to_s).to match(/next billing date/i)
+      [ mail.html_part.body.to_s, mail.text_part.body.to_s ].each do |body|
+        expect(body).to match(/will change from/i)
+        expect(body).to match(/Nothing changes today/i)
+        expect(body).to include("Pro+ limits")    # the tier they KEEP, not the one they move to
+        expect(body).to include("August 1, 2026") # when it actually switches
+        expect(body).to include("$20/mo")         # the new rate, starting then
+        expect(body).not_to match(/right away/i)  # that's the upgrade framing
+      end
+    end
+
+    it "downgrade: renders without a period_end (falls back to 'end of your current billing period')" do
+      mail = described_class.with(
+        user: user, from_plan: pro_plus, plan: pro, plan_key: "orbits_pro",
+        direction: "downgrade", period_end: nil
+      ).plan_changed
+
+      expect { mail.html_part.body.to_s }.not_to raise_error
+      expect(mail.text_part.body.to_s).to include("end of your current billing period")
     end
   end
 

--- a/spec/requests/api/levelcode/v1/checkouts_spec.rb
+++ b/spec/requests/api/levelcode/v1/checkouts_spec.rb
@@ -37,6 +37,22 @@ RSpec.describe "Api::Levelcode::V1::Checkouts", type: :request do
     allow(Stripe::Price).to receive(:list).and_return(double("price_list", data: []))
   end
 
+  # An existing subscription sitting on `price`, mid-period (paid through 20 days out).
+  def stripe_sub_on(price)
+    item = double("item", id: "si_item123", price: price,
+                          current_period_start: 1.day.ago.to_i, current_period_end: 20.days.from_now.to_i)
+    double("Stripe::Subscription", id: "sub_existing", status: "active", schedule: nil,
+                                   items: double("items", data: [ item ]))
+  end
+
+  def stub_schedule
+    phase = double("phase", start_date: 1.day.ago.to_i, end_date: 20.days.from_now.to_i)
+    sched = double("sched", id: "sub_sched_1", phases: [ phase ])
+    allow(Stripe::SubscriptionSchedule).to receive(:create).and_return(sched)
+    allow(Stripe::SubscriptionSchedule).to receive(:update).and_return(sched)
+    sched
+  end
+
   # ─── Tests ────────────────────────────────────────────────────────────────
 
   describe "POST /api/levelcode/v1/checkouts" do
@@ -111,6 +127,55 @@ RSpec.describe "Api::Levelcode::V1::Checkouts", type: :request do
 
         expect(response).to have_http_status(:ok)
         expect(response.parsed_body["change_type"]).to eq("upgraded")
+      end
+    end
+
+    # ── Downgrade ────────────────────────────────────────────────────────────
+    context "when the user downgrades to a cheaper plan" do
+      let(:existing_sub) { double("Subscription", subscription_id: "sub_existing", status: "active") }
+      let(:ultra_price)  { double("Stripe::Price", id: "price_orbits_ultra", unit_amount: 10_000, lookup_key: "orbits_ultra") }
+
+      before do
+        stub_price_list(pro_price) # moving DOWN to Pro
+        allow(user).to receive(:subscriptions).and_return(double("subs", find_by: existing_sub))
+        allow(Stripe::Subscription).to receive(:retrieve).with("sub_existing").and_return(stripe_sub_on(ultra_price))
+        stub_schedule
+        allow(LevelcodeBillingMailer).to receive(:with)
+          .and_return(double("mailer", plan_changed: double("delivery", deliver_later: true)))
+      end
+
+      # The bug this fixes: an immediate item swap (even with proration_behavior "none") lowers the price on
+      # the Stripe object at once, so the wallet is re-provisioned DOWN mid-period and the customer loses the
+      # Ultra allowance they already paid for.
+      it "does NOT swap the subscription item immediately" do
+        expect(Stripe::Subscription).not_to receive(:update)
+
+        post checkout_url, params: { lookup_key: "orbits_pro" }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body["change_type"]).to eq("downgraded")
+      end
+
+      it "schedules the switch for the period boundary, keeping the higher tier until then" do
+        expect(Stripe::SubscriptionSchedule).to receive(:create).with(from_subscription: "sub_existing")
+          .and_return(double("sched", id: "sub_sched_1",
+                                      phases: [ double("phase", start_date: 1.day.ago.to_i, end_date: 20.days.from_now.to_i) ]))
+        expect(Stripe::SubscriptionSchedule).to receive(:update).with(
+          "sub_sched_1",
+          hash_including(
+            end_behavior: "release",
+            phases: [ hash_including(items: [ { price: "price_orbits_ultra", quantity: 1 } ]),
+                      hash_including(items: [ { price: pro_price_id, quantity: 1 } ]) ]
+          )
+        ).and_return(double("sched"))
+
+        post checkout_url, params: { lookup_key: "orbits_pro" }
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "tells the customer they keep their current plan until the boundary" do
+        post checkout_url, params: { lookup_key: "orbits_pro" }
+        expect(response.parsed_body["message"]).to include("keep your current plan")
       end
     end
 

--- a/spec/requests/levelcode/web_spec.rb
+++ b/spec/requests/levelcode/web_spec.rb
@@ -263,19 +263,32 @@ RSpec.describe 'Levelcode::Web (SPA backend at /ai/*)', type: :request do
       expect(response).to redirect_to('/ai/account')
     end
 
-    def price_double(id:, amount:)
-      double('Stripe::Price', id: id, unit_amount: amount)
+    def price_double(id:, amount:, lookup_key: 'orbits_pro')
+      double('Stripe::Price', id: id, unit_amount: amount, lookup_key: lookup_key)
     end
 
     def stub_price(price)
       allow(Stripe::Price).to receive(:list).and_return(double('price_list', data: [ price ]))
     end
 
-    # Existing Stripe subscription whose single item sits at `amount` (in cents via unit_amount).
-    def stub_current_stripe_sub(amount:, price_id: 'price_current')
-      item = double('item', id: 'si_1', price: double('cur_price', id: price_id, unit_amount: amount))
+    # Existing Stripe subscription whose single item sits at `amount` (in cents via unit_amount), with the
+    # period the customer has already paid for running until 20 days out.
+    def stub_current_stripe_sub(amount:, price_id: 'price_current', lookup_key: 'orbits_ultra')
+      item = double('item', id: 'si_1',
+                            price: double('cur_price', id: price_id, unit_amount: amount, lookup_key: lookup_key),
+                            current_period_start: 1.day.ago.to_i, current_period_end: 20.days.from_now.to_i)
       allow(Stripe::Subscription).to receive(:retrieve).with('sub_x')
-                                                       .and_return(double('sub', items: double('items', data: [ item ])))
+                                                       .and_return(double('sub', id: 'sub_x', schedule: nil,
+                                                                                 items: double('items', data: [ item ])))
+    end
+
+    # A subscription schedule mirroring the current (paid-through) phase.
+    def stub_schedule
+      phase = double('phase', start_date: 1.day.ago.to_i, end_date: 20.days.from_now.to_i)
+      sched = double('sched', id: 'sub_sched_1', phases: [ phase ])
+      allow(Stripe::SubscriptionSchedule).to receive(:create).and_return(sched)
+      allow(Stripe::SubscriptionSchedule).to receive(:update).and_return(sched)
+      sched
     end
 
     context 'first purchase (no active levelcode subscription)' do
@@ -313,15 +326,27 @@ RSpec.describe 'Levelcode::Web (SPA backend at /ai/*)', type: :request do
         expect(json).not_to have_key('url')
       end
 
-      it 'downgrade → applies at period end (proration_behavior none)' do
-        stub_price(price_double(id: 'price_pro', amount: 2000))
-        stub_current_stripe_sub(amount: 10_000) # currently on Ultra
+      # Ultra → Pro must NOT touch the subscription item now: that would drop the wallet to Pro mid-period
+      # via customer.subscription.updated, losing the tier the customer already paid for. It is scheduled at
+      # the period boundary instead.
+      it 'downgrade → schedules the switch at period end, never swaps the item now' do
+        stub_price(price_double(id: 'price_pro', amount: 2000, lookup_key: 'orbits_pro'))
+        stub_current_stripe_sub(amount: 10_000, lookup_key: 'orbits_ultra') # currently on Ultra
+        stub_schedule
         expect(Stripe::Checkout::Session).not_to receive(:create)
-        expect(Stripe::Subscription).to receive(:update).with('sub_x', hash_including(proration_behavior: 'none'))
+        expect(Stripe::Subscription).not_to receive(:update)
+        expect(Stripe::SubscriptionSchedule).to receive(:update).with(
+          'sub_sched_1',
+          hash_including(end_behavior: 'release',
+                         phases: [ hash_including(items: [ { price: 'price_current', quantity: 1 } ]),
+                                   hash_including(items: [ { price: 'price_pro', quantity: 1 } ]) ])
+        ).and_return(double('sched', id: 'sub_sched_1'))
+
         post '/ai/checkout', params: { lookup_key: 'orbits_pro' }
 
         expect(response).to have_http_status(:ok)
         expect(json['change_type']).to eq('downgraded')
+        expect(json['message']).to include('keep your current plan')
       end
 
       it 'same plan → 422 already_subscribed, no Stripe write' do

--- a/spec/services/levelcode/plan_change_spec.rb
+++ b/spec/services/levelcode/plan_change_spec.rb
@@ -1,0 +1,166 @@
+require "rails_helper"
+
+# rubocop:disable Metrics/BlockLength
+RSpec.describe Levelcode::PlanChange do
+  let(:user) { create(:user, stripe_id: "cus_test123") }
+
+  # Period the customer has ALREADY PAID FOR: started yesterday, ends in 20 days. A downgrade must not
+  # touch their entitlement until period_end.
+  let(:period_start) { 1.day.ago.to_i }
+  let(:period_end)   { 20.days.from_now.to_i }
+
+  let(:ultra_price) { double("Stripe::Price", id: "price_ultra", unit_amount: 10_000, lookup_key: "orbits_ultra") }
+  let(:pro_price)   { double("Stripe::Price", id: "price_pro",   unit_amount: 2_000,  lookup_key: "orbits_pro") }
+
+  # An active subscription currently sitting on `price`, with no schedule attached.
+  def stripe_sub(price, schedule: nil)
+    item = double("item", id: "si_1", price: price,
+                          current_period_start: period_start, current_period_end: period_end)
+    double("Stripe::Subscription", id: "sub_x", status: "active",
+                                   schedule: schedule, items: double("items", data: [ item ]))
+  end
+
+  def schedule_double(id: "sub_sched_1")
+    phase = double("phase", start_date: period_start, end_date: period_end)
+    double("Stripe::SubscriptionSchedule", id: id, phases: [ phase ])
+  end
+
+  before do
+    allow(Stripe::Customer).to receive(:create).and_return(double(id: "cus_test123"))
+    user # materialize
+    @delivery = double("delivery", deliver_later: true)
+    @mailer = double("mailer", plan_changed: @delivery)
+    allow(LevelcodeBillingMailer).to receive(:with).and_return(@mailer)
+  end
+
+  def call(new_price)
+    described_class.call(user: user, subscription_id: "sub_x", new_price: new_price)
+  end
+
+  describe "upgrade (Pro → Ultra)" do
+    before do
+      allow(Stripe::Subscription).to receive(:retrieve).with("sub_x").and_return(stripe_sub(pro_price))
+      allow(Stripe::Subscription).to receive(:update).and_return(double("updated"))
+    end
+
+    it "swaps the price IMMEDIATELY and prorates the difference" do
+      expect(Stripe::Subscription).to receive(:update).with(
+        "sub_x",
+        hash_including(
+          items: [ { id: "si_1", price: "price_ultra" } ],
+          proration_behavior: "create_prorations"
+        )
+      ).and_return(double("updated"))
+
+      expect(call(ultra_price).change_type).to eq("upgraded")
+    end
+
+    it "never opens a subscription schedule (upgrades take effect now)" do
+      expect(Stripe::SubscriptionSchedule).not_to receive(:create)
+      expect(Stripe::SubscriptionSchedule).not_to receive(:update)
+      call(ultra_price)
+    end
+
+    it "does NOT email — the webhook announces the upgrade when it observes the flip" do
+      call(ultra_price)
+      expect(LevelcodeBillingMailer).not_to have_received(:with)
+    end
+  end
+
+  describe "downgrade (Ultra → Pro)" do
+    let(:schedule) { schedule_double }
+
+    before do
+      allow(Stripe::Subscription).to receive(:retrieve).with("sub_x").and_return(stripe_sub(ultra_price))
+      allow(Stripe::SubscriptionSchedule).to receive(:create).and_return(schedule)
+      allow(Stripe::SubscriptionSchedule).to receive(:update).and_return(schedule)
+    end
+
+    # THE FIX. An immediate item swap (even with proration_behavior "none") changes the price on the Stripe
+    # object at once, so customer.subscription.updated re-provisions the wallet DOWN mid-period and the
+    # customer loses the tier they already paid for.
+    it "NEVER swaps the subscription item immediately — that is what dropped the entitlement mid-period" do
+      expect(Stripe::Subscription).not_to receive(:update)
+      expect(call(pro_price).change_type).to eq("downgraded")
+    end
+
+    it "schedules the switch at the period boundary: current price until period_end, then the new one" do
+      expect(Stripe::SubscriptionSchedule).to receive(:create).with(from_subscription: "sub_x").and_return(schedule)
+      expect(Stripe::SubscriptionSchedule).to receive(:update).with(
+        "sub_sched_1",
+        hash_including(
+          end_behavior: "release", # never "cancel" — that would END the subscription at the boundary
+          phases: [
+            {
+              items: [ { price: "price_ultra", quantity: 1 } ], # keeps the HIGHER tier they paid for
+              start_date: period_start,
+              end_date: period_end
+            },
+            { items: [ { price: "price_pro", quantity: 1 } ] }  # takes over at period_end, open-ended
+          ]
+        )
+      ).and_return(schedule)
+
+      call(pro_price)
+    end
+
+    it "announces the scheduled downgrade now, dated at the boundary" do
+      call(pro_price)
+
+      expect(LevelcodeBillingMailer).to have_received(:with).with(
+        hash_including(
+          direction: "downgrade",
+          plan_key: "orbits_pro",
+          from_plan: Levelcode.plan("orbits_ultra"),
+          plan: Levelcode.plan("orbits_pro"),
+          period_end: Time.at(period_end).to_datetime
+        )
+      )
+      expect(@delivery).to have_received(:deliver_later)
+    end
+
+    it "reuses an existing schedule rather than creating a second one (Stripe rejects two)" do
+      existing = schedule_double(id: "sub_sched_existing")
+      allow(Stripe::Subscription).to receive(:retrieve).with("sub_x")
+        .and_return(stripe_sub(ultra_price, schedule: "sub_sched_existing"))
+      allow(Stripe::SubscriptionSchedule).to receive(:retrieve).with("sub_sched_existing").and_return(existing)
+
+      expect(Stripe::SubscriptionSchedule).not_to receive(:create)
+      expect(Stripe::SubscriptionSchedule).to receive(:update).with("sub_sched_existing", anything).and_return(existing)
+
+      call(pro_price)
+    end
+
+    it "is best-effort about the email: an enqueue failure never fails the plan change" do
+      allow(LevelcodeBillingMailer).to receive(:with).and_raise(StandardError, "queue down")
+      expect { expect(call(pro_price).change_type).to eq("downgraded") }.not_to raise_error
+    end
+  end
+
+  describe "equal-priced move (no real increase)" do
+    it "is treated as a downgrade — scheduled, never an immediate prorated charge" do
+      same_priced = double("Stripe::Price", id: "price_other", unit_amount: 10_000, lookup_key: "orbits_ultra")
+      allow(Stripe::Subscription).to receive(:retrieve).with("sub_x").and_return(stripe_sub(ultra_price))
+      allow(Stripe::SubscriptionSchedule).to receive(:create).and_return(schedule_double)
+      allow(Stripe::SubscriptionSchedule).to receive(:update).and_return(schedule_double)
+
+      expect(Stripe::Subscription).not_to receive(:update)
+      expect(call(same_priced).change_type).to eq("downgraded")
+    end
+  end
+
+  describe "guards" do
+    it "raises SamePlanError when the price is the one already on the subscription" do
+      allow(Stripe::Subscription).to receive(:retrieve).with("sub_x").and_return(stripe_sub(pro_price))
+      expect { call(pro_price) }.to raise_error(described_class::SamePlanError)
+    end
+
+    it "raises a Stripe error when the subscription has no price item to change" do
+      empty = double("Stripe::Subscription", id: "sub_x", status: "active",
+                                             schedule: nil, items: double("items", data: []))
+      allow(Stripe::Subscription).to receive(:retrieve).with("sub_x").and_return(empty)
+      expect { call(pro_price) }.to raise_error(Stripe::StripeError)
+    end
+  end
+end
+# rubocop:enable Metrics/BlockLength

--- a/spec/services/levelcode/plan_change_spec.rb
+++ b/spec/services/levelcode/plan_change_spec.rb
@@ -58,7 +58,22 @@ RSpec.describe Levelcode::PlanChange do
     it "never opens a subscription schedule (upgrades take effect now)" do
       expect(Stripe::SubscriptionSchedule).not_to receive(:create)
       expect(Stripe::SubscriptionSchedule).not_to receive(:update)
+      expect(Stripe::SubscriptionSchedule).not_to receive(:release)
       call(ultra_price)
+    end
+
+    # Upgrade AFTER a scheduled downgrade: the pending schedule must be detached first, or Stripe
+    # rejects the direct update / the schedule flips the price back down at the boundary anyway.
+    it "releases a pending downgrade schedule BEFORE the immediate swap (never cancels it)" do
+      allow(Stripe::Subscription).to receive(:retrieve).with("sub_x")
+        .and_return(stripe_sub(pro_price, schedule: "sub_sched_pending"))
+
+      expect(Stripe::SubscriptionSchedule).to receive(:release).with("sub_sched_pending").ordered
+      expect(Stripe::Subscription).to receive(:update)
+        .with("sub_x", hash_including(items: [ { id: "si_1", price: "price_ultra" } ])).ordered
+        .and_return(double("updated"))
+
+      expect(call(ultra_price).change_type).to eq("upgraded")
     end
 
     it "does NOT email — the webhook announces the upgrade when it observes the flip" do
@@ -129,6 +144,35 @@ RSpec.describe Levelcode::PlanChange do
       expect(Stripe::SubscriptionSchedule).to receive(:update).with("sub_sched_existing", anything).and_return(existing)
 
       call(pro_price)
+    end
+
+    # A subscriber who already went through one scheduled downgrade has a schedule whose ACTIVE phase is
+    # our open-ended final phase (no end_date). The next downgrade must fall back to the item's
+    # current_period_end — never Time.at(nil), never an end_date-less first phase.
+    it "handles a reused schedule whose active phase is open-ended: the item's period end is the boundary" do
+      open_phase = double("phase", start_date: period_start, end_date: nil)
+      existing = double("Stripe::SubscriptionSchedule", id: "sub_sched_existing", phases: [ open_phase ])
+      allow(Stripe::Subscription).to receive(:retrieve).with("sub_x")
+        .and_return(stripe_sub(ultra_price, schedule: "sub_sched_existing"))
+      allow(Stripe::SubscriptionSchedule).to receive(:retrieve).with("sub_sched_existing").and_return(existing)
+
+      expect(Stripe::SubscriptionSchedule).to receive(:update).with(
+        "sub_sched_existing",
+        hash_including(
+          phases: [
+            {
+              items: [ { price: "price_ultra", quantity: 1 } ],
+              start_date: period_start,
+              end_date: period_end # from the item — the phase has none
+            },
+            { items: [ { price: "price_pro", quantity: 1 } ] }
+          ]
+        )
+      ).and_return(existing)
+
+      expect(call(pro_price).change_type).to eq("downgraded")
+      expect(LevelcodeBillingMailer).to have_received(:with)
+        .with(hash_including(period_end: Time.at(period_end).to_datetime))
     end
 
     it "is best-effort about the email: an enqueue failure never fails the plan change" do

--- a/spec/services/levelcode/webhook_sync_spec.rb
+++ b/spec/services/levelcode/webhook_sync_spec.rb
@@ -304,18 +304,41 @@ RSpec.describe Levelcode::WebhookSync do
       expect(@mailer).not_to have_received(:welcome)
     end
 
-    it "queues a DOWNGRADE email on a paid→cheaper change (Ultra → Pro)" do
+    # Downgrades are deferred to period end by a Stripe subscription schedule and announced by
+    # Levelcode::PlanChange at REQUEST time (see its spec). By the time the wallet sees the paid→cheaper
+    # transition, the schedule has rolled the subscription at the boundary — a month after the customer
+    # asked for it — so announcing it here would be a duplicate arriving as stale news.
+    it "does NOT queue a downgrade email on a paid→cheaper change (Levelcode::PlanChange already announced it)" do
       paid_wallet!(plan_key: "orbits_ultra")
       sub = stripe_subscription(lookup_key: "orbits_pro")
       allow(sub).to receive(:customer).and_return("cus_test123")
 
       described_class.call(event("customer.subscription.updated", sub))
 
-      expect(LevelcodeBillingMailer).to have_received(:with)
-        .with(hash_including(direction: "downgrade", plan_key: "orbits_pro"))
-      expect(@mailer).to have_received(:plan_changed)
-      expect(@welcome_delivery).to have_received(:deliver_later)
+      expect(@mailer).not_to have_received(:plan_changed)
       expect(@mailer).not_to have_received(:welcome)
+    end
+
+    # The wallet still has to LAND the downgrade when the schedule rolls the subscription at the boundary —
+    # silent, but it must actually drop the tier and reset the period's spend.
+    it "still provisions the wallet DOWN when the scheduled downgrade rolls at the period boundary" do
+      old_end = Time.at(1_700_000_000).to_datetime
+      CreditWallet.create!(
+        user: user, product: "levelcode", plan_key: "orbits_ultra",
+        input_cap: 10, output_cap: 10, budget_micros: 50_000_000, spent_micros: 9_000_000,
+        period_start: old_end - 1.month, period_end: old_end, overage_policy: "throttle"
+      )
+      # New period (period_end advances) carrying the now-active cheaper price — i.e. the schedule rolled.
+      sub = stripe_subscription(lookup_key: "orbits_pro", period_start: 1_700_000_000, period_end: 1_705_000_000)
+      allow(sub).to receive(:customer).and_return("cus_test123")
+
+      described_class.call(event("customer.subscription.updated", sub))
+
+      wallet = CreditWallet.find_by(user: user, product: "levelcode")
+      expect(wallet.plan_key).to eq("orbits_pro")
+      expect(wallet.budget_micros).to eq(Levelcode.budget_micros("orbits_pro"))
+      expect(wallet.spent_micros).to eq(0) # fresh period
+      expect(@mailer).not_to have_received(:plan_changed) # still silent — announced at schedule time
     end
 
     it "does NOT queue a plan-change email on a renewal (same plan, invoice.paid)" do


### PR DESCRIPTION
## The bug

On a downgrade (e.g. Ultra $100 → Pro $20) both checkout paths swapped the Stripe subscription item **immediately** with `proration_behavior: "none"`.

That defers only the **charge**. The price on the Stripe object drops at once, so `customer.subscription.updated` fires right away and `WebhookSync#provision_from_stripe_subscription` re-provisions the `CreditWallet` to the cheaper plan's `budget_micros`/caps mid-period.

Net effect: **the customer paid for Ultra this period but lost Ultra's allowance the moment they clicked downgrade** — while still being billed at Ultra until the boundary. Exactly backwards from the intent.

## The fix

A downgrade no longer touches the subscription item. `Levelcode::PlanChange` attaches a Stripe **SubscriptionSchedule**:

- **phase 1** — current (higher) price, through `current_period_end`
- **phase 2** — new price, open-ended, starting at the boundary
- `end_behavior: "release"` (never `"cancel"`, which would *end* the subscription instead of downgrading it)

Because the subscription keeps *reporting* the higher price until the boundary, every mid-period webhook sees the higher plan and the wallet keeps its full entitlement — **no webhook guard, no pending-downgrade state, no new column**. When the schedule rolls, the existing provisioning path lowers the wallet naturally.

Upgrades are untouched: still an immediate `create_prorations` swap.

Both checkout paths (`Levelcode::WebController#checkout`, `Api::Levelcode::V1::CheckoutsController`) now share the service instead of duplicating the logic — the subtle schedule handling can't drift between them. Both controllers got *smaller*.

## Why the schedule, not a webhook guard

Guarding `WebhookSync` was the alternative. Two things decided it:

1. **`plan_key` gates the model roster**, not just the caps (`AiController` → `Levelcode.gateway_model(wallet.plan_key)`). So "keep the entitlement" means keeping `plan_key` at the higher tier too — which rules out the tempting "flip `plan_key` early, hold the caps" shortcut.
2. With the item swapped early, the wallet has no way to tell "already-announced deferred downgrade" from "fresh downgrade", so the downgrade email **re-fires on every unrelated `subscription.updated`** (card change, etc.) during the deferred window. Fixing that needs persisted state.

Making the Stripe object report the truth makes both problems disappear.

## Email ownership

Follows from the above:

- **Upgrade** → announced by `WebhookSync`, which observes it land immediately.
- **Downgrade** → announced by `PlanChange` at **request time**, when the customer can still act on it. The webhook stays silent when the schedule rolls a month later, so there's no duplicate arriving as stale news.

## Copy

The downgrade copy can finally say the thing it always wanted to, because it's now true:

> Nothing changes today — you keep your **Ultra** limits for the rest of the billing period you've already paid for. Your new rate ($20/mo) starts on August 1, 2026.

(Previously the honest-but-thin *"your new rate starts at your next billing date"* from #358, which deliberately avoided claiming limits persist — because they didn't.)

## Verification

- **925 examples, 0 failures** (full suite); rubocop clean across all 12 files.
- New `spec/services/levelcode/plan_change_spec.rb` (11 examples) pins the core guarantee: `expect(Stripe::Subscription).not_to receive(:update)` on a downgrade.
- `spec/requests/api/levelcode/v1/checkouts_spec.rb` **had no downgrade coverage at all** — partly how this shipped. It does now.
- Updated the two specs that asserted the old buggy behavior (`proration_behavior: 'none'`, `/next billing date/i`).
- Rendered the real email to check the copy, not just the assertions.

## Before merging

- [ ] **One manual downgrade in Stripe test mode.** The schedule call shape is mock-verified only; nothing here has hit real Stripe. A wrong `end_behavior` would cancel a subscription rather than downgrade it, so this is worth eyeballing once against the real API.

## Follow-up (not in this PR)

`app/controllers/api/v1/checkouts_controller.rb` (the **link-shortener** product) has the byte-identical immediate-swap pattern *and* the same comment claiming period-end access. Its webhook syncs plan state straight from the Stripe object, so it plausibly drops entitlement early too. Left alone rather than widening a money-path PR; tracked separately.

Related: #356 (proration fix), #358 (plan-change emails).