### PR TITLE
feat(update-feed): serve the arch-matched signed .app.zip (auto-update S2)

### DIFF
--- a/app/controllers/api/updates_controller.rb
+++ b/app/controllers/api/updates_controller.rb
@@ -11,10 +11,13 @@
 #   2. GitHub Releases (Levelcode::EditorReleaseFeed, cached 5 min) — the zero-maintenance default:
 #      publishing a release on levelcodeai/levelcode IS the announcement.
 #
-# UNSIGNED-BUILD GUARD: the built-in Squirrel updater AUTO-DOWNLOADS a 200's url and fails on
-# ad-hoc-signed builds (and the GitHub-backed url is a web page, not a signed .zip). Until signed
-# builds ship (flip LEVELCODE_UPDATE_FEED_SIGNED=1), only the notify-only levelcode-updater
-# extension — which merely OPENS the url — is served a release; everything else gets 204.
+# UNSIGNED-BUILD GUARD: the built-in Squirrel updater AUTO-DOWNLOADS a 200's url and installs it, so it
+# is served a release only when BOTH hold: (a) signed feed assets are declared live
+# (LEVELCODE_UPDATE_FEED_SIGNED=1), and (b) the resolved entry is INSTALLABLE — i.e. a signed
+# `LevelCode-<arch>.app.zip` exists for that arch, not just a release page. Releases cut before signed
+# assets shipped therefore stay notify-only even with the flag on. Everything else gets 204; the
+# notify-only levelcode-updater extension — which merely OPENS the url — is always safe to serve.
+# Producer side + rollout order: docs/AUTO-UPDATE.md in the editor repo.
 #
 # FAIL-SAFE: this endpoint must NEVER return 5xx or HTML — the native updater and the extension both treat
 # anything that isn't 204/valid-JSON as an error. Any exception or unknown release resolves to 204.
@@ -34,8 +37,10 @@ class Api::UpdatesController < ApplicationController
                                 rel[:commit] == params[:commit]
 
     # Unsigned-build guard (see class comment): a newer build exists, but only the notify-only
-    # extension may hear about it until signed feed assets ship.
-    return head(:no_content) unless notify_only_client? || signed_feed?
+    # extension may hear about it until signed feed assets ship. The built-in Squirrel updater
+    # additionally requires an INSTALLABLE entry — a signed .app.zip for this arch — so that flipping
+    # LEVELCODE_UPDATE_FEED_SIGNED early can't hand it a release page to auto-download and choke on.
+    return head(:no_content) unless notify_only_client? || (signed_feed? && rel[:installable])
 
     render json: {
       version: rel[:commit], # the latest build's commit — the editor compares this to the running commit
@@ -72,7 +77,9 @@ class Api::UpdatesController < ApplicationController
     return nil if target.blank? || quality.blank?
 
     entry = parsed_feed.dig(target.to_s, quality.to_s)
-    return entry.symbolize_keys if entry.is_a?(Hash)
+    # An operator-pinned entry is assumed INSTALLABLE — pinning a signed asset is the whole point of the
+    # override. Set "installable": false in the JSON to pin a notify-only announcement instead.
+    return { installable: true }.merge(entry.symbolize_keys) if entry.is_a?(Hash)
 
     Levelcode::EditorReleaseFeed.latest(target: target, quality: quality)
   end

--- a/app/controllers/api/updates_controller.rb
+++ b/app/controllers/api/updates_controller.rb
@@ -79,6 +79,11 @@ class Api::UpdatesController < ApplicationController
     entry = parsed_feed.dig(target.to_s, quality.to_s)
     # An operator-pinned entry is assumed INSTALLABLE — pinning a signed asset is the whole point of the
     # override. Set "installable": false in the JSON to pin a notify-only announcement instead.
+    #
+    # An explicit `"installable": null` counts as FALSE, not as "key absent": merge lets the pinned nil
+    # win and the guard reads nil as falsy. Deliberate — the two directions aren't symmetric. Treating an
+    # ambiguous null as installable would hand Squirrel a url to auto-download and fail on; treating it as
+    # notify-only merely withholds an update. Omit the key entirely to get the default. Specs pin all three.
     return { installable: true }.merge(entry.symbolize_keys) if entry.is_a?(Hash)
 
     Levelcode::EditorReleaseFeed.latest(target: target, quality: quality)

--- a/app/services/levelcode/editor_release_feed.rb
+++ b/app/services/levelcode/editor_release_feed.rb
@@ -16,17 +16,27 @@ module Levelcode
 
     REPO = "levelcodeai/levelcode"
     RELEASES_PAGE = "https://github.com/#{REPO}/releases/latest"
+    # Feed target → the release asset that serves it. Squirrel installs a .zip of the signed .app, so
+    # that is the only INSTALLABLE artifact (the .dmg is the human download). Matching on an exact
+    # filename means an Intel app can never be handed the arm64 build.
     # Only macOS builds ship today — announcing on other targets would notify users of a build
     # that does not exist for them.
-    TARGETS = %w[darwin darwin-arm64].freeze
+    ASSET_FOR_TARGET = {
+      "darwin-arm64" => "LevelCode-arm64.app.zip",
+      "darwin" => "LevelCode-x64.app.zip"
+    }.freeze
+    TARGETS = ASSET_FOR_TARGET.keys.freeze
     CACHE_KEY = "levelcode:editor_release_feed:latest"
     CACHE_TTL = 5.minutes
 
     def latest(target:, quality:)
       return nil unless quality.to_s == "stable" && TARGETS.include?(target.to_s)
 
+      # One GitHub lookup serves every target; the arch-specific asset is resolved per call.
       cached = Rails.cache.fetch(CACHE_KEY, expires_in: CACHE_TTL) { fetch_release || :none }
-      cached == :none ? nil : cached
+      return nil if cached == :none
+
+      entry_for(cached, target.to_s)
     rescue StandardError => e
       Rails.logger.warn("[Levelcode::EditorReleaseFeed] #{e.class}: #{e.message} — serving nil (→ 204)")
       nil
@@ -47,14 +57,51 @@ module Levelcode
       {
         commit: sha,
         product_version: tag.delete_prefix("v"),
-        # The release PAGE, not a build asset: pre-signing, the only client served a 200 is the
-        # notify-only updater, which merely OPENS this url. Signed .zip feed assets, when they ship,
-        # get pinned via LEVELCODE_UPDATE_FEED (the env override wins over this fallback).
-        url: rel["html_url"].presence || RELEASES_PAGE,
-        sha256hash: nil,
-        timestamp: rel["published_at"].present? ? Time.zone.parse(rel["published_at"]).to_i : 0,
-        release_notes_url: rel["html_url"].presence || RELEASES_PAGE
+        page_url: rel["html_url"].presence || RELEASES_PAGE,
+        # arch => { url:, sha256: } for each signed .app.zip on this release. Empty for releases cut
+        # before signed assets shipped — those stay notify-only (see entry_for).
+        assets: build_assets(rel["assets"]),
+        timestamp: rel["published_at"].present? ? Time.zone.parse(rel["published_at"]).to_i : 0
       }
+    end
+
+    # Resolve the cached release to ONE target's feed entry.
+    #
+    # `installable` is the load-bearing bit: true only when this arch has a signed .app.zip, i.e. when
+    # the built-in Squirrel updater could actually install it. Releases without one still serve the
+    # release PAGE so the notify-only updater keeps working — but the controller must never hand a page
+    # to Squirrel, which would auto-download a web page and fail.
+    def entry_for(rel, target)
+      asset = rel[:assets][target]
+      {
+        commit: rel[:commit],
+        product_version: rel[:product_version],
+        url: asset ? asset[:url] : rel[:page_url],
+        sha256hash: asset && asset[:sha256],
+        timestamp: rel[:timestamp],
+        release_notes_url: rel[:page_url],
+        installable: asset.present?
+      }
+    end
+
+    # Pick the signed .app.zip per arch by EXACT filename — an unknown or renamed asset is ignored
+    # rather than guessed at, so a cross-arch zip can never be served.
+    def build_assets(list)
+      Array(list).each_with_object({}) do |a, out|
+        target = ASSET_FOR_TARGET.key(a["name"].to_s)
+        next if target.nil?
+
+        url = a["browser_download_url"].to_s
+        next if url.blank?
+
+        out[target] = { url: url, sha256: sha256_from(a["digest"]) }
+      end
+    end
+
+    # GitHub reports asset digests as "sha256:<hex>" (and may omit them entirely); the feed wants bare hex.
+    def sha256_from(digest)
+      d = digest.to_s
+      d.start_with?("sha256:") ? d.delete_prefix("sha256:").presence : nil
     end
 
     def github_json(url)

--- a/app/services/levelcode/editor_release_feed.rb
+++ b/app/services/levelcode/editor_release_feed.rb
@@ -26,7 +26,15 @@ module Levelcode
       "darwin" => "LevelCode-x64.app.zip"
     }.freeze
     TARGETS = ASSET_FOR_TARGET.keys.freeze
-    CACHE_KEY = "levelcode:editor_release_feed:latest"
+    # The reverse direction, precomputed: `build_assets` asks "which target does this asset name serve?"
+    # once per asset, so store the mapping in the direction it's queried instead of reverse-scanning.
+    TARGET_FOR_ASSET = ASSET_FOR_TARGET.invert.freeze
+    # NOTE the `:v2:` — the cached payload is a RELEASE object ({page_url:, assets:, …}); v1 cached a
+    # single per-target ENTRY. The version lives in the key so a deploy can never hand new code an
+    # old-shape hash: `entry_for` would call `rel[:assets][target]` on one and blow up on nil. That's
+    # rescued into a 204, so it would not 500 — it would silently withhold updates for the whole TTL,
+    # which is worse to diagnose. Bump this suffix whenever the cached shape changes.
+    CACHE_KEY = "levelcode:editor_release_feed:v2:latest"
     CACHE_TTL = 5.minutes
 
     def latest(target:, quality:)
@@ -88,7 +96,7 @@ module Levelcode
     # rather than guessed at, so a cross-arch zip can never be served.
     def build_assets(list)
       Array(list).each_with_object({}) do |a, out|
-        target = ASSET_FOR_TARGET.key(a["name"].to_s)
+        target = TARGET_FOR_ASSET[a["name"].to_s]
         next if target.nil?
 
         url = a["browser_download_url"].to_s

--- a/spec/requests/api/updates_spec.rb
+++ b/spec/requests/api/updates_spec.rb
@@ -6,9 +6,21 @@ RSpec.describe "Api::Updates", type: :request do
   # The notify-only levelcode-updater extension's UA — pre-signing, the only client served a 200.
   NOTIFY_UA = { "User-Agent" => "LevelCode Updater" }.freeze
 
-  after do
-    ENV.delete("LEVELCODE_UPDATE_FEED")
-    ENV.delete("LEVELCODE_UPDATE_FEED_SIGNED")
+  FEED_VARS = %w[LEVELCODE_UPDATE_FEED LEVELCODE_UPDATE_FEED_SIGNED].freeze
+
+  # Both vars are snapshotted, cleared for the example, and restored afterwards, so these specs neither
+  # leak into each other NOR read the developer's shell. The `after`-only cleanup this replaces already
+  # stopped the leak — but not the read: the FIRST example to run still saw the ambient value, and
+  # `config.order = :random` picks which one that is. Measured: with LEVELCODE_UPDATE_FEED_SIGNED=1
+  # exported, "serves 204 to the built-in Squirrel updater" gets a 200 and fails — on the seeds where it
+  # happens to run first. A seed-dependent flake, not a clean red. `ensure` covers the failure path too.
+  around do |example|
+    saved = ENV.slice(*FEED_VARS)
+    FEED_VARS.each { |k| ENV.delete(k) }
+    example.run
+  ensure
+    FEED_VARS.each { |k| ENV.delete(k) }
+    saved.each { |k, v| ENV[k] = v }
   end
 
   # No spec below may hit GitHub — the fallback is stubbed quiet unless a context opts in.
@@ -118,6 +130,31 @@ RSpec.describe "Api::Updates", type: :request do
         end
 
         it "still serves the notify-only extension (it only opens the page)" do
+          get UPDATE_URL, headers: NOTIFY_UA
+          expect(response).to have_http_status(:ok)
+        end
+      end
+
+      # Completes the pinned-`installable` tri-state: ABSENT defaults to installable (covered by "serves
+      # EVERY client once signed feed assets ship" above), FALSE is the context above, and an explicit
+      # JSON `null` is below. Null resolving to notify-only is a decision, not an accident — see the
+      # comment on Api::UpdatesController#latest_release — so it gets a test that a refactor of the
+      # `{ installable: true }.merge(...)` default would have to consciously delete.
+      context "when the pinned entry sets installable to an explicit JSON null" do
+        before do
+          set_feed("darwin-arm64" => { "stable" => {
+            "commit" => "def456newsha", "product_version" => "0.5.0",
+            "url" => "https://x/z.zip", "installable" => nil
+          } })
+          ENV["LEVELCODE_UPDATE_FEED_SIGNED"] = "1"
+        end
+
+        it "reads null as NOT installable — 204 to Squirrel, never the installable default" do
+          get UPDATE_URL, headers: { "User-Agent" => "LevelCode/0.5.0 Squirrel/1.0" }
+          expect(response).to have_http_status(:no_content)
+        end
+
+        it "still announces to the notify-only extension" do
           get UPDATE_URL, headers: NOTIFY_UA
           expect(response).to have_http_status(:ok)
         end

--- a/spec/requests/api/updates_spec.rb
+++ b/spec/requests/api/updates_spec.rb
@@ -99,6 +99,29 @@ RSpec.describe "Api::Updates", type: :request do
         get UPDATE_URL, headers: { "User-Agent" => "LevelCode/0.5.0 Squirrel/1.0" }
         expect(response).to have_http_status(:ok)
       end
+
+      context "when the entry is NOT installable (no signed .app.zip for this arch)" do
+        before do
+          # A release cut before signed assets shipped: `url` is a release PAGE. Auto-downloading a web
+          # page would fail, so Squirrel must stay on 204 even if the SIGNED flag is flipped early.
+          set_feed("darwin-arm64" => { "stable" => {
+            "commit" => "def456newsha", "product_version" => "0.5.0",
+            "url" => "https://github.com/levelcodeai/levelcode/releases/tag/v0.5.0",
+            "installable" => false
+          } })
+        end
+
+        it "serves 204 to Squirrel even with LEVELCODE_UPDATE_FEED_SIGNED=1" do
+          ENV["LEVELCODE_UPDATE_FEED_SIGNED"] = "1"
+          get UPDATE_URL, headers: { "User-Agent" => "LevelCode/0.5.0 Squirrel/1.0" }
+          expect(response).to have_http_status(:no_content)
+        end
+
+        it "still serves the notify-only extension (it only opens the page)" do
+          get UPDATE_URL, headers: NOTIFY_UA
+          expect(response).to have_http_status(:ok)
+        end
+      end
     end
 
     context "GitHub-Releases fallback — no env feed configured" do

--- a/spec/services/levelcode/editor_release_feed_spec.rb
+++ b/spec/services/levelcode/editor_release_feed_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Levelcode::EditorReleaseFeed do
     end
 
     it "NEVER serves a cross-arch zip: an arch with no asset falls back to the page, not installable" do
-      stub_github(release: RELEASE.merge("assets" => [zip_asset("LevelCode-arm64.app.zip")]))
+      stub_github(release: RELEASE.merge("assets" => [ zip_asset("LevelCode-arm64.app.zip") ]))
 
       intel = described_class.latest(target: "darwin", quality: "stable")
       expect(intel[:url]).to eq("https://github.com/levelcodeai/levelcode/releases/tag/v0.6.0")
@@ -66,7 +66,7 @@ RSpec.describe Levelcode::EditorReleaseFeed do
     end
 
     it "tolerates a missing digest (GitHub may omit it) — installable, hash nil" do
-      stub_github(release: RELEASE.merge("assets" => [zip_asset("LevelCode-arm64.app.zip", digest: nil)]))
+      stub_github(release: RELEASE.merge("assets" => [ zip_asset("LevelCode-arm64.app.zip", digest: nil) ]))
       entry = described_class.latest(target: "darwin-arm64", quality: "stable")
       expect(entry).to include(sha256hash: nil, installable: true)
     end

--- a/spec/services/levelcode/editor_release_feed_spec.rb
+++ b/spec/services/levelcode/editor_release_feed_spec.rb
@@ -18,6 +18,11 @@ RSpec.describe Levelcode::EditorReleaseFeed do
       .with("https://api.github.com/repos/levelcodeai/levelcode/commits/v0.6.0").and_return(sha && { "sha" => sha })
   end
 
+  # A release carrying the signed Squirrel assets.
+  def zip_asset(name, digest: "sha256:abc123")
+    { "name" => name, "browser_download_url" => "https://github.com/dl/#{name}", "digest" => digest }
+  end
+
   describe ".latest" do
     it "maps the latest release + tag commit to the feed-entry shape (v-prefix stripped, epoch timestamp)" do
       stub_github
@@ -25,11 +30,45 @@ RSpec.describe Levelcode::EditorReleaseFeed do
       expect(entry).to eq(
         commit: "fd81887a",
         product_version: "0.6.0",
+        # No signed .app.zip on this release → the release PAGE, and NOT installable: the notify-only
+        # updater still announces it, but Squirrel must never be handed a web page to auto-install.
         url: "https://github.com/levelcodeai/levelcode/releases/tag/v0.6.0",
         sha256hash: nil,
         timestamp: Time.zone.parse("2026-07-16T20:38:23Z").to_i,
-        release_notes_url: "https://github.com/levelcodeai/levelcode/releases/tag/v0.6.0"
+        release_notes_url: "https://github.com/levelcodeai/levelcode/releases/tag/v0.6.0",
+        installable: false
       )
+    end
+
+    it "serves the arch-matched signed .app.zip (+ bare sha256) and marks it installable" do
+      stub_github(release: RELEASE.merge("assets" => [
+        zip_asset("LevelCode-arm64.app.zip"),
+        zip_asset("LevelCode-x64.app.zip", digest: "sha256:def456"),
+        { "name" => "LevelCode-arm64.dmg", "browser_download_url" => "https://github.com/dl/dmg" }
+      ]))
+
+      arm = described_class.latest(target: "darwin-arm64", quality: "stable")
+      expect(arm).to include(url: "https://github.com/dl/LevelCode-arm64.app.zip",
+                             sha256hash: "abc123", installable: true)
+
+      intel = described_class.latest(target: "darwin", quality: "stable")
+      expect(intel).to include(url: "https://github.com/dl/LevelCode-x64.app.zip",
+                               sha256hash: "def456", installable: true)
+    end
+
+    it "NEVER serves a cross-arch zip: an arch with no asset falls back to the page, not installable" do
+      stub_github(release: RELEASE.merge("assets" => [zip_asset("LevelCode-arm64.app.zip")]))
+
+      intel = described_class.latest(target: "darwin", quality: "stable")
+      expect(intel[:url]).to eq("https://github.com/levelcodeai/levelcode/releases/tag/v0.6.0")
+      expect(intel[:installable]).to be(false)
+      expect(intel[:url]).not_to include("arm64")
+    end
+
+    it "tolerates a missing digest (GitHub may omit it) — installable, hash nil" do
+      stub_github(release: RELEASE.merge("assets" => [zip_asset("LevelCode-arm64.app.zip", digest: nil)]))
+      entry = described_class.latest(target: "darwin-arm64", quality: "stable")
+      expect(entry).to include(sha256hash: nil, installable: true)
     end
 
     it "serves both shipped macOS targets, and nothing else (no phantom announcements)" do


### PR DESCRIPTION
**S2 of the signed auto-update path** (producer side: levelcodeai/levelcode — emits the `.app.zip`).

The feed returned the release **page** for every target, so the built-in Squirrel updater had nothing installable. `EditorReleaseFeed` now resolves the per-arch signed asset:

- `darwin-arm64 → LevelCode-arm64.app.zip`, `darwin → LevelCode-x64.app.zip`, matched on **exact filename** — an Intel app can never be handed the arm64 build. An arch with no asset falls back to the release page rather than borrowing another arch's zip.
- `sha256hash` from GitHub's asset `digest` (`sha256:<hex>` → bare hex), tolerated as `nil` when omitted.
- One GitHub lookup still serves every target.

**The safety bit:** entries carry `installable` (a signed `.app.zip` exists for this arch), and the controller requires it before serving Squirrel. So flipping `LEVELCODE_UPDATE_FEED_SIGNED` early **cannot** hand the auto-installer a web page — it just stays 204. Releases cut before signed assets shipped remain notify-only, keeping today's working notification path intact. An operator-pinned `LEVELCODE_UPDATE_FEED` entry defaults to installable (that's the point of pinning).

29 examples, 0 failures; rubocop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
