### PR TITLE
feat(levelcode): store first-touch signup attribution on account creation

### DIFF
--- a/app/controllers/levelcode/web_controller.rb
+++ b/app/controllers/levelcode/web_controller.rb
@@ -345,6 +345,11 @@ module Levelcode
         terms_accepted: true,
         signup_attribution: sanitize_signup_attribution(attribution)
       )
+    rescue ActiveRecord::RecordNotUnique
+      # Two sign-ins for the same NEW email raced between the find_by and the INSERT, and the unique index
+      # on users.email rejected the loser. Re-find the winner so a valid sign-in never 500s. (Attribution
+      # was stamped by whichever request won the create; the loser just returns the existing account.)
+      User.find_by(email: email)
     end
 
     # Campaign params we recognize (mirror of the SPA's attribution util). Anything else is dropped.

--- a/app/controllers/levelcode/web_controller.rb
+++ b/app/controllers/levelcode/web_controller.rb
@@ -77,7 +77,7 @@ module Levelcode
         return render_error("invalid_code", "That code is invalid or has expired.", :unauthorized)
       end
 
-      user = find_or_create_email_user(email)
+      user = find_or_create_email_user(email, params[:attribution])
       unless user&.persisted?
         log_auth(kind: "email", outcome: "failure", email: email, reason: "account_error")
         return render_error("account_error", "Could not sign you in. Please try again.", :unprocessable_content)
@@ -335,13 +335,47 @@ module Levelcode
     # --- Helpers --------------------------------------------------------------
 
     # Passwordless find-or-create; a random password satisfies Devise validatable
-    # and is never used (sign-in is OTP/OAuth only).
-    def find_or_create_email_user(email)
+    # and is never used (sign-in is OTP/OAuth only). On the CREATE path only, stamp the first-touch
+    # marketing attribution the SPA sent — an existing user keeps whatever acquired them (acquisition
+    # attribution, not last-touch).
+    def find_or_create_email_user(email, attribution = nil)
       User.find_by(email: email) || User.create(
         email: email,
         password: Devise.friendly_token[0, 32],
-        terms_accepted: true
+        terms_accepted: true,
+        signup_attribution: sanitize_signup_attribution(attribution)
       )
+    end
+
+    # Campaign params we recognize (mirror of the SPA's attribution util). Anything else is dropped.
+    ATTRIBUTION_PARAM_KEYS = %w[linkedin youtube ref utm_source utm_medium utm_campaign utm_content].freeze
+
+    # Coerce the CLIENT-CONTROLLED attribution blob (query params → localStorage → request body) into a
+    # small, bounded, whitelisted hash before it touches the DB — never store the raw params object. Returns
+    # nil for organic/absent/garbage input so the column stays null.
+    def sanitize_signup_attribution(raw)
+      h = raw.respond_to?(:to_unsafe_h) ? raw.to_unsafe_h : raw
+      return nil unless h.is_a?(Hash)
+
+      src = h["params"] || h[:params]
+      params = {}
+      if src.is_a?(Hash)
+        ATTRIBUTION_PARAM_KEYS.each do |k|
+          v = src[k] || src[k.to_sym]
+          params[k] = v.to_s[0, 120] if v.present?
+        end
+      end
+      source = h["source"].to_s[0, 40]
+      return nil if params.empty? && source.blank?
+
+      {
+        "source" => source.presence || "other",
+        "params" => params,
+        "landing" => h["landing"].to_s[0, 300].presence,
+        "referrer" => h["referrer"].to_s[0, 300].presence,
+        "ts" => h["ts"].to_s[0, 40].presence,
+        "recorded_at" => Time.current.utc.iso8601
+      }.compact
     end
 
     def valid_email?(email)

--- a/db/migrate/20260722120001_add_signup_attribution_to_users.rb
+++ b/db/migrate/20260722120001_add_signup_attribution_to_users.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# First-touch marketing attribution captured at account creation (LevelCode sign-in). The SPA persists the
+# campaign channel from the landing URL (?linkedin=…/?youtube=…/utm_*) and sends it on /ai/auth/verify;
+# Levelcode::WebController records a sanitized copy here on the NEW user only. Nullable — null means the
+# account predates attribution or arrived organically.
+class AddSignupAttributionToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :signup_attribution, :jsonb
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_07_07_120001) do
+ActiveRecord::Schema[7.2].define(version: 2026_07_22_120001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -389,6 +389,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_07_120001) do
     t.string "role", default: "member", null: false
     t.string "last_country"
     t.datetime "last_seen_at"
+    t.jsonb "signup_attribution"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["jti"], name: "index_users_on_jti", unique: true
     t.index ["last_seen_at"], name: "index_users_on_last_seen_at"

--- a/spec/requests/levelcode/web_spec.rb
+++ b/spec/requests/levelcode/web_spec.rb
@@ -115,6 +115,20 @@ RSpec.describe 'Levelcode::Web (SPA backend at /ai/*)', type: :request do
         expect(User.find_by(email: 'organic@example.com').signup_attribution).to be_nil
       end
 
+      it 'survives a concurrent-signup race (unique-violation → re-find, never a 500)' do
+        # A parallel request already created this email; our find_by missed it, so our INSERT loses to the
+        # DB unique index. The rescue must re-find the winner and sign them in cleanly.
+        winner = User.create!(email: 'race@example.com', password: 'password123', terms_accepted: true)
+        allow(User).to receive(:find_by).and_call_original
+        allow(User).to receive(:find_by).with(email: 'race@example.com').and_return(nil, winner)
+        allow(User).to receive(:create).and_raise(ActiveRecord::RecordNotUnique)
+
+        post '/ai/auth/verify', params: { email: 'race@example.com', code: '123456' }, as: :json
+
+        expect(response).to have_http_status(:ok)
+        expect(json).to eq('redirect' => '/ai/account')
+      end
+
       it 'whitelists keys and bounds sizes — never trusts the client blob' do
         hostile = { source: 'x' * 200,
                     params: { linkedin: 'a' * 500, evil: 'ignored', utm_source: 'newsletter' },

--- a/spec/requests/levelcode/web_spec.rb
+++ b/spec/requests/levelcode/web_spec.rb
@@ -81,6 +81,53 @@ RSpec.describe 'Levelcode::Web (SPA backend at /ai/*)', type: :request do
       expect(response).to have_http_status(:ok)
     end
 
+    context 'signup attribution (first-touch, stamped on the NEW user only)' do
+      before { allow(Levelcode::EmailCode).to receive(:verify).and_return(true) }
+
+      let(:attribution) do
+        { source: 'linkedin', params: { linkedin: 'saienkoanastasia' },
+          landing: '/ai?linkedin=saienkoanastasia', referrer: 'https://lnkd.in/x',
+          ts: '2026-07-22T19:35:41.166Z' }
+      end
+
+      it 'stamps a sanitized attribution on a newly created account' do
+        post '/ai/auth/verify', params: { email: 'lead@example.com', code: '123456', attribution: attribution }, as: :json
+        expect(response).to have_http_status(:ok)
+
+        attr = User.find_by(email: 'lead@example.com').signup_attribution
+        expect(attr['source']).to eq('linkedin')
+        expect(attr['params']).to eq('linkedin' => 'saienkoanastasia')
+        expect(attr['landing']).to eq('/ai?linkedin=saienkoanastasia')
+        expect(attr['recorded_at']).to be_present # server timestamp, not client-controlled
+      end
+
+      it 'does NOT overwrite an existing account (acquisition attribution, not last-touch)' do
+        existing = User.create!(email: 'known@example.com', password: 'password123', terms_accepted: true)
+        expect(existing.signup_attribution).to be_nil
+
+        post '/ai/auth/verify', params: { email: 'known@example.com', code: '123456', attribution: attribution }, as: :json
+        expect(response).to have_http_status(:ok)
+        expect(existing.reload.signup_attribution).to be_nil
+      end
+
+      it 'stays null on an organic sign-in (no campaign params)' do
+        post '/ai/auth/verify', params: { email: 'organic@example.com', code: '123456' }, as: :json
+        expect(User.find_by(email: 'organic@example.com').signup_attribution).to be_nil
+      end
+
+      it 'whitelists keys and bounds sizes — never trusts the client blob' do
+        hostile = { source: 'x' * 200,
+                    params: { linkedin: 'a' * 500, evil: 'ignored', utm_source: 'newsletter' },
+                    landing: 'y' * 1000 }
+        post '/ai/auth/verify', params: { email: 'hostile@example.com', code: '123456', attribution: hostile }, as: :json
+
+        attr = User.find_by(email: 'hostile@example.com').signup_attribution
+        expect(attr['source'].length).to eq(40) # truncated
+        expect(attr['params']).to eq('linkedin' => 'a' * 120, 'utm_source' => 'newsletter') # unknown 'evil' dropped
+        expect(attr['landing'].length).to eq(300)
+      end
+    end
+
     it 'editor mode: returns { redirect: deep-link?code= } bound to the PKCE challenge' do
       allow(Levelcode::EmailCode).to receive(:verify).and_return(true)
       allow(Levelcode::OneTimeCode).to receive(:issue).and_return('one-time-code')


### PR DESCRIPTION
## What & why

Companion to the account-app change (onetime PR #82) that captures the marketing channel off the landing URL. The SPA now sends that attribution on `/ai/auth/verify`; this persists it so **signups can be attributed by channel** (LinkedIn vs YouTube vs organic), not just clicks.

Context: we're running a creator collaboration and needed to answer "which channel actually drove sign-ups." thin.ly short links give per-link *click* counts for free; this carries the channel identity through to the *signup* conversion.

## Changes

- **Migration** — `users.signup_attribution` (`jsonb`, nullable). Null = organic or pre-attribution account.
- **`WebController#find_or_create_email_user`** — stamps the attribution on the **CREATE path only**. An existing user keeps whatever acquired them (**acquisition** attribution, not last-touch).
- **`sanitize_signup_attribution`** — the blob is **client-controlled** (query params → localStorage → request body), so it's never stored raw: only whitelisted campaign keys (`linkedin/youtube/ref/utm_*`) are kept, every value is length-bounded, and `recorded_at` is **server-set**.

## Behavior

| Sign-in | Result |
|---|---|
| New account, `?linkedin=…` | `signup_attribution = { source: "linkedin", params: {…}, landing, referrer, ts, recorded_at }` |
| Existing account | unchanged (acquisition wins) |
| Organic (no params) | `null` |
| Hostile/oversized blob | whitelisted + truncated |

## Verification

- New specs: new-user stamp · no-overwrite for existing users · null on organic · hostile-input whitelisting/bounding.
- **Full `web_spec` green — 30 examples, 0 failures.** Rubocop clean.

## Notes

- **Frontend companion:** onetime PR #82 (attribution capture + it's sent on the verify call). This PR makes that data land somewhere; harmless without it (the param was already being ignored).
- **Scope:** attributes **signups**. Download/BYO-key users (no account) aren't captured here — those are covered by thin.ly's per-link click counts.
- **Easy follow-up (not in this PR):** a per-channel count in the admin summary (`signup_attribution->>'source'`), and an index on it if volume grows.