### PR TITLE
fix(sidekiq): repair the worker boot, make the deploy check real, date usage from the request

### DIFF
--- a/.platform/files/start-sidekiq.sh
+++ b/.platform/files/start-sidekiq.sh
@@ -1,27 +1,60 @@
 #!/bin/bash
-# Wrapper script to set up Ruby environment for Sidekiq
+# Wrapper script to set up the Ruby environment for Sidekiq.
+#
+# HISTORY — read before editing. This script used to hardcode
+#   PATH=.../vendor/bundle/ruby/3.4.0/bin
+# When the Elastic Beanstalk platform moved to Ruby 4.0, that directory stopped existing. Sidekiq then
+# resolved through the system gems, where the bundler pinned in Gemfile.lock is absent, and died on
+# every boot with:
+#   "Could not find 'bundler' (~> 2.5) - did find: [bundler-4.0.10]"
+# Puma was unaffected — EB launches it through the platform's own Ruby setup rather than this wrapper —
+# so the site stayed up while the usage ledger silently froze for ~27 hours and 141 jobs queued.
+#
+# Two rules follow: never hardcode a Ruby ABI version here, and never assume the platform's bundler
+# matches the one recorded in Gemfile.lock.
 
-# Exit on error
-set -e
+set -euo pipefail
 
-# Change to app directory
 cd /var/app/current || exit 1
 
-# Set production environment first
 export RAILS_ENV=production
 export RACK_ENV=production
 export BUNDLE_GEMFILE=/var/app/current/Gemfile
 export BUNDLE_WITHOUT="development:test"
 
-# Try to source Ruby environment setup if it exists
-if [ -f /opt/elasticbeanstalk/bin/use-app-ruby.sh ]; then
-  source /opt/elasticbeanstalk/bin/use-app-ruby.sh
-elif [ -f /opt/elasticbeanstalk/support/scripts/use-app-ruby.sh ]; then
-  source /opt/elasticbeanstalk/support/scripts/use-app-ruby.sh
+# Adopt the platform's Ruby FIRST, so the vendored bundle selected below matches the interpreter we are
+# about to exec.
+for ruby_env in /opt/elasticbeanstalk/bin/use-app-ruby.sh /opt/elasticbeanstalk/support/scripts/use-app-ruby.sh; do
+  if [ -f "$ruby_env" ]; then
+    # shellcheck disable=SC1090
+    . "$ruby_env"
+    break
+  fi
+done
+
+# Resolve the vendored bundle for WHATEVER Ruby ABI is present, instead of a version baked in here.
+bundle_bin=""
+for candidate in /var/app/current/vendor/bundle/ruby/*/bin; do
+  if [ -d "$candidate" ]; then
+    bundle_bin="$candidate"
+    break
+  fi
+done
+export PATH="/var/app/current/bin${bundle_bin:+:$bundle_bin}:$PATH"
+
+# The bundler recorded in Gemfile.lock ("BUNDLED WITH") is what `bundle` activates. A platform upgrade
+# can ship a different one — exactly the failure above — so install the pinned version on demand rather
+# than refusing to boot. --user-install keeps it in the webapp user's GEM_PATH, needing no privileges.
+# Best effort: if it fails we still attempt to start, and the postdeploy verifier fails the deploy
+# loudly rather than leaving a dead worker behind.
+required_bundler="$(awk '/^BUNDLED WITH$/ { getline; gsub(/[[:space:]]/, ""); print; exit }' \
+  /var/app/current/Gemfile.lock 2>/dev/null || true)"
+if [ -n "$required_bundler" ] && ! gem list -i -v "$required_bundler" bundler >/dev/null 2>&1; then
+  echo "start-sidekiq: bundler $required_bundler not installed; installing (--user-install)"
+  gem install bundler -v "$required_bundler" --no-document --user-install ||
+    echo "start-sidekiq: WARNING could not install bundler $required_bundler; continuing"
 fi
 
-# Ensure bundler is in PATH
-export PATH="/var/app/current/bin:/var/app/current/vendor/bundle/ruby/3.4.0/bin:$PATH"
-
-# Start Sidekiq using binstub (cleaner than bundle exec)
-exec /var/app/current/bin/sidekiq -e production -C config/sidekiq.yml
+# `bundle exec` rather than the bin/sidekiq binstub: the binstub resolves through the pinned bundler,
+# which is the brittle path this entire comment is about.
+exec bundle exec sidekiq -e production -C config/sidekiq.yml

--- a/.platform/files/start-sidekiq.sh
+++ b/.platform/files/start-sidekiq.sh
@@ -32,14 +32,24 @@ for ruby_env in /opt/elasticbeanstalk/bin/use-app-ruby.sh /opt/elasticbeanstalk/
   fi
 done
 
-# Resolve the vendored bundle for WHATEVER Ruby ABI is present, instead of a version baked in here.
+# Resolve the vendored bundle for the ABI of the Ruby WE ARE ABOUT TO RUN, not merely the first one on
+# disk. A glob alone is not enough: a leftover 3.4.0 directory sitting beside a new 4.0.0 sorts first,
+# so we would hand the new interpreter the old gemset and walk straight back into the boot failure this
+# script exists to prevent. Ask Ruby for its own ABI, and only fall back to "any present" if that exact
+# path is missing (a fallback is still better than the hardcoded version this replaced).
+ruby_abi="$(ruby -e 'print RbConfig::CONFIG["ruby_version"]' 2>/dev/null || true)"
 bundle_bin=""
-for candidate in /var/app/current/vendor/bundle/ruby/*/bin; do
-  if [ -d "$candidate" ]; then
-    bundle_bin="$candidate"
-    break
-  fi
-done
+if [ -n "$ruby_abi" ] && [ -d "/var/app/current/vendor/bundle/ruby/${ruby_abi}/bin" ]; then
+  bundle_bin="/var/app/current/vendor/bundle/ruby/${ruby_abi}/bin"
+else
+  for candidate in /var/app/current/vendor/bundle/ruby/*/bin; do
+    if [ -d "$candidate" ]; then
+      bundle_bin="$candidate"
+      echo "start-sidekiq: WARNING no bundle for Ruby ABI '${ruby_abi:-unknown}'; falling back to $candidate"
+      break
+    fi
+  done
+fi
 export PATH="/var/app/current/bin${bundle_bin:+:$bundle_bin}:$PATH"
 
 # The bundler recorded in Gemfile.lock ("BUNDLED WITH") is what `bundle` activates. A platform upgrade

--- a/.platform/hooks/postdeploy/99_verify_sidekiq.sh
+++ b/.platform/hooks/postdeploy/99_verify_sidekiq.sh
@@ -25,16 +25,32 @@ dump_diagnostics() {
 
 echo "=== Verifying Sidekiq (up to ${READY_TIMEOUT}s) ==="
 
-# Poll rather than sampling once: the unit legitimately takes a few seconds to come up, and — more
-# importantly — a crash-looping unit under Restart=always flickers through "active", so a single
-# is-active check can catch it mid-bounce and pass. Require the unit active AND a live worker process.
+# Ask SYSTEMD for the worker pid rather than pattern-matching the process table.
+#
+# `pgrep -f sidekiq` cannot be used here: THIS SCRIPT is called 99_verify_sidekiq.sh, so its own command
+# line contains "sidekiq" and it matches itself. The check would then pass whenever the unit merely
+# reported active — including mid-bounce of a crash loop — which is the exact false negative this file
+# exists to eliminate. Demonstrated: pgrep -f sidekiq matches `bash .../99_verify_sidekiq.sh`.
+#
+# MainPID is systemd's own view of the process it started, so there is nothing to mis-match.
+worker_alive() {
+  local pid
+  pid="$(systemctl show sidekiq --property=MainPID --value 2>/dev/null || echo 0)"
+  [[ "${pid:-0}" =~ ^[0-9]+$ ]] || return 1
+  (( pid > 0 )) || return 1
+  kill -0 "$pid" 2>/dev/null
+}
+
+# Poll rather than sampling once: the unit legitimately takes a few seconds to come up, and a
+# crash-looping unit under Restart=always flickers through "active", so a single check can catch it
+# mid-bounce and pass.
 deadline=$(( SECONDS + READY_TIMEOUT ))
 while (( SECONDS < deadline )); do
-  if systemctl is-active --quiet sidekiq && pgrep -f "sidekiq" >/dev/null 2>&1; then
-    # Confirm it stays up, rather than being one bounce of a restart loop.
+  if systemctl is-active --quiet sidekiq && worker_alive; then
+    # Confirm it STAYS up, rather than being one bounce of a restart loop.
     sleep 5
-    if systemctl is-active --quiet sidekiq && pgrep -f "sidekiq" >/dev/null 2>&1; then
-      echo "OK: sidekiq is active with a live worker process."
+    if systemctl is-active --quiet sidekiq && worker_alive; then
+      echo "OK: sidekiq is active, MainPID $(systemctl show sidekiq --property=MainPID --value) alive."
       exit 0
     fi
   fi

--- a/.platform/hooks/postdeploy/99_verify_sidekiq.sh
+++ b/.platform/hooks/postdeploy/99_verify_sidekiq.sh
@@ -1,22 +1,47 @@
 #!/usr/bin/env bash
-# Test script to verify Sidekiq systemd setup
+# Verify Sidekiq is actually RUNNING after a deploy — and FAIL the deploy if it is not.
+#
+# This script used to only print diagnostics. Every check ended in `|| echo "..."` and the file ended on
+# a succeeding `ps`, so it returned 0 no matter what it found. On 2026-07-22 Sidekiq stopped booting
+# (the launcher pointed at a Ruby ABI a platform upgrade had removed) and this hook reported SUCCESS for
+# every deploy that followed. 141 jobs queued and the usage ledger froze for ~27 hours with nothing
+# flagged anywhere.
+#
+# A check that cannot fail is not a check. This one exits non-zero, which fails the deploy — that is the
+# point: a release that leaves the worker dead should not be reported as healthy.
 
-echo "=== Sidekiq Systemd Status ==="
-systemctl status sidekiq --no-pager || echo "Service not found"
+set -uo pipefail
 
-echo ""
-echo "=== Recent Sidekiq Logs (journalctl) ==="
-journalctl -u sidekiq -n 30 --no-pager || echo "No logs found"
+READY_TIMEOUT="${SIDEKIQ_READY_TIMEOUT:-45}"   # seconds to allow for a slow boot
 
-echo ""
-echo "=== Sidekiq Application Log ==="
-if [ -f /var/app/current/log/sidekiq.log ]; then
-  echo "Last 30 lines of sidekiq.log:"
-  tail -30 /var/app/current/log/sidekiq.log
-else
-  echo "No sidekiq.log found"
-fi
+dump_diagnostics() {
+  echo "--- systemctl status ---"
+  systemctl status sidekiq --no-pager 2>&1 | tail -25 || true
+  echo "--- last 40 lines of sidekiq.log ---"
+  tail -40 /var/app/current/log/sidekiq.log 2>/dev/null || echo "(no sidekiq.log)"
+  echo "--- journalctl -u sidekiq ---"
+  journalctl -u sidekiq -n 40 --no-pager 2>&1 | tail -40 || true
+}
 
-echo ""
-echo "=== Sidekiq Processes ==="
-ps auxf | grep -E "(sidekiq|PID)" | grep -v grep || echo "No process found"
+echo "=== Verifying Sidekiq (up to ${READY_TIMEOUT}s) ==="
+
+# Poll rather than sampling once: the unit legitimately takes a few seconds to come up, and — more
+# importantly — a crash-looping unit under Restart=always flickers through "active", so a single
+# is-active check can catch it mid-bounce and pass. Require the unit active AND a live worker process.
+deadline=$(( SECONDS + READY_TIMEOUT ))
+while (( SECONDS < deadline )); do
+  if systemctl is-active --quiet sidekiq && pgrep -f "sidekiq" >/dev/null 2>&1; then
+    # Confirm it stays up, rather than being one bounce of a restart loop.
+    sleep 5
+    if systemctl is-active --quiet sidekiq && pgrep -f "sidekiq" >/dev/null 2>&1; then
+      echo "OK: sidekiq is active with a live worker process."
+      exit 0
+    fi
+  fi
+  sleep 3
+done
+
+echo "FATAL: sidekiq is not running ${READY_TIMEOUT}s after deploy — failing the deploy."
+echo "Background jobs (usage ledger, wallet counters) would silently queue up behind this."
+dump_diagnostics
+exit 1

--- a/app/controllers/api/levelcode/v1/ai_controller.rb
+++ b/app/controllers/api/levelcode/v1/ai_controller.rb
@@ -235,7 +235,8 @@ module Api
           settled = true
           RecordUsageJob.perform_async(
             current_levelcode_user.id, request_id, billing_model, PROVIDER,
-            0, 0, 0, charge.to_i, wallet.period_end.to_i
+            0, 0, 0, charge.to_i, wallet.period_end.to_i,
+            Time.current.to_i # when it HAPPENED — the ledger row is dated from this, not from insert time
           )
           [ true, charge ]
         rescue => e
@@ -307,7 +308,8 @@ module Api
             output_tokens,
             cached,
             cost_micros,
-            wallet.period_end.to_i # period at enqueue — scopes the durable counter to the right period
+            wallet.period_end.to_i, # period at enqueue — scopes the durable counter to the right period
+            Time.current.to_i # when it HAPPENED — the ledger row is dated from this, not from insert time
           )
 
           [ true, cost_micros ] # [LevelCode] cost flows to stream_chat's credits frame

--- a/app/jobs/record_usage_job.rb
+++ b/app/jobs/record_usage_job.rb
@@ -17,7 +17,9 @@ class RecordUsageJob
   include Sidekiq::Job
   queue_as :default
 
-  def perform(user_id, request_id, model, provider, input_tokens, output_tokens, cached_input_tokens, cost_micros, period_end_epoch = nil)
+  # occurred_at_epoch is LAST and optional on purpose: jobs already sitting in the queue were
+  # serialized with the old arity, so a deploy of this change must not make them fail.
+  def perform(user_id, request_id, model, provider, input_tokens, output_tokens, cached_input_tokens, cost_micros, period_end_epoch = nil, occurred_at_epoch = nil)
     request_id = SecureRandom.uuid if request_id.blank? # never collapse blanks onto one row
 
     event = UsageEvent.create_or_find_by!(request_id: request_id) do |e|
@@ -28,7 +30,12 @@ class RecordUsageJob
         input_tokens: input_tokens.to_i,
         output_tokens: output_tokens.to_i,
         cached_input_tokens: cached_input_tokens.to_i,
-        cost_micros: cost_micros.to_i
+        cost_micros: cost_micros.to_i,
+        # Date the row from WHEN THE REQUEST HAPPENED, not when this job finally ran. Without this, any
+        # queue lag silently rewrites history: during the 2026-07-22 worker outage 141 jobs backed up,
+        # and draining them would have stamped every one with the recovery moment — a false spike on the
+        # recovery day and a permanent hole on the days the work was actually done.
+        created_at: occurred_at_epoch.present? ? Time.zone.at(occurred_at_epoch.to_i) : Time.current
       )
     end
 

--- a/app/jobs/record_usage_job.rb
+++ b/app/jobs/record_usage_job.rb
@@ -11,8 +11,13 @@ require "sidekiq"
 #     time (`period_end_epoch`), so a late job for an already-rolled period no-ops
 #     instead of corrupting the new period's totals.
 #
+#   - The row is DATED from `occurred_at_epoch` (when the request ran), not from when
+#     this job happens to execute — so a backed-up queue cannot rewrite usage history.
+#
 # Enqueued as: RecordUsageJob.perform_async(user_id, request_id, model, provider,
-#   input_tokens, output_tokens, cached_input_tokens, cost_micros, period_end_epoch).
+#   input_tokens, output_tokens, cached_input_tokens, cost_micros, period_end_epoch,
+#   occurred_at_epoch).
+# The last two are optional and trailing so jobs serialized by an older deploy still run.
 class RecordUsageJob
   include Sidekiq::Job
   queue_as :default

--- a/spec/jobs/record_usage_job_spec.rb
+++ b/spec/jobs/record_usage_job_spec.rb
@@ -16,6 +16,37 @@ RSpec.describe RecordUsageJob, type: :job do
     )
   end
 
+  describe "dating the ledger row" do
+    # The whole point: a job that runs LATE must still land on the day the request happened. During the
+    # 2026-07-22 worker outage 141 jobs backed up for ~27 hours; without this, draining them would have
+    # stamped every one with the recovery moment — a false spike on the recovery day and a permanent
+    # hole on the days the work was actually done.
+    it "dates the row from when the request happened, not when the job ran" do
+      happened = 2.days.ago.change(hour: 14, min: 30)
+
+      # No time-travel needed: the job runs NOW, the request happened two days ago. If the row is dated
+      # from insert time, created_at lands today and this fails.
+      described_class.new.perform(user.id, "req-late", "moonshotai/kimi-k2.7-code", "openrouter",
+                                  100, 50, 0, 1_000, nil, happened.to_i)
+
+      event = UsageEvent.find_by(request_id: "req-late")
+      expect(event.created_at).to be_within(1.second).of(happened)
+      expect(event.created_at.to_date).to eq(happened.to_date),
+                                          "a late job must not move the usage onto the day it was processed"
+      expect(event.created_at.to_date).not_to eq(Date.current)
+    end
+
+    it "falls back to now when no timestamp is given — jobs enqueued by the OLD code still work" do
+      # 141 jobs were already queued with the previous arity when this shipped. They must not fail, and
+      # the argument is optional and last precisely so they do not.
+      expect {
+        described_class.new.perform(user.id, "req-legacy", "openai/gpt-oss-120b", "openrouter",
+                                    10, 5, 0, 100)
+      }.not_to raise_error
+      expect(UsageEvent.find_by(request_id: "req-legacy").created_at).to be_within(30.seconds).of(Time.current)
+    end
+  end
+
   it "bumps the durable per-period counters on the first (unique) ledger insert" do
     pe = Time.zone.local(2026, 8, 7, 6, 32, 37)
     wallet = wallet_with(period_end: pe)

--- a/spec/requests/api/levelcode/v1/ai_spec.rb
+++ b/spec/requests/api/levelcode/v1/ai_spec.rb
@@ -170,8 +170,13 @@ RSpec.describe "Api::Levelcode::V1::Ai", type: :request do
     it "settles the reservation to the final usage (tokens + $ spend) and writes the durable ledger" do
       # reservation amount 0 (stubbed) → settle! reconciles to the actual cost_micros (1_000).
       expect(Levelcode::Metering).to receive(:settle!).with(wallet, 0, 12, 8, 1_000)
+      # The trailing arg is the occurred-at epoch: the ledger row is dated from WHEN THE REQUEST RAN,
+      # not from whenever Sidekiq gets to it, so a backed-up queue can't rewrite usage history. Asserted
+      # as a plausible "now" rather than kind_of(Integer) — passing the wrong integer (a duration, a
+      # period_end) would satisfy a type check while silently misdating every row.
       expect(RecordUsageJob).to receive(:perform_async)
-        .with(user.id, anything, kind_of(String), "openrouter", 12, 8, 4, 1_000, kind_of(Integer))
+        .with(user.id, anything, kind_of(String), "openrouter", 12, 8, 4, 1_000, kind_of(Integer),
+              be_within(60).of(Time.current.to_i))
 
       post "/api/levelcode/v1/ai/chat", params: body, as: :json
     end


### PR DESCRIPTION
Root cause of the frozen usage ledger, found in the EB log bundle. Sidekiq had not run since **2026-07-22 23:25 UTC (~27h)**, with **141 jobs queued** and **8 dead**, while the site served normally.

## 1. The boot failure

`start-sidekiq.sh` hardcoded `vendor/bundle/ruby/3.4.0/bin`. The platform moved to **Ruby 4.0**, that directory stopped existing, and Sidekiq resolved through system gems where the pinned bundler is absent:

```
Could not find 'bundler' (~> 2.5) - did find: [bundler-4.0.10]
```

`sidekiq.log` contains *nothing else*, on repeat — `Restart=always` retried forever. Puma was unaffected because EB launches it through the platform's own Ruby setup rather than this wrapper, which is precisely why the outage was invisible from the outside.

Now resolves the vendored bundle for whatever ABI is present, installs the `Gemfile.lock`-pinned bundler on demand (`--user-install`, no privileges needed), and uses `bundle exec` instead of the binstub that depends on that pin.

## 2. Why it hid for a day

`99_verify_sidekiq.sh` only **printed** diagnostics. Every check ended in `|| echo`, and the file ended on a succeeding `ps`, so it returned `0` regardless. It reported SUCCESS on every deploy while the worker was dead — including 01:18 on 24 Jul.

Verified against the old file, with Sidekiq absent:

```
OLD hook -> exit=0     NEW hook -> exit=1
```

It now polls up to 45s, requires the unit **active** *and* a live worker process, re-checks after 5s so a `Restart=always` crash-loop can't pass mid-bounce, and **fails the deploy** otherwise.

A check that cannot fail is not a check.

## 3. Queue lag rewrote history

`usage_events` has only `created_at`, the job never set it, and the enqueue passed no timestamp — so a late job is dated from when it was *processed*. Draining the 141-job backlog would have stamped all of them with the recovery moment: a false spike on one day, a permanent hole on the days the work happened.

Both enqueue sites now pass an occurred-at epoch and the job dates the row from it. The new argument is **last and optional** so the 141 jobs already serialized with the old arity keep working when this deploys — pinned by a spec.

## Verification

**973 examples, 0 failures.** The dating fix is mutation-checked (reverting to insert-time dating fails). The `ai_spec` assertion checks the timestamp is a plausible *now* rather than `kind_of(Integer)` — a wrong integer would satisfy a type check while misdating every row.

**Not verified on the instance** — I have no access. The launcher change is reasoned from the log bundle (`GEM_PATH=…/ruby/4.0.0` vs the hardcoded `3.4.0`). Fix 2 is what makes that safe: if the launcher is still wrong, the next deploy fails loudly instead of pretending.

## After deploying

- The 141 queued jobs **will** still be mis-dated — their payloads predate this change and carry no timestamp. Unavoidable.
- The **8 dead jobs** are lost usage events (unbilled spend); worth inspecting before clearing, as they may name the original trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)