### PR TITLE
fix(levelcode): report account activity spend at RETAIL, not raw wire cost

### DIFF
--- a/app/controllers/api/levelcode/v1/account_controller.rb
+++ b/app/controllers/api/levelcode/v1/account_controller.rb
@@ -81,7 +81,9 @@ module Api
         # from the durable usage_events ledger. `year` defaults to the current year.
         def activity
           year = (params[:year].presence || Time.current.year).to_i
-          render json: ::Levelcode::Activity.for_user(current_user, year: year), status: :ok
+          # plan_key makes the per-model/day costs RETAIL — the same unit as the balance on this page.
+          render json: ::Levelcode::Activity.for_user(current_user, year: year, plan_key: current_plan_key),
+                 status: :ok
         end
 
         private

--- a/app/services/levelcode/activity.rb
+++ b/app/services/levelcode/activity.rb
@@ -10,7 +10,7 @@ module Levelcode
 
     # @return [Hash] { year:, total:, days: { "YYYY-MM-DD" => {count,input,output,cost_micros,models:[…]} },
     #                  models: [{model,count,input,output,cost_micros,up,down}, …], years: [Int,…] }
-    def for_user(user, year:)
+    def for_user(user, year:, plan_key: nil)
       year = year.to_i
       range = Time.zone.local(year, 1, 1).all_year
 
@@ -42,6 +42,22 @@ module Levelcode
       end
       # Fold each day's per-model map into a count-sorted array.
       days.each_value { |d| d[:models] = d[:models].map { |mm, v| v.merge(model: mm) }.sort_by { |x| -x[:count] } }
+
+      # Present the customer's OWN spend at RETAIL — the unit their balance is shown in. The ledger
+      # stores what a request cost us at the wire; leaving that raw here made the dashboard understate
+      # what the user actually spent (roughly by the margin), and put two different units on one page:
+      # a retail-converted balance above, cost-denominated per-model rows below. Converted on the
+      # AGGREGATES, so each figure rounds once rather than once per ledger row.
+      #
+      # plan_key nil leaves the raw COST figures alone, deliberately: an operator-side caller wants the
+      # real COGS, not what the customer was charged. (The admin panel does not use this service today.)
+      if plan_key
+        days.each_value do |d|
+          d[:cost_micros] = ::Levelcode.retail_micros(d[:cost_micros], plan_key)
+          d[:models].each { |dm| dm[:cost_micros] = ::Levelcode.retail_micros(dm[:cost_micros], plan_key) }
+        end
+        model_totals.each_value { |v| v[:cost_micros] = ::Levelcode.retail_micros(v[:cost_micros], plan_key) }
+      end
 
       fb = feedback_by_model(user, range)
       models = model_totals.map { |m, v| v.merge(model: m, up: fb.dig(m, "up").to_i, down: fb.dig(m, "down").to_i) }

--- a/spec/requests/api/levelcode/v1/account_spec.rb
+++ b/spec/requests/api/levelcode/v1/account_spec.rb
@@ -37,6 +37,41 @@ RSpec.describe "Api::Levelcode::V1::Account", type: :request do
       expect(body["years"]).to include(2026, 2025)
     end
 
+    it "reports the user's spend at RETAIL, matching the balance shown on the same page" do
+      # The ledger stores what a request cost us at the wire. Reporting that raw understated what the
+      # customer actually spent (by the margin) and put two units on one page — a retail balance above,
+      # cost-denominated per-model rows below. Both must now be the same unit, or the per-model figures
+      # cannot be reconciled against the credits the dashboard says were spent.
+      CreditWallet.create!(user: user, product: "levelcode", plan_key: "orbits_pro",
+                           input_cap: 15_000_000, output_cap: 2_000_000,
+                           budget_micros: Levelcode.budget_micros("orbits_pro"), spent_micros: 0,
+                           period_start: Time.current, period_end: 1.month.from_now, overage_policy: "throttle")
+      UsageEvent.create!(user: user, model: "moonshotai/kimi-k2.7-code", provider: "openrouter",
+                         input_tokens: 100, output_tokens: 50, cost_micros: 1_000,
+                         created_at: Time.zone.local(2026, 5, 2, 10))
+
+      get "/api/levelcode/v1/account/activity", params: { year: 2026 }
+
+      expect(response).to have_http_status(:ok)
+      expected = Levelcode.retail_micros(1_000, "orbits_pro")
+      expect(expected).to be > 1_000, "precondition: retail must exceed cost, or this proves nothing"
+      kimi = response.parsed_body["models"].find { |m| m["model"] == "moonshotai/kimi-k2.7-code" }
+      expect(kimi["cost_micros"]).to eq(expected)
+      expect(response.parsed_body.dig("days", "2026-05-02", "cost_micros")).to eq(expected)
+      day_model = response.parsed_body.dig("days", "2026-05-02", "models").first
+      expect(day_model["cost_micros"]).to eq(expected), "the per-day model rows must convert too"
+    end
+
+    it "leaves costs at raw COST when no plan_key is given (the operator's view)" do
+      # Levelcode::Activity is a shared service. An operator-side caller wants real COGS, not what the
+      # customer was charged — so the conversion is opt-in rather than baked into the aggregation.
+      UsageEvent.create!(user: user, model: "openai/gpt-oss-120b", provider: "openrouter",
+                         input_tokens: 10, output_tokens: 5, cost_micros: 777,
+                         created_at: Time.zone.local(2026, 6, 1, 10))
+      raw = Levelcode::Activity.for_user(user, year: 2026)
+      expect(raw[:models].find { |m| m[:model] == "openai/gpt-oss-120b" }[:cost_micros]).to eq(777)
+    end
+
     it "merges a dated model snapshot with feedback recorded against the base model id" do
       # Metering records the upstream-resolved snapshot; the editor records feedback against the
       # requested base id. They must aggregate to ONE per-model row (the reported bug).


### PR DESCRIPTION
The account page has been showing **two different units for the same quantity**: a retail-converted balance (`1,279 credits left`) above, and per-day / per-model spend summed straight from `usage_events.cost_micros` below.

The ledger stores what a request cost **us** at the wire. So those rows understated what the customer actually spent — by the margin — and could not be reconciled against the credits the same page reported as spent.

This is a real bug independent of credits: the per-model "cost" on the account page has been understating user spend in dollars all along.

## What changed

`Activity.for_user` takes an optional `plan_key` and converts the **aggregates** through `retail_micros` — one rounding per figure, rather than one per ledger row. The account controller passes the caller's plan.

Left **opt-in** rather than baked into the aggregation, deliberately: this is a shared service, and an operator-side caller wants real COGS, not what the customer was charged. Passing no `plan_key` still yields raw cost.

## Why the admin panel is not converted

Its figures carry no retail conversion — they are real **COGS**, what we pay providers. Credits are a *retail* unit (≈2× cost via `CREDIT_COGS_RATIO`), so rendering them there would conflate what we pay with what the customer is charged, and destroy the one view where margin is legible. Dollars are correct there.

## Verification

**971 examples, 0 failures.** New specs assert the retail figure on the per-model row, the per-day total **and** the per-day model rows — with a precondition that retail actually exceeds cost, so the assertion cannot pass vacuously. One more pins that the no-`plan_key` path still returns raw cost.

## Deploy order

The matching frontend change ([onetime #88](https://github.com/systemu-net/onetime/pull/88)) renders these figures as credits. **Ship this first** — until it lands, that UI would divide raw cost and understate spend by the margin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)