### PR TITLE
feat(gateway): serve Kimi K3 as a selectable Pro model

### DIFF
--- a/app/services/levelcode/model_catalog.rb
+++ b/app/services/levelcode/model_catalog.rb
@@ -48,6 +48,18 @@ module Levelcode
         input: 3.00, cached_input: 0.30, output: 15.00,
         context: 200_000, min_tier: :pro, status: :assumption
       },
+      # Ordered by cost, NOT by family: K3 sits by its ~4.00× multiplier (== Sonnet 5's, same rates),
+      # not next to Kimi K2.7 — the monotonic-multiplier invariant (spec) is what keeps the picker honest.
+      "moonshotai/kimi-k3" => {
+        label: "Kimi K3", provider: "openrouter",
+        # Confirmed vs OpenRouter (2026-07-20): $3/M in · $15/M out · $0.30/M cached read. Reached via
+        # OpenRouter like every moonshotai/* slug (the native MoonshotAdapter is a disabled stub). K3 is
+        # always-on reasoning with no non-thinking mode, and the reasoning trace bills at the output rate;
+        # the ledger meters real usage, so that is covered. OpenRouter flags upstream capacity as limited
+        # (429s) this early — fine for an opt-in Pro pick, a reason NOT to make it the default yet.
+        input: 3.00, cached_input: 0.30, output: 15.00,
+        context: 1_048_576, min_tier: :pro, status: :confirmed
+      },
       "anthropic/claude-opus-4-8" => {
         label: "Opus 4.8", provider: "openrouter",
         # Confirmed vs OpenRouter (2026-07-07): output $25/M; input list ~$5/M (effective ~$1.56

--- a/spec/models/levelcode_model_catalog_spec.rb
+++ b/spec/models/levelcode_model_catalog_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Levelcode::ModelCatalog do
       expect(described_class.find("openai/gpt-oss-120b")[:status]).to eq(:confirmed)
       expect(described_class.find("moonshotai/kimi-k2.7-code")[:status]).to eq(:confirmed)
       expect(described_class.find("anthropic/claude-opus-4-8")[:status]).to eq(:confirmed) # price confirmed 2026-07-07
+      expect(described_class.find("moonshotai/kimi-k3")[:status]).to eq(:confirmed)       # OpenRouter list, 2026-07-20
       assumed = described_class.all.select { |_id, m| m[:status] == :assumption }.keys
       expect(assumed).to include("anthropic/claude-fable-5", "openai/gpt-5.5")
       expect(assumed).not_to include("anthropic/claude-opus-4-8")
@@ -15,6 +16,7 @@ RSpec.describe Levelcode::ModelCatalog do
 
     it "rate_table exposes every roster model's per-token rates (feeds Levelcode.cost_micros)" do
       expect(described_class.rate_table["moonshotai/kimi-k2.7-code"]).to eq(input: 0.74, cached_input: 0.15, output: 3.50)
+      expect(described_class.rate_table["moonshotai/kimi-k3"]).to eq(input: 3.00, cached_input: 0.30, output: 15.00)
       expect(described_class.rate_table.keys).to match_array(described_class.ids)
     end
   end
@@ -30,8 +32,8 @@ RSpec.describe Levelcode::ModelCatalog do
     it "reproduces the analysis multipliers (within rounding)" do
       {
         "openai/gpt-oss-120b" => 0.05, "moonshotai/kimi-k2.7-code" => 1.00, "openai/codex-5.3" => 2.22,
-        "openai/gpt-5.5" => 2.66, "anthropic/claude-sonnet-5" => 4.00, "anthropic/claude-opus-4-8" => 6.67,
-        "anthropic/claude-fable-5" => 13.35
+        "openai/gpt-5.5" => 2.66, "anthropic/claude-sonnet-5" => 4.00, "moonshotai/kimi-k3" => 4.00,
+        "anthropic/claude-opus-4-8" => 6.67, "anthropic/claude-fable-5" => 13.35
       }.each { |id, mult| expect(described_class.multiplier(id)).to be_within(0.02).of(mult) }
     end
 

--- a/spec/models/levelcode_plans_spec.rb
+++ b/spec/models/levelcode_plans_spec.rb
@@ -45,7 +45,8 @@ RSpec.describe Levelcode do
     end
 
     it 'a paid plan may use the flagship AND the open-weights engine (confirmed-price roster)' do
-      expect(Levelcode.allowed_models('orbits_pro')).to match_array([ Levelcode::DEFAULT_MODEL, Levelcode::FREE_MODEL, 'anthropic/claude-opus-4-8' ])
+      # Kimi K3 joined the confirmed-price roster (a selectable Pro pick — see the gateway K3 change).
+      expect(Levelcode.allowed_models('orbits_pro')).to match_array([ Levelcode::DEFAULT_MODEL, Levelcode::FREE_MODEL, 'anthropic/claude-opus-4-8', 'moonshotai/kimi-k3' ])
       # A tier-entitled but ASSUMPTION-priced frontier model stays staged — never billed on a guess.
       expect(Levelcode.allowed_models('orbits_pro')).not_to include('openai/gpt-5.5')
     end

--- a/spec/requests/api/levelcode/v1/account_spec.rb
+++ b/spec/requests/api/levelcode/v1/account_spec.rb
@@ -70,11 +70,14 @@ RSpec.describe "Api::Levelcode::V1::Account", type: :request do
       body = response.parsed_body
       expect(body["plan"]).to eq("Pro")
       ids = body["models"].map { |m| m["id"] }
-      expect(ids).to include("openai/gpt-oss-120b", "moonshotai/kimi-k2.7-code", "anthropic/claude-opus-4-8")
+      expect(ids).to include("openai/gpt-oss-120b", "moonshotai/kimi-k2.7-code", "moonshotai/kimi-k3", "anthropic/claude-opus-4-8")
       kimi = body["models"].find { |m| m["id"] == "moonshotai/kimi-k2.7-code" }
       expect(kimi["live"]).to be(true)
       expect(kimi["multiplier"]).to eq(1.0)
       expect(kimi["turns_left"]).to be_within(2).of(260)  # $10 budget (50% of $20) ÷ Kimi ref-turn
+      k3 = body["models"].find { |m| m["id"] == "moonshotai/kimi-k3" }
+      expect(k3["live"]).to be(true)                   # confirmed OpenRouter price → selectable + billable
+      expect(k3["multiplier"]).to be_within(0.05).of(4.00)   # ~4× the Kimi K2.7 flagship baseline
       opus = body["models"].find { |m| m["id"] == "anthropic/claude-opus-4-8" }
       expect(opus["live"]).to be(true)                # price confirmed → live + billable
       expect(opus["multiplier"]).to be_within(0.05).of(6.67)


### PR DESCRIPTION
## What

Adds `moonshotai/kimi-k3` to `Levelcode::ModelCatalog::MODELS` — one row. The gateway, entitlement, pricing, the derived multiplier, and the editor picker all derive from that table, so this is the whole feature.

```ruby
"moonshotai/kimi-k3" => {
  label: "Kimi K3", provider: "openrouter",
  input: 3.00, cached_input: 0.30, output: 15.00,
  context: 1_048_576, min_tier: :pro, status: :confirmed
},
```

**Ships on deploy — no editor release.** The client reads the roster live from `GET /account/models`, so a new `:confirmed` row appears in every Pro user's picker automatically.

## Routing

Nothing new. Like every `moonshotai/*` slug it rides **OpenRouter** on the existing `OPENROUTER_API_KEY` (the native `MoonshotAdapter` stays a disabled stub). Confirmed live on OpenRouter 2026-07-20: **$3 / $15 / $0.30, 1M context**.

## Scope — selectable, not default (deliberate)

`min_tier: :pro`, `status: :confirmed` → a **selectable Pro pick**, not the flagship. Two verified reasons it's not the default:

- **Cost is 4.00×** the Kimi K2.7 baseline — a $10 Pro budget buys **~65 K3 turns vs ~260** on K2.7. (K3 is always-on reasoning with no non-thinking mode; the hidden reasoning bills at the full $15/M output rate.)
- **OpenRouter flags K3 supply as capacity-limited (429s)** this early.

Both are contained when a user opts in and sees the multiplier; they'd hit the whole paid base if K3 were the default. The default switch (`DEFAULT_MODEL` + client constants) is **not** in this PR.

Margins are unaffected — budgets are dollar-denominated, so the ledger meters real cost regardless of model mix; only the displayed turns-left moves.

## Verification

- 198 levelcode specs green, rubocop clean.
- Runtime check through the real Rails code: multiplier `4.0`, status `confirmed`, `min_tier :pro`, ctx `1048576`, Pro-entitled / free-not.

## Before deploy

Run the reasoning-loop spike (`extensions/levelcode-ai/scripts/kimi-k3-spike.js` in the editor repo, companion PR): K3's always-on reasoning + the agent path dropping `reasoning_content` is the `deepseek-reasoner` failure mode, and K3 has no non-reasoning fallback. Server-side, uses this gateway's own OpenRouter key. If it fails, the editor-side catalog flips K3 to chat-only — this roster row is unaffected either way (thin.ly has no per-model tools flag; agent capability is a token-scope check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)