### PR TITLE
fix(gateway): always send HTTP-Referer so OpenRouter can attribute our spend

### DIFF
--- a/app/services/levelcode/open_router_adapter.rb
+++ b/app/services/levelcode/open_router_adapter.rb
@@ -136,7 +136,11 @@ module Levelcode
       request["Content-Type"] = "application/json"
       request["Accept"] = "text/event-stream"
       # OpenRouter attribution headers (optional but recommended).
-      request["HTTP-Referer"] = ENV["SITE_ORIGIN"] if ENV["SITE_ORIGIN"].present?
+      # Attribution: OpenRouter groups spend by app using HTTP-Referer. This was conditional on
+      # SITE_ORIGIN being set — and it isn't in production — so every gateway generation logged as
+      # "Unknown" and our OpenRouter spend couldn't be broken out by app. Fall back to the same default
+      # the controller already uses (site_origin) so attribution works with or without the env var.
+      request["HTTP-Referer"] = ENV["SITE_ORIGIN"].presence || "https://levelcode.ai"
       request["X-Title"] = "LevelCode"
       request.body = JSON.generate(body)
       request


### PR DESCRIPTION
Spotted while verifying prompt caching in your OpenRouter logs: every generation showed **App: "Unknown"**.

## Cause
OpenRouter groups spend by app via `HTTP-Referer`, but the adapter sent it **conditionally**:

```ruby
request["HTTP-Referer"] = ENV["SITE_ORIGIN"] if ENV["SITE_ORIGIN"].present?
```

`SITE_ORIGIN` **isn't set** in the Beanstalk env — so no referer was ever sent, and OpenRouter couldn't attribute our spend to LevelCode.

Notably `SITE_ORIGIN` is read in three places and the **other two already have a fallback** (`ENV["SITE_ORIGIN"].presence || "https://levelcode.ai"`) — which is exactly why everything else kept working and only attribution broke.

## Fix
Use the same fallback the controller already uses, so attribution works **with or without** the env var:

```ruby
request["HTTP-Referer"] = ENV["SITE_ORIGIN"].presence || "https://levelcode.ai"
```

Setting `SITE_ORIGIN` in EB also fixes it and needs no deploy — but this makes the code correct by default rather than dependent on an env var that was never set.

**57 examples, 0 failures** (adapter + router + gateway request specs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)