### PR TITLE
test(levelcode): pin the 50% gross-margin invariant

### DIFF
--- a/spec/models/levelcode_plans_spec.rb
+++ b/spec/models/levelcode_plans_spec.rb
@@ -97,6 +97,52 @@ RSpec.describe Levelcode do
     end
   end
 
+  describe 'gross margin (the economic invariant credits must not disturb)' do
+    # The business promise: model COGS stay at or below CREDIT_COGS_RATIO of subscription revenue, so
+    # gross margin is (1 - ratio) — 50% today — NO MATTER which models a customer picks. That holds
+    # because the budget is enforced in COST micro-$ while metering charges each model its real wire
+    # price: an expensive model burns the same dollar allowance faster, it does not overspend it.
+    #
+    # Denominating the customer's balance in CREDITS is presentation only and must never move this. This
+    # spec is the standing proof of that — if a future change to pricing, the roster, the routing fee or
+    # the credit conversion ever eats the margin, it fails here rather than in a monthly P&L.
+    it 'caps COGS at the target share of revenue for every plan' do
+      Levelcode::PLANS.each do |plan|
+        revenue = plan[:price_cents] / 100.0
+        max_cogs = Levelcode.budget_micros(plan[:key]) / 1_000_000.0
+        expect(max_cogs).to be <= (revenue * Levelcode::CREDIT_COGS_RATIO) + 0.005,
+                            "#{plan[:name]}: enforced budget $#{max_cogs.round(2)} exceeds its COGS share"
+        margin = (revenue - max_cogs) / revenue
+        expect(margin).to be >= (1 - Levelcode::CREDIT_COGS_RATIO) - 0.001,
+                          "#{plan[:name]}: margin #{(margin * 100).round(1)}% is under target"
+      end
+    end
+
+    it 'holds for ANY model mix — the worst case is still at target' do
+      # Spending the entire allowance on the single priciest model is the adversarial case: if margin
+      # survives that, it survives every blend. Checked per model rather than on an average.
+      Levelcode::PLANS.each do |plan|
+        revenue = plan[:price_cents] / 100.0
+        Levelcode.roster_for(plan[:key], Levelcode.budget_micros(plan[:key])).each do |m|
+          cogs = m[:turns_left] * Levelcode.per_turn_cost_micros(m[:id]) / 1_000_000.0
+          margin = (revenue - cogs) / revenue
+          expect(margin).to be >= (1 - Levelcode::CREDIT_COGS_RATIO) - 0.001,
+                            "#{plan[:name]} spent entirely on #{m[:id]}: margin #{(margin * 100).round(1)}%"
+        end
+      end
+    end
+
+    it 'keeps the credit allowance and the COGS ceiling two sides of one number' do
+      # credits are retail (= price), the enforced budget is cost (= price x ratio). If those ever drift
+      # apart, customers are either given credits we do not fund or funded for credits they cannot spend.
+      Levelcode::PLANS.each do |plan|
+        credits_in_dollars = Levelcode.plan_credits(plan[:key]) / Levelcode::CREDITS_PER_DOLLAR.to_f
+        cost_budget = Levelcode.budget_micros(plan[:key]) / 1_000_000.0
+        expect(cost_budget).to be_within(0.01).of(credits_in_dollars * Levelcode::CREDIT_COGS_RATIO)
+      end
+    end
+  end
+
   describe '.plan' do
     it 'looks up a plan by key' do
       expect(Levelcode.plan('orbits_max')[:name]).to eq('Max')


### PR DESCRIPTION
Answers *"how do we verify the credit economics still hold the 50% margin?"* with something that runs on every change, rather than a spreadsheet someone re-derives each quarter.

## The promise being pinned

Model COGS stay at or below `CREDIT_COGS_RATIO` of subscription revenue, so gross margin is `1 - ratio` = **50%** today — for **any** model mix. That holds because the budget is enforced in **cost** micro-$ while metering charges each model its real wire price: an expensive model burns the same dollar allowance *faster*, it cannot overspend it.

## Measured

Spending the whole allowance on a single model — the adversarial case, not an average:

| plan | price | credits | enforced budget (cost) | margin |
|---|---|---|---|---|
| Pro | $20 | 2,000 | $10.00 | **50.0%** |
| Pro+ | $40 | 4,000 | $20.00 | **50.0%** |
| Max | $60 | 6,000 | $30.00 | **50.0%** |
| Ultra | $100 | 10,000 | $50.00 | **50.0%** |

Worst single-model case on Ultra — gpt-oss, kimi-k2.7, kimi-k3, codex, gpt-5.5, sonnet, opus, fable — all land at **50.0–50.4%**. Never below target.

## Three specs

1. the per-plan COGS ceiling
2. the any-model-mix worst case, checked **per model** rather than on an average
3. that the credit allowance and the enforced cost budget stay two sides of one number — credits are retail (= price), the budget is cost (= price × ratio). If those drift, customers are either handed credits we don't fund, or funded for credits they can't spend.

Denominating balances in credits was presentation only and did not move any of this. This spec is the standing proof: a future change to pricing, the roster, the routing fee, or the conversion fails **here** rather than in a monthly P&L.

Verified: 34 examples, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)