### PR TITLE
feat(levelcode): GitHub-Releases-backed update feed + unsigned-build guard

### DIFF
--- a/app/controllers/api/updates_controller.rb
+++ b/app/controllers/api/updates_controller.rb
@@ -5,16 +5,22 @@
 #   • 200 { version, productVersion, url, sha256hash, timestamp, releaseNotesUrl }  → a newer build exists
 #     (`version` is the LATEST build's commit; the editor notifies when it differs from the running commit).
 #
-# Today this returns 204 (up to date): it makes the editor's "Check for Updates" report "Up to Date"
-# instead of "The server sent an invalid response" (the old 404 that broke both the native Squirrel updater
-# and the levelcode-updater extension). Real in-app updates on macOS need a Developer-ID-signed .zip feed
-# asset (Squirrel.Mac auto-installs + verifies the signature) — until that ships, users update via the
-# download page and this feed stays quiet. Populate LEVELCODE_UPDATE_FEED to switch it on.
+# The release source, in priority order:
+#   1. LEVELCODE_UPDATE_FEED (env JSON) — the manual override/pin, and later the home of signed
+#      .zip feed assets (Squirrel.Mac auto-installs + verifies the signature).
+#   2. GitHub Releases (Levelcode::EditorReleaseFeed, cached 5 min) — the zero-maintenance default:
+#      publishing a release on levelcodeai/levelcode IS the announcement.
+#
+# UNSIGNED-BUILD GUARD: the built-in Squirrel updater AUTO-DOWNLOADS a 200's url and fails on
+# ad-hoc-signed builds (and the GitHub-backed url is a web page, not a signed .zip). Until signed
+# builds ship (flip LEVELCODE_UPDATE_FEED_SIGNED=1), only the notify-only levelcode-updater
+# extension — which merely OPENS the url — is served a release; everything else gets 204.
 #
 # FAIL-SAFE: this endpoint must NEVER return 5xx or HTML — the native updater and the extension both treat
 # anything that isn't 204/valid-JSON as an error. Any exception or unknown release resolves to 204.
 class Api::UpdatesController < ApplicationController
   RELEASE_NOTES_FALLBACK = "https://github.com/levelcodeai/levelcode/releases/latest".freeze
+  NOTIFY_ONLY_UA_PREFIX = "LevelCode Updater".freeze
 
   def show
     response.set_header("Cache-Control", "no-store")
@@ -26,6 +32,10 @@ class Api::UpdatesController < ApplicationController
     return head(:no_content) if rel.blank? ||
                                 rel[:commit].blank? || rel[:url].blank? || rel[:product_version].blank? ||
                                 rel[:commit] == params[:commit]
+
+    # Unsigned-build guard (see class comment): a newer build exists, but only the notify-only
+    # extension may hear about it until signed feed assets ship.
+    return head(:no_content) unless notify_only_client? || signed_feed?
 
     render json: {
       version: rel[:commit], # the latest build's commit — the editor compares this to the running commit
@@ -42,15 +52,29 @@ class Api::UpdatesController < ApplicationController
 
   private
 
-  # The latest published build for a target/quality, or nil. Config-driven (LEVELCODE_UPDATE_FEED, a JSON
-  # map) so the feed is fast and can't be rate-limited; absent/empty → nil → 204 (the notify-via-site state).
+  # The notify-only levelcode-updater extension identifies itself; the built-in Squirrel updater
+  # (and anything else) does not.
+  def notify_only_client?
+    request.user_agent.to_s.start_with?(NOTIFY_ONLY_UA_PREFIX)
+  end
+
+  # Signed .zip feed assets are live — every client (incl. Squirrel auto-install) may take the 200.
+  def signed_feed?
+    ENV["LEVELCODE_UPDATE_FEED_SIGNED"] == "1"
+  end
+
+  # The latest published build for a target/quality, or nil. The env feed (LEVELCODE_UPDATE_FEED, a JSON
+  # map) wins when it has an entry — the manual pin / signed-asset home; otherwise fall back to the
+  # cached GitHub Releases lookup. Absent both → nil → 204.
   #   LEVELCODE_UPDATE_FEED = {"darwin-arm64":{"stable":{"commit":"…","product_version":"0.4.0",
   #                            "url":"…signed.zip","sha256hash":"…","timestamp":0,"release_notes_url":"…"}}}
   def latest_release(target, quality)
     return nil if target.blank? || quality.blank?
 
     entry = parsed_feed.dig(target.to_s, quality.to_s)
-    entry.is_a?(Hash) ? entry.symbolize_keys : nil
+    return entry.symbolize_keys if entry.is_a?(Hash)
+
+    Levelcode::EditorReleaseFeed.latest(target: target, quality: quality)
   end
 
   def parsed_feed

--- a/app/services/levelcode/editor_release_feed.rb
+++ b/app/services/levelcode/editor_release_feed.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "net/http"
+
+module Levelcode
+  # The GitHub-Releases-backed source for the editor update feed (Api::UpdatesController): the latest
+  # published release of levelcodeai/levelcode, resolved to the Code-OSS feed-entry shape. Publishing
+  # a GitHub release IS the whole announcement — no LEVELCODE_UPDATE_FEED JSON to hand-maintain per
+  # release (that env var remains as an override/pin and as the home of signed assets later).
+  #
+  # Fail-safe by contract: ANY failure (network, rate limit, bad JSON) → nil → the controller's 204.
+  # Cached — positive AND negative — for 5 minutes, so the feed answers fast and two lookups per TTL
+  # stay far inside GitHub's anonymous rate limit (set GITHUB_FEED_TOKEN to lift it anyway).
+  module EditorReleaseFeed
+    module_function
+
+    REPO = "levelcodeai/levelcode"
+    RELEASES_PAGE = "https://github.com/#{REPO}/releases/latest"
+    # Only macOS builds ship today — announcing on other targets would notify users of a build
+    # that does not exist for them.
+    TARGETS = %w[darwin darwin-arm64].freeze
+    CACHE_KEY = "levelcode:editor_release_feed:latest"
+    CACHE_TTL = 5.minutes
+
+    def latest(target:, quality:)
+      return nil unless quality.to_s == "stable" && TARGETS.include?(target.to_s)
+
+      cached = Rails.cache.fetch(CACHE_KEY, expires_in: CACHE_TTL) { fetch_release || :none }
+      cached == :none ? nil : cached
+    rescue StandardError => e
+      Rails.logger.warn("[Levelcode::EditorReleaseFeed] #{e.class}: #{e.message} — serving nil (→ 204)")
+      nil
+    end
+
+    # ---- internals (stub `github_json` in specs) -------------------------------------------------
+
+    def fetch_release
+      rel = github_json("https://api.github.com/repos/#{REPO}/releases/latest")
+      tag = rel && rel["tag_name"].presence
+      return nil if tag.blank? || rel["draft"] || rel["prerelease"]
+
+      # The feed contract compares COMMITS (product.json stamps the build's commit) — resolve the tag.
+      head = github_json("https://api.github.com/repos/#{REPO}/commits/#{ERB::Util.url_encode(tag)}")
+      sha = head && head["sha"].presence
+      return nil if sha.blank?
+
+      {
+        commit: sha,
+        product_version: tag.delete_prefix("v"),
+        # The release PAGE, not a build asset: pre-signing, the only client served a 200 is the
+        # notify-only updater, which merely OPENS this url. Signed .zip feed assets, when they ship,
+        # get pinned via LEVELCODE_UPDATE_FEED (the env override wins over this fallback).
+        url: rel["html_url"].presence || RELEASES_PAGE,
+        sha256hash: nil,
+        timestamp: rel["published_at"].present? ? Time.zone.parse(rel["published_at"]).to_i : 0,
+        release_notes_url: rel["html_url"].presence || RELEASES_PAGE
+      }
+    end
+
+    def github_json(url)
+      uri = URI.parse(url)
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = true
+      http.open_timeout = 3
+      http.read_timeout = 3
+      req = Net::HTTP::Get.new(uri)
+      req["Accept"] = "application/vnd.github+json"
+      req["User-Agent"] = "levelcode.ai update feed"
+      token = ENV["GITHUB_FEED_TOKEN"].presence
+      req["Authorization"] = "Bearer #{token}" if token
+      res = http.request(req)
+      res.is_a?(Net::HTTPSuccess) ? JSON.parse(res.body) : nil
+    end
+  end
+end

--- a/spec/requests/api/updates_spec.rb
+++ b/spec/requests/api/updates_spec.rb
@@ -3,8 +3,16 @@ require "rails_helper"
 # The LevelCode editor update feed (Code-OSS contract). See Api::UpdatesController.
 RSpec.describe "Api::Updates", type: :request do
   UPDATE_URL = "/api/update/darwin-arm64/stable/abc123runningsha".freeze
+  # The notify-only levelcode-updater extension's UA — pre-signing, the only client served a 200.
+  NOTIFY_UA = { "User-Agent" => "LevelCode Updater" }.freeze
 
-  after { ENV.delete("LEVELCODE_UPDATE_FEED") }
+  after do
+    ENV.delete("LEVELCODE_UPDATE_FEED")
+    ENV.delete("LEVELCODE_UPDATE_FEED_SIGNED")
+  end
+
+  # No spec below may hit GitHub — the fallback is stubbed quiet unless a context opts in.
+  before { allow(Levelcode::EditorReleaseFeed).to receive(:latest).and_return(nil) }
 
   def set_feed(map)
     ENV["LEVELCODE_UPDATE_FEED"] = map.to_json
@@ -45,8 +53,8 @@ RSpec.describe "Api::Updates", type: :request do
         } })
       end
 
-      it "returns 200 JSON in the exact Code-OSS feed shape" do
-        get UPDATE_URL
+      it "returns 200 JSON in the exact Code-OSS feed shape (to the notify-only updater)" do
+        get UPDATE_URL, headers: NOTIFY_UA
         expect(response).to have_http_status(:ok)
         body = response.parsed_body
         expect(body["version"]).to eq("def456newsha") # editor notifies because != running commit
@@ -59,8 +67,72 @@ RSpec.describe "Api::Updates", type: :request do
 
       it "falls back to the GitHub releases page when the feed omits release_notes_url" do
         set_feed("darwin-arm64" => { "stable" => { "commit" => "def456newsha", "product_version" => "0.5.0", "url" => "https://x/z.zip" } })
-        get UPDATE_URL
+        get UPDATE_URL, headers: NOTIFY_UA
         expect(response.parsed_body["releaseNotesUrl"]).to eq("https://github.com/levelcodeai/levelcode/releases/latest")
+      end
+    end
+
+    context "UNSIGNED-BUILD GUARD — a newer build exists, but the client matters" do
+      before do
+        set_feed("darwin-arm64" => { "stable" => {
+          "commit" => "def456newsha", "product_version" => "0.5.0", "url" => "https://x/z.zip"
+        } })
+      end
+
+      it "serves 204 to the built-in Squirrel updater (it would auto-download and fail on unsigned builds)" do
+        get UPDATE_URL, headers: { "User-Agent" => "LevelCode/0.5.0 Squirrel/1.0" }
+        expect(response).to have_http_status(:no_content)
+      end
+
+      it "serves 204 to a UA-less client" do
+        get UPDATE_URL
+        expect(response).to have_http_status(:no_content)
+      end
+
+      it "serves the notify-only extension (it only OPENS the url, never installs it)" do
+        get UPDATE_URL, headers: NOTIFY_UA
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "serves EVERY client once signed feed assets ship (LEVELCODE_UPDATE_FEED_SIGNED=1)" do
+        ENV["LEVELCODE_UPDATE_FEED_SIGNED"] = "1"
+        get UPDATE_URL, headers: { "User-Agent" => "LevelCode/0.5.0 Squirrel/1.0" }
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "GitHub-Releases fallback — no env feed configured" do
+      before do
+        allow(Levelcode::EditorReleaseFeed).to receive(:latest)
+          .with(target: "darwin-arm64", quality: "stable")
+          .and_return(
+            commit: "fd81887anewsha", product_version: "0.6.0",
+            url: "https://github.com/levelcodeai/levelcode/releases/tag/v0.6.0",
+            sha256hash: nil, timestamp: 1_784_231_903,
+            release_notes_url: "https://github.com/levelcodeai/levelcode/releases/tag/v0.6.0"
+          )
+      end
+
+      it "announces the release straight from GitHub — publishing a release IS the announcement" do
+        get UPDATE_URL, headers: NOTIFY_UA
+        expect(response).to have_http_status(:ok)
+        body = response.parsed_body
+        expect(body["version"]).to eq("fd81887anewsha")
+        expect(body["productVersion"]).to eq("0.6.0")
+        expect(body["url"]).to eq("https://github.com/levelcodeai/levelcode/releases/tag/v0.6.0")
+      end
+
+      it "the env feed WINS over the GitHub fallback when both exist (the manual pin)" do
+        set_feed("darwin-arm64" => { "stable" => {
+          "commit" => "pinnedsha", "product_version" => "0.6.1", "url" => "https://x/pinned.zip"
+        } })
+        get UPDATE_URL, headers: NOTIFY_UA
+        expect(response.parsed_body["version"]).to eq("pinnedsha")
+      end
+
+      it "returns 204 when the running build IS the GitHub latest" do
+        get "/api/update/darwin-arm64/stable/fd81887anewsha", headers: NOTIFY_UA
+        expect(response).to have_http_status(:no_content)
       end
     end
 

--- a/spec/services/levelcode/editor_release_feed_spec.rb
+++ b/spec/services/levelcode/editor_release_feed_spec.rb
@@ -1,0 +1,64 @@
+require "rails_helper"
+
+# The GitHub-Releases-backed update-feed source. HTTP is stubbed at the `github_json` seam;
+# the test cache store is :null_store, so Rails.cache.fetch executes the block every time.
+RSpec.describe Levelcode::EditorReleaseFeed do
+  RELEASE = {
+    "tag_name" => "v0.6.0",
+    "html_url" => "https://github.com/levelcodeai/levelcode/releases/tag/v0.6.0",
+    "published_at" => "2026-07-16T20:38:23Z",
+    "draft" => false,
+    "prerelease" => false
+  }.freeze
+
+  def stub_github(release: RELEASE, sha: "fd81887a")
+    allow(described_class).to receive(:github_json)
+      .with("https://api.github.com/repos/levelcodeai/levelcode/releases/latest").and_return(release)
+    allow(described_class).to receive(:github_json)
+      .with("https://api.github.com/repos/levelcodeai/levelcode/commits/v0.6.0").and_return(sha && { "sha" => sha })
+  end
+
+  describe ".latest" do
+    it "maps the latest release + tag commit to the feed-entry shape (v-prefix stripped, epoch timestamp)" do
+      stub_github
+      entry = described_class.latest(target: "darwin-arm64", quality: "stable")
+      expect(entry).to eq(
+        commit: "fd81887a",
+        product_version: "0.6.0",
+        url: "https://github.com/levelcodeai/levelcode/releases/tag/v0.6.0",
+        sha256hash: nil,
+        timestamp: Time.zone.parse("2026-07-16T20:38:23Z").to_i,
+        release_notes_url: "https://github.com/levelcodeai/levelcode/releases/tag/v0.6.0"
+      )
+    end
+
+    it "serves both shipped macOS targets, and nothing else (no phantom announcements)" do
+      stub_github
+      expect(described_class.latest(target: "darwin", quality: "stable")).to be_present
+      expect(described_class.latest(target: "win32-x64", quality: "stable")).to be_nil
+      expect(described_class.latest(target: "darwin-arm64", quality: "insider")).to be_nil
+    end
+
+    it "short-circuits unknown targets WITHOUT calling GitHub" do
+      expect(described_class).not_to receive(:github_json)
+      described_class.latest(target: "linux-x64", quality: "stable")
+    end
+
+    it "ignores drafts and prereleases" do
+      stub_github(release: RELEASE.merge("prerelease" => true))
+      expect(described_class.latest(target: "darwin-arm64", quality: "stable")).to be_nil
+    end
+
+    it "returns nil when the tag can't be resolved to a commit" do
+      stub_github(sha: nil)
+      expect(described_class.latest(target: "darwin-arm64", quality: "stable")).to be_nil
+    end
+
+    it "FAIL-SAFE: any exception → nil (the controller's 204), logged, never raised" do
+      allow(described_class).to receive(:github_json).and_raise(SocketError, "getaddrinfo")
+      allow(Rails.logger).to receive(:warn)
+      expect(described_class.latest(target: "darwin-arm64", quality: "stable")).to be_nil
+      expect(Rails.logger).to have_received(:warn).with(/EditorReleaseFeed.*SocketError/)
+    end
+  end
+end


### PR DESCRIPTION
## Why

`Api::UpdatesController` shipped serving a permanent 204 until `LEVELCODE_UPDATE_FEED` was hand-populated — which never happened, so **v0.5.0 installs never learned v0.6.0 existed** (the "There are currently no updates available" bug).

## What

1. **`Levelcode::EditorReleaseFeed`** — GitHub-Releases-backed source: latest published release → `{commit (tag-resolved), product_version, url, timestamp, release_notes_url}`. Cached 5 min (positive **and** negative), fail-safe (any error → nil → 204), macOS-targets-only so no phantom announcements on win32/linux. **Publishing a GitHub release is now the entire announcement workflow.** The env feed stays as the manual pin / future signed-asset home and wins when both exist.
2. **Unsigned-build guard** — Squirrel (the built-in updater) auto-downloads a 200's `url` and fails on ad-hoc-signed builds. Until `LEVELCODE_UPDATE_FEED_SIGNED=1`, only the notify-only extension (UA `LevelCode Updater`, which merely opens the link) is served a release.

## Effect once deployed

Every existing v0.5.0 install gets the "LevelCode 0.6.0 is available — Download / Release Notes" toast within 30s of launch (or ≤4h in the background), with **zero env configuration**. The built-in menu item keeps saying "up to date" until signed builds ship — deliberate, it cannot install anyway.

## Tests

24 examples: UA-gate matrix (Squirrel/UA-less → 204, extension → 200, SIGNED=1 → everyone), env-over-GitHub precedence, GitHub-backed announcement + up-to-date, shape mapping, draft/prerelease skip, no-GitHub-call short-circuit for unknown targets, fail-safe exception path. Rubocop clean.

Optional env: `GITHUB_FEED_TOKEN` (lifts anonymous rate limits; unnecessary with the cache).