### PR TITLE
feat(levelcode): denominate the customer-facing balance in credits, not dollars

### DIFF
--- a/lib/levelcode.rb
+++ b/lib/levelcode.rb
@@ -28,7 +28,7 @@ module Levelcode
       turns: 260,
       stripe_lookup_key: "orbits_pro",
       features: [
-        "~260 Kimi turns/mo · ~39 on Opus 4.8",
+        "2,000 credits/mo · ~260 Kimi turns, or ~39 on Opus 4.8",
         "Usage that refreshes through your billing cycle",
         "Kimi K2.7 Code + Opus 4.8",
         "Bring-your-own-key always free"
@@ -44,7 +44,7 @@ module Levelcode
       turns: 520,
       stripe_lookup_key: "orbits_pro_plus",
       features: [
-        "~520 Kimi turns/mo · ~78 on Opus 4.8",
+        "4,000 credits/mo · ~520 Kimi turns, or ~78 on Opus 4.8",
         "Usage that refreshes through your billing cycle",
         "Kimi K2.7 Code + Opus 4.8",
         "Priority routing"
@@ -60,7 +60,7 @@ module Levelcode
       turns: 780,
       stripe_lookup_key: "orbits_max",
       features: [
-        "~780 Kimi turns/mo · ~117 on Opus 4.8",
+        "6,000 credits/mo · ~780 Kimi turns, or ~117 on Opus 4.8",
         "Usage that refreshes through your billing cycle",
         "Kimi K2.7 Code + Opus 4.8",
         "Priority routing"
@@ -76,7 +76,7 @@ module Levelcode
       turns: 1_300,
       stripe_lookup_key: "orbits_ultra",
       features: [
-        "~1,300 Kimi turns/mo · ~195 on Opus 4.8",
+        "10,000 credits/mo · ~1,300 Kimi turns, or ~195 on Opus 4.8",
         "Usage that refreshes through your billing cycle",
         "Kimi K2.7 Code + Opus 4.8",
         "Highest priority routing"
@@ -125,6 +125,21 @@ module Levelcode
   # charges each model its REAL per-token cost, this margin holds for ANY model mix — pricey models
   # (Opus ≈ 7× Kimi) just burn the budget faster. ENV-tunable so pricing can move without a deploy.
   CREDIT_COGS_RATIO = ENV.fetch("LEVELCODE_CREDIT_COGS_RATIO", 0.50).to_f
+
+  # The in-product spending unit. Balances are SHOWN in credits, never dollars: $1 = 100 credits, so
+  # 1 credit = $0.01 = 10_000 micro-$.
+  #
+  # This is PRESENTATION ONLY. The ledger, metering, Stripe prices, and invoices all stay in
+  # micro-dollars, because dollars are what providers charge us and what we actually bill — and
+  # re-denominating stored balances would put Stripe reconciliation at risk for no gain. Credits exist
+  # for a behavioural reason: a shrinking DOLLAR balance reads as money being lost, while credits read
+  # as an allowance meant to be spent.
+  #
+  # Because a plan's retail budget equals its price (budget_micros == price × CREDIT_COGS_RATIO, and
+  # retail divides that ratio back out), a plan's credit allowance is exactly its price in CENTS:
+  # $20 Pro → 2_000 credits, $100 Ultra → 10_000 credits. See #plan_credits.
+  CREDITS_PER_DOLLAR = 100
+  MICROS_PER_CREDIT = 1_000_000 / CREDITS_PER_DOLLAR   # 10_000 micro-$ == 1 credit
 
   # Time-released budget tranches (rolling usage windows). When > 1, the enforced ceiling rises in N
   # equal steps from budget/N up to the full budget across the billing period (window = period / N), so
@@ -343,10 +358,27 @@ module Levelcode
 
     # How many reference turns a given DOLLAR balance buys on a model (used for "≈ N turns left").
     def turns_in_budget(budget, model)
-      per_turn = Levelcode::ModelCatalog.reference_cost_micros(model) * ROUTING_FEE
+      per_turn = per_turn_cost_micros(model)
       return 0 if per_turn <= 0
 
       (budget.to_i / per_turn).floor
+    end
+
+    # What ONE reference turn costs on a model, in COST micro-$ (real wire cost incl. the routing fee).
+    # Extracted so turns-left and the per-turn figure the dashboard shows can never diverge.
+    def per_turn_cost_micros(model)
+      Levelcode::ModelCatalog.reference_cost_micros(model) * ROUTING_FEE
+    end
+
+    # RETAIL micro-$ → credits (the unit the customer sees). Display only — see CREDITS_PER_DOLLAR.
+    def micros_to_credits(retail_micros)
+      retail_micros.to_f / MICROS_PER_CREDIT
+    end
+
+    # A plan's monthly credit allowance. Derived, not hard-coded: the retail budget IS the plan price,
+    # so this comes out to the price in cents ($100 Ultra → 10_000 credits).
+    def plan_credits(plan_key)
+      micros_to_credits(retail_micros(budget_micros(plan_key), plan_key)).round
     end
 
     # The plan's model roster for the picker/dashboard: every ENTITLED model with its display
@@ -363,6 +395,10 @@ module Levelcode
           context: m[:context],
           multiplier: model_multiplier(id),
           live: live.include?(id),
+          # What one turn costs at RETAIL, in micro-$ — the same unit as the balance fields, so the
+          # dashboard converts both with one helper and "N credits/turn" divides into the balance
+          # exactly. Derived from the SAME per-turn cost as turns_left, so the two always agree.
+          per_turn_micros: retail_micros(per_turn_cost_micros(id), plan_key).round,
           turns_budget: turns_for(plan_key, id),
           turns_left: remaining_micros.nil? ? nil : turns_in_budget(remaining_micros, id)
         }

--- a/lib/levelcode.rb
+++ b/lib/levelcode.rb
@@ -351,23 +351,38 @@ module Levelcode
       Levelcode::ModelCatalog.multiplier(model)
     end
 
-    # How many reference turns a plan's budget buys on a model (budget ÷ per-turn cost incl. routing).
+    # How many reference turns a plan's FULL monthly allowance buys on a model.
     def turns_for(plan_key, model)
-      turns_in_budget(budget_micros(plan_key), model)
-    end
-
-    # How many reference turns a given DOLLAR balance buys on a model (used for "≈ N turns left").
-    def turns_in_budget(budget, model)
-      per_turn = per_turn_cost_micros(model)
-      return 0 if per_turn <= 0
-
-      (budget.to_i / per_turn).floor
+      turns_in_retail_budget(retail_micros(budget_micros(plan_key), plan_key),
+                             retail_per_turn_micros(plan_key, model))
     end
 
     # What ONE reference turn costs on a model, in COST micro-$ (real wire cost incl. the routing fee).
-    # Extracted so turns-left and the per-turn figure the dashboard shows can never diverge.
+    # Rounded to a whole micro-dollar like cost_micros: the name says micro-$, and keeping it an Integer
+    # stops a float from propagating into the turn counts below (PR #380 review).
     def per_turn_cost_micros(model)
-      Levelcode::ModelCatalog.reference_cost_micros(model) * ROUTING_FEE
+      (Levelcode::ModelCatalog.reference_cost_micros(model) * ROUTING_FEE).round
+    end
+
+    # What one turn costs at RETAIL — the unit the customer's balance is shown in. THE single definition
+    # of the per-turn figure: the dashboard prints it, and both turn counts below divide by it.
+    def retail_per_turn_micros(plan_key, model)
+      retail_micros(per_turn_cost_micros(model), plan_key).round
+    end
+
+    # How many reference turns a RETAIL balance buys at a RETAIL per-turn price.
+    #
+    # Both arguments must already be retail integers. That is the whole point (PR #380 review): the
+    # dashboard shows "N credits/turn" beside "≈ turns left", and a user divides one into the other by
+    # eye. Previously turns came from COST micro-$ while the per-turn figure was ROUNDED RETAIL, so the
+    # two rounded independently and disagreed for ~12% of balances (measured: 3,440 of 28,000 sampled).
+    # Deriving both from the same rounded retail figure makes them agree by construction rather than by
+    # coincidence. The margin ratio cancels in the division, so the counts themselves are unchanged.
+    def turns_in_retail_budget(retail_budget, retail_per_turn)
+      per_turn = retail_per_turn.to_i
+      return 0 if per_turn <= 0
+
+      retail_budget.to_i / per_turn
     end
 
     # RETAIL micro-$ → credits (the unit the customer sees). Display only — see CREDITS_PER_DOLLAR.
@@ -387,8 +402,12 @@ module Levelcode
     # not selectable/billable. This is the ONE surface the editor + dashboard render.
     def roster_for(plan_key, remaining_micros = nil)
       live = allowed_models(plan_key)
+      # Convert the balances ONCE, up front, so every row divides the same retail figures.
+      retail_budget = retail_micros(budget_micros(plan_key), plan_key)
+      retail_remaining = remaining_micros.nil? ? nil : retail_micros(remaining_micros, plan_key)
       entitled_models(plan_key).map do |id|
         m = Levelcode::ModelCatalog.find(id)
+        per_turn = retail_per_turn_micros(plan_key, id)
         {
           id: id,
           label: m[:label],
@@ -398,9 +417,9 @@ module Levelcode
           # What one turn costs at RETAIL, in micro-$ — the same unit as the balance fields, so the
           # dashboard converts both with one helper and "N credits/turn" divides into the balance
           # exactly. Derived from the SAME per-turn cost as turns_left, so the two always agree.
-          per_turn_micros: retail_micros(per_turn_cost_micros(id), plan_key).round,
-          turns_budget: turns_for(plan_key, id),
-          turns_left: remaining_micros.nil? ? nil : turns_in_budget(remaining_micros, id)
+          per_turn_micros: per_turn,
+          turns_budget: turns_in_retail_budget(retail_budget, per_turn),
+          turns_left: remaining_micros.nil? ? nil : turns_in_retail_budget(retail_remaining, per_turn)
         }
       end
     end

--- a/spec/models/levelcode_plans_spec.rb
+++ b/spec/models/levelcode_plans_spec.rb
@@ -28,6 +28,55 @@ RSpec.describe Levelcode do
     end
   end
 
+  describe 'credits (the in-product spending unit)' do
+    it 'converts retail micro-$ at $1 = 100 credits' do
+      expect(Levelcode::CREDITS_PER_DOLLAR).to eq(100)
+      expect(Levelcode::MICROS_PER_CREDIT).to eq(10_000)
+      expect(Levelcode.micros_to_credits(12_790_000)).to eq(1_279.0)  # the dashboard's "$12.79 left"
+      expect(Levelcode.micros_to_credits(0)).to eq(0.0)
+    end
+
+    it "gives each plan an allowance equal to its price in CENTS" do
+      # Not a coincidence to be re-derived by hand anywhere: budget_micros == price × CREDIT_COGS_RATIO
+      # and retail divides that ratio back out, so the credit allowance lands exactly on price_cents.
+      # $100 Ultra → 10_000 credits. Pinned because the marketing copy states these numbers.
+      {
+        'orbits_pro' => 2_000, 'orbits_pro_plus' => 4_000,
+        'orbits_max' => 6_000, 'orbits_ultra' => 10_000
+      }.each do |key, credits|
+        expect(Levelcode.plan_credits(key)).to eq(credits)
+        expect(Levelcode.plan_credits(key)).to eq(Levelcode.plan(key)[:price_cents])
+      end
+    end
+
+    it 'survives a change to the COGS ratio — the allowance still tracks the price' do
+      # The allowance is revenue-derived, so moving the margin must NOT move what the customer is told
+      # they get. This is the property that makes "Ultra = 10,000 credits" safe to print.
+      stub_const('Levelcode::CREDIT_COGS_RATIO', 0.30)
+      expect(Levelcode.plan_credits('orbits_ultra')).to eq(10_000)
+    end
+  end
+
+  describe '.roster_for per-turn economics' do
+    it 'reports per_turn_micros in the same RETAIL unit as the balance' do
+      row = Levelcode.roster_for('orbits_pro_plus', 0).find { |m| m[:id] == 'moonshotai/kimi-k2.7-code' }
+      # ~7.7 credits/turn on the 1× flagship — the figure the dashboard prints beside "≈ turns left".
+      expect(Levelcode.micros_to_credits(row[:per_turn_micros])).to be_within(0.5).of(7.7)
+    end
+
+    it 'keeps per_turn_micros and turns_left derived from the SAME per-turn cost' do
+      # The load-bearing invariant. The dashboard shows "N credits/turn" next to "≈ turns left"; if the
+      # two were computed from different costs the columns would quietly disagree and neither would be
+      # checkable by eye. Balance ÷ per-turn must reproduce turns_left for every model on the plan.
+      remaining_cost = 5_000_000
+      Levelcode.roster_for('orbits_pro_plus', remaining_cost).each do |m|
+        retail_balance = Levelcode.retail_micros(remaining_cost, 'orbits_pro_plus')
+        expect(retail_balance / m[:per_turn_micros]).to eq(m[:turns_left]),
+                                                       "#{m[:id]}: per-turn and turns_left disagree"
+      end
+    end
+  end
+
   describe '.plan' do
     it 'looks up a plan by key' do
       expect(Levelcode.plan('orbits_max')[:name]).to eq('Max')

--- a/spec/models/levelcode_plans_spec.rb
+++ b/spec/models/levelcode_plans_spec.rb
@@ -64,15 +64,35 @@ RSpec.describe Levelcode do
       expect(Levelcode.micros_to_credits(row[:per_turn_micros])).to be_within(0.5).of(7.7)
     end
 
-    it 'keeps per_turn_micros and turns_left derived from the SAME per-turn cost' do
-      # The load-bearing invariant. The dashboard shows "N credits/turn" next to "≈ turns left"; if the
-      # two were computed from different costs the columns would quietly disagree and neither would be
-      # checkable by eye. Balance ÷ per-turn must reproduce turns_left for every model on the plan.
-      remaining_cost = 5_000_000
-      Levelcode.roster_for('orbits_pro_plus', remaining_cost).each do |m|
-        retail_balance = Levelcode.retail_micros(remaining_cost, 'orbits_pro_plus')
-        expect(retail_balance / m[:per_turn_micros]).to eq(m[:turns_left]),
-                                                       "#{m[:id]}: per-turn and turns_left disagree"
+    it 'keeps per_turn_micros and turns_left in exact agreement across MANY balances' do
+      # The load-bearing invariant: the dashboard prints "N credits/turn" beside "≈ turns left" and the
+      # user divides one into the other by eye, so they must agree for EVERY balance, not on average.
+      #
+      # This test used to assert a single balance and passed while the invariant was broken — turns came
+      # from COST micro-$ while the per-turn figure was ROUNDED RETAIL, so the two rounded independently
+      # and disagreed for ~12% of balances (PR #380 review; measured 3,440 of 28,000 sampled). One value
+      # proves nothing about a rounding boundary, so sweep a range that crosses many of them.
+      plan = 'orbits_pro_plus'
+      (1..400).each do |k|
+        balance = k * 12_345
+        retail_balance = Levelcode.retail_micros(balance, plan)
+        Levelcode.roster_for(plan, balance).each do |m|
+          expect(retail_balance / m[:per_turn_micros]).to eq(m[:turns_left]),
+                                                         "#{m[:id]} @ #{balance}: balance ÷ per-turn " \
+                                                         "(#{retail_balance / m[:per_turn_micros]}) != " \
+                                                         "turns_left (#{m[:turns_left]})"
+        end
+      end
+    end
+
+    it 'reports whole micro-dollars for a turn, not a float' do
+      # per_turn_cost_micros multiplies an integer cost by the float routing fee; leaving it a Float let
+      # the imprecision leak into the turn counts. The name says micro-$ — it should BE micro-$.
+      expect(Levelcode.per_turn_cost_micros('moonshotai/kimi-k2.7-code')).to be_a(Integer)
+      expect(Levelcode.retail_per_turn_micros('orbits_pro_plus', 'moonshotai/kimi-k2.7-code')).to be_a(Integer)
+      Levelcode.roster_for('orbits_pro_plus', 1_000_000).each do |m|
+        expect(m[:per_turn_micros]).to be_a(Integer), "#{m[:id]} per_turn_micros must be an Integer"
+        expect(m[:turns_left]).to be_a(Integer)
       end
     end
   end

--- a/spec/requests/api/levelcode/v1/account_spec.rb
+++ b/spec/requests/api/levelcode/v1/account_spec.rb
@@ -81,6 +81,13 @@ RSpec.describe "Api::Levelcode::V1::Account", type: :request do
       opus = body["models"].find { |m| m["id"] == "anthropic/claude-opus-4-8" }
       expect(opus["live"]).to be(true)                # price confirmed → live + billable
       expect(opus["multiplier"]).to be_within(0.05).of(6.67)
+
+      # Per-turn cost rides along in the SAME retail unit as the balance fields, so the dashboard can
+      # render "N credits/turn" beside "≈ turns left" using one conversion. ~7.7 credits on the 1×
+      # flagship; Opus is ~6.67× that.
+      expect(kimi["per_turn_micros"]).to be > 0
+      expect(Levelcode.micros_to_credits(kimi["per_turn_micros"])).to be_within(0.5).of(7.7)
+      expect(opus["per_turn_micros"]).to be > kimi["per_turn_micros"]
     end
   end
 


### PR DESCRIPTION
Balances are now shown in credits: $1 = 100 credits, so $12.79 left reads as 1,279 credits and the $100 Ultra plan is a 10,000-credit allowance. The reason is behavioural, not technical — a shrinking DOLLAR balance reads as money being lost, so people ration it; an allowance reads as something to spend.

PRESENTATION ONLY. The ledger, metering, Stripe prices and invoices all stay in micro-dollars, because dollars are what providers charge and what we actually bill; re-denominating stored balances would put Stripe reconciliation at risk for no gain, and would be painful to undo. Nothing about the economics moves.

The mapping needed no new maths: budget_micros == price × CREDIT_COGS_RATIO and retail_micros divides that ratio back out, so a plan's retail budget already IS its price — which makes the credit allowance exactly the price in CENTS. Pro 2,000 / Pro+ 4,000 / Max 6,000 / Ultra 10,000, verified against the running app.

- CREDITS_PER_DOLLAR + MICROS_PER_CREDIT: the unit, defined once beside the margin constant it derives from.
- micros_to_credits / plan_credits: conversion + the derived allowance.
- roster_for gains per_turn_micros — one turn's cost at RETAIL, the same unit as the balance, so the dashboard can print "N credits/turn" beside "≈ turns left" using a single conversion. Extracted per_turn_cost_micros so that figure and turns_left are computed from the SAME cost and cannot drift.
- Plan feature copy now leads with the credit allowance.

Verified: 968 examples, 0 failures. New specs pin the allowance to price_cents (the numbers the marketing copy prints), prove it survives a CREDIT_COGS_RATIO change, and assert balance ÷ per_turn_micros reproduces turns_left for every model on the plan. That last one is mutation-checked: dropping the routing fee from per_turn_micros so it diverges from turns_left fails the suite.