### PR TITLE
feat(catalog): enable the frontier models (Codex 5.3, GPT-5.5, Sonnet 5, Fable 5)

### DIFF
--- a/app/services/levelcode/model_catalog.rb
+++ b/app/services/levelcode/model_catalog.rb
@@ -18,10 +18,12 @@ module Levelcode
     TIERS = { free: 0, pro: 1, pro_plus: 2, max: 3, ultra: 4 }.freeze
 
     # The roster. Prices are micro-dollars per token (== $/M tokens). `status`:
-    #   :confirmed  — a verified provider list price.
-    #   :assumption — a lineage-based estimate. It MUST be replaced with a live quote before the model
-    #                 is billed on. (Because the ledger meters ACTUAL response cost, an assumed price
-    #                 only skews the DISPLAYED multiplier, never the charge — but keep them honest.)
+    #   :confirmed  — a verified/adopted list price. As of 2026-07-25 EVERY row is confirmed: the frontier
+    #                 engines (Codex 5.3, GPT-5.5, Sonnet 5, Fable 5) went live, their lineage-estimated
+    #                 prices adopted as official. Fable 5 stays Max-tier by entitlement, not by price.
+    #   :assumption — a lineage estimate: shown as "coming soon", never billable. None remain today; the
+    #                 tier stays so a future model can be staged before its price lands. (The ledger meters
+    #                 ACTUAL response cost, so an estimate only skews the DISPLAYED multiplier, not the charge.)
     MODELS = {
       "openai/gpt-oss-120b" => {
         label: "gpt-oss-120b", provider: "openrouter",
@@ -36,17 +38,17 @@ module Levelcode
       "openai/codex-5.3" => {
         label: "Codex 5.3", provider: "openrouter",
         input: 1.25, cached_input: 0.125, output: 10.00,
-        context: 400_000, min_tier: :pro, status: :assumption
+        context: 400_000, min_tier: :pro, status: :confirmed
       },
       "openai/gpt-5.5" => {
         label: "GPT-5.5", provider: "openrouter",
         input: 1.50, cached_input: 0.15, output: 12.00,
-        context: 400_000, min_tier: :pro, status: :assumption
+        context: 400_000, min_tier: :pro, status: :confirmed
       },
       "anthropic/claude-sonnet-5" => {
         label: "Sonnet 5", provider: "openrouter",
         input: 3.00, cached_input: 0.30, output: 15.00,
-        context: 200_000, min_tier: :pro, status: :assumption
+        context: 200_000, min_tier: :pro, status: :confirmed
       },
       # Ordered by cost, NOT by family: K3 sits by its ~4.00× multiplier (== Sonnet 5's, same rates),
       # not next to Kimi K2.7 — the monotonic-multiplier invariant (spec) is what keeps the picker honest.
@@ -87,7 +89,7 @@ module Levelcode
         label: "Fable 5", provider: "openrouter",
         input: 10.00, cached_input: 1.00, output: 50.00,
         # 13.35× → only ~28 Pro turns; gated to Max/Ultra so it never feels broken (rec #3).
-        context: 200_000, min_tier: :max, status: :assumption
+        context: 200_000, min_tier: :max, status: :confirmed
       }
     }.freeze
 

--- a/app/services/levelcode/model_catalog.rb
+++ b/app/services/levelcode/model_catalog.rb
@@ -35,23 +35,23 @@ module Levelcode
         input: 0.74, cached_input: 0.15, output: 3.50,
         context: 262_144, min_tier: :pro, status: :confirmed
       },
-      "openai/codex-5.3" => {
-        label: "Codex 5.3", provider: "openrouter",
-        input: 1.25, cached_input: 0.125, output: 10.00,
-        context: 400_000, min_tier: :pro, status: :confirmed
-      },
-      "openai/gpt-5.5" => {
-        label: "GPT-5.5", provider: "openrouter",
-        input: 1.50, cached_input: 0.15, output: 12.00,
-        context: 400_000, min_tier: :pro, status: :confirmed
-      },
+      # Frontier rows re-verified against the OpenRouter models API on 2026-07-26 -- the earlier lineage
+      # estimates were wrong (Codex even carried a non-existent slug). Ordered by COST (ascending multiplier),
+      # the monotonic-multiplier invariant (spec) the picker relies on.
       "anthropic/claude-sonnet-5" => {
         label: "Sonnet 5", provider: "openrouter",
-        input: 3.00, cached_input: 0.30, output: 15.00,
-        context: 200_000, min_tier: :pro, status: :confirmed
+        # OpenRouter 2026-07-26: $2/M in, $10/M out, $0.20/M cached, 1M ctx.
+        input: 2.00, cached_input: 0.20, output: 10.00,
+        context: 1_000_000, min_tier: :pro, status: :confirmed
       },
-      # Ordered by cost, NOT by family: K3 sits by its ~4.00× multiplier (== Sonnet 5's, same rates),
-      # not next to Kimi K2.7 — the monotonic-multiplier invariant (spec) is what keeps the picker honest.
+      "openai/gpt-5.3-codex" => {
+        label: "Codex 5.3", provider: "openrouter",
+        # OpenRouter 2026-07-26 (openai/gpt-5.3-codex): $1.75/M in, $14/M out, $0.175/M cached, 400K ctx.
+        # The old `openai/codex-5.3` slug does NOT exist on OpenRouter -- it would 404 / fall back to max rate.
+        input: 1.75, cached_input: 0.175, output: 14.00,
+        context: 400_000, min_tier: :pro, status: :confirmed
+      },
+      # K3 sits by its ~4.00x multiplier, not next to Kimi K2.7 -- the monotonic-multiplier invariant (spec).
       "moonshotai/kimi-k3" => {
         label: "Kimi K3", provider: "openrouter",
         # Confirmed vs OpenRouter (2026-07-20): $3/M in · $15/M out · $0.30/M cached read. Reached via
@@ -85,11 +85,18 @@ module Levelcode
         input: 5.00, cached_input: 0.50, output: 25.00,
         context: 1_000_000, min_tier: :pro, status: :confirmed
       },
+      "openai/gpt-5.5" => {
+        label: "GPT-5.5", provider: "openrouter",
+        # OpenRouter 2026-07-26: $5/M in, $30/M out, $0.50/M cached, 1.05M ctx (922K in / 128K out).
+        input: 5.00, cached_input: 0.50, output: 30.00,
+        context: 1_050_000, min_tier: :pro, status: :confirmed
+      },
       "anthropic/claude-fable-5" => {
         label: "Fable 5", provider: "openrouter",
+        # OpenRouter 2026-07-26: $10/M in, $50/M out, $1/M cached, 1M ctx. ~13.3x -> ~28 Pro turns;
+        # gated to Max/Ultra so it never feels broken (rec #3).
         input: 10.00, cached_input: 1.00, output: 50.00,
-        # 13.35× → only ~28 Pro turns; gated to Max/Ultra so it never feels broken (rec #3).
-        context: 200_000, min_tier: :max, status: :confirmed
+        context: 1_000_000, min_tier: :max, status: :confirmed
       }
     }.freeze
 

--- a/app/services/levelcode/model_catalog.rb
+++ b/app/services/levelcode/model_catalog.rb
@@ -17,13 +17,14 @@ module Levelcode
     # Plan tiers, ranked. A model with `min_tier: T` is reachable by any plan of rank >= rank(T).
     TIERS = { free: 0, pro: 1, pro_plus: 2, max: 3, ultra: 4 }.freeze
 
-    # The roster. Prices are micro-dollars per token (== $/M tokens). `status`:
-    #   :confirmed  — a verified/adopted list price. As of 2026-07-25 EVERY row is confirmed: the frontier
-    #                 engines (Codex 5.3, GPT-5.5, Sonnet 5, Fable 5) went live, their lineage-estimated
-    #                 prices adopted as official. Fable 5 stays Max-tier by entitlement, not by price.
-    #   :assumption — a lineage estimate: shown as "coming soon", never billable. None remain today; the
-    #                 tier stays so a future model can be staged before its price lands. (The ledger meters
-    #                 ACTUAL response cost, so an estimate only skews the DISPLAYED multiplier, not the charge.)
+    # The roster. Prices are micro-dollars per token (== $/M tokens). `status` records HOW a row's price
+    # was established — a per-row property, deliberately not a point-in-time statement about the roster:
+    #   :confirmed  — a verified provider list price (each row cites its source + date inline). Only
+    #                 confirmed rows are selectable/billable; entitlement then gates access by min_tier.
+    #   :assumption — a lineage estimate: shown as "coming soon", never billable. Staged so a model can
+    #                 land before its price is quoted; flip to :confirmed once a live quote is in hand.
+    #                 (The ledger meters ACTUAL response cost, so an estimate only skews the DISPLAYED
+    #                 multiplier, never the charge — but keep them honest and short-lived.)
     MODELS = {
       "openai/gpt-oss-120b" => {
         label: "gpt-oss-120b", provider: "openrouter",

--- a/spec/models/levelcode_model_catalog_spec.rb
+++ b/spec/models/levelcode_model_catalog_spec.rb
@@ -4,15 +4,15 @@ require "rails_helper"
 # design invariants hold (entitlement tiers, monotonic multipliers, dollar-denominated budgets).
 RSpec.describe Levelcode::ModelCatalog do
   describe "roster integrity" do
-    it "marks only the verified engines as confirmed; frontier rows are assumptions" do
-      expect(described_class.find("openai/gpt-oss-120b")[:status]).to eq(:confirmed)
-      expect(described_class.find("moonshotai/kimi-k2.7-code")[:status]).to eq(:confirmed)
-      expect(described_class.find("anthropic/claude-opus-4-8")[:status]).to eq(:confirmed) # price confirmed 2026-07-07
-      expect(described_class.find("moonshotai/kimi-k3")[:status]).to eq(:confirmed)       # OpenRouter list, 2026-07-20
-      expect(described_class.find("anthropic/claude-opus-5")[:status]).to eq(:confirmed)  # OpenRouter list, 2026-07-24
+    it "carries a confirmed price on every roster engine — the frontier rows are enabled now" do
+      %w[openai/gpt-oss-120b moonshotai/kimi-k2.7-code anthropic/claude-opus-4-8 moonshotai/kimi-k3
+         anthropic/claude-opus-5 openai/codex-5.3 openai/gpt-5.5 anthropic/claude-sonnet-5
+         anthropic/claude-fable-5].each do |id|
+        expect(described_class.find(id)[:status]).to eq(:confirmed), id
+      end
+      # Nothing left staged — the "coming soon" set is empty.
       assumed = described_class.all.select { |_id, m| m[:status] == :assumption }.keys
-      expect(assumed).to include("anthropic/claude-fable-5", "openai/gpt-5.5")
-      expect(assumed).not_to include("anthropic/claude-opus-4-8")
+      expect(assumed).to be_empty
     end
 
     # `context` is not decoration — estimate_cost_micros clamps its input estimate DOWN to it, so a

--- a/spec/models/levelcode_model_catalog_spec.rb
+++ b/spec/models/levelcode_model_catalog_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Levelcode::ModelCatalog do
   describe "roster integrity" do
     it "carries a confirmed price on every roster engine — the frontier rows are enabled now" do
       %w[openai/gpt-oss-120b moonshotai/kimi-k2.7-code anthropic/claude-opus-4-8 moonshotai/kimi-k3
-         anthropic/claude-opus-5 openai/codex-5.3 openai/gpt-5.5 anthropic/claude-sonnet-5
+         anthropic/claude-opus-5 openai/gpt-5.3-codex openai/gpt-5.5 anthropic/claude-sonnet-5
          anthropic/claude-fable-5].each do |id|
         expect(described_class.find(id)[:status]).to eq(:confirmed), id
       end
@@ -44,12 +44,12 @@ RSpec.describe Levelcode::ModelCatalog do
 
     it "reproduces the analysis multipliers (within rounding)" do
       {
-        "openai/gpt-oss-120b" => 0.05, "moonshotai/kimi-k2.7-code" => 1.00, "openai/codex-5.3" => 2.22,
-        "openai/gpt-5.5" => 2.66, "anthropic/claude-sonnet-5" => 4.00, "moonshotai/kimi-k3" => 4.00,
+        "openai/gpt-oss-120b" => 0.05, "moonshotai/kimi-k2.7-code" => 1.00,
+        "anthropic/claude-sonnet-5" => 2.67, "openai/gpt-5.3-codex" => 3.10, "moonshotai/kimi-k3" => 4.00,
         # Opus 5 TIES Opus 4.8 — identical rates ⇒ identical multiplier. That tie is exactly what lets
         # it sit beside 4.8 without disturbing the monotonic ordering asserted below.
         "anthropic/claude-opus-4-8" => 6.67, "anthropic/claude-opus-5" => 6.67,
-        "anthropic/claude-fable-5" => 13.35
+        "openai/gpt-5.5" => 7.40, "anthropic/claude-fable-5" => 13.35
       }.each { |id, mult| expect(described_class.multiplier(id)).to be_within(0.02).of(mult) }
     end
 

--- a/spec/models/levelcode_plans_spec.rb
+++ b/spec/models/levelcode_plans_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe Levelcode do
 
     it 'a paid plan may use the flagship AND the open-weights engine (confirmed-price roster)' do
       # Every Pro-tier engine is confirmed now — the frontier rows (Codex 5.3, GPT-5.5, Sonnet 5) went live.
-      expect(Levelcode.allowed_models('orbits_pro')).to match_array([ Levelcode::DEFAULT_MODEL, Levelcode::FREE_MODEL, 'anthropic/claude-opus-4-8', 'anthropic/claude-opus-5', 'moonshotai/kimi-k3', 'openai/codex-5.3', 'openai/gpt-5.5', 'anthropic/claude-sonnet-5' ])
+      expect(Levelcode.allowed_models('orbits_pro')).to match_array([ Levelcode::DEFAULT_MODEL, Levelcode::FREE_MODEL, 'anthropic/claude-opus-4-8', 'anthropic/claude-opus-5', 'moonshotai/kimi-k3', 'openai/gpt-5.3-codex', 'openai/gpt-5.5', 'anthropic/claude-sonnet-5' ])
       # Fable 5 is confirmed too, but Max-tier — a Pro plan still can't reach it (entitlement, not price).
       expect(Levelcode.allowed_models('orbits_pro')).not_to include('anthropic/claude-fable-5')
     end

--- a/spec/models/levelcode_plans_spec.rb
+++ b/spec/models/levelcode_plans_spec.rb
@@ -114,10 +114,10 @@ RSpec.describe Levelcode do
     end
 
     it 'a paid plan may use the flagship AND the open-weights engine (confirmed-price roster)' do
-      # Kimi K3, then Opus 5, joined the confirmed-price roster as selectable Pro picks.
-      expect(Levelcode.allowed_models('orbits_pro')).to match_array([ Levelcode::DEFAULT_MODEL, Levelcode::FREE_MODEL, 'anthropic/claude-opus-4-8', 'anthropic/claude-opus-5', 'moonshotai/kimi-k3' ])
-      # A tier-entitled but ASSUMPTION-priced frontier model stays staged — never billed on a guess.
-      expect(Levelcode.allowed_models('orbits_pro')).not_to include('openai/gpt-5.5')
+      # Every Pro-tier engine is confirmed now — the frontier rows (Codex 5.3, GPT-5.5, Sonnet 5) went live.
+      expect(Levelcode.allowed_models('orbits_pro')).to match_array([ Levelcode::DEFAULT_MODEL, Levelcode::FREE_MODEL, 'anthropic/claude-opus-4-8', 'anthropic/claude-opus-5', 'moonshotai/kimi-k3', 'openai/codex-5.3', 'openai/gpt-5.5', 'anthropic/claude-sonnet-5' ])
+      # Fable 5 is confirmed too, but Max-tier — a Pro plan still can't reach it (entitlement, not price).
+      expect(Levelcode.allowed_models('orbits_pro')).not_to include('anthropic/claude-fable-5')
     end
 
     it 'free CANNOT reach the flagship no matter what is requested' do
@@ -259,8 +259,9 @@ RSpec.describe Levelcode do
 
     it 'falls back to the MOST EXPENSIVE confirmed rate for unknown/off-catalog models (never under-bills)' do
       # An off-catalog id (e.g. a dated snapshot or upstream substitution) must not bill at the cheapest
-      # rate. Conservative fallback = the max confirmed rate (Opus input 5.0): 1M * 5.0 * 1.055 = 5_275_000
-      expect(Levelcode.cost_micros('some/unknown-model', 1_000_000, 0, 0)).to eq(5_275_000)
+      # rate. Conservative fallback = the max confirmed rate. Now that Fable 5 is confirmed, the max input
+      # rate is 10.0 (Fable, up from Opus's 5.0): 1M * 10.0 * 1.055 = 10_550_000.
+      expect(Levelcode.cost_micros('some/unknown-model', 1_000_000, 0, 0)).to eq(10_550_000)
     end
 
     it 'bills the free-tier engine at its own (much cheaper) rate (incl. routing fee)' do


### PR DESCRIPTION
Enables the four staged "coming soon" frontier models in the LevelCode Cloud roster, at prices **re-verified against the OpenRouter models API (2026-07-26)**.

## What changes

Flips `status: :assumption → :confirmed` for the frontier engines, which makes them **selectable + billable**:

| Model | id | Reachable by |
|---|---|---|
| Sonnet 5 | `anthropic/claude-sonnet-5` | `min_tier: :pro` → **Pro and up** |
| Codex 5.3 | `openai/gpt-5.3-codex` | `min_tier: :pro` → **Pro and up** |
| GPT-5.5 | `openai/gpt-5.5` | `min_tier: :pro` → **Pro and up** |
| Fable 5 | `anthropic/claude-fable-5` | `min_tier: :max` → **Max and up** |

This preserves the established roster invariant — **Pro reaches every engine except Fable; Fable alone is gated to Max/Ultra by entitlement (UX rec #3), not by price** — exactly as Opus 5 and Kimi K3 already behave on Pro. The editor picker drops the 🔒 "coming soon" and the roster's `live` flag flips to `true`.

## Price correction (2nd commit)

The first commit enabled with lineage estimates; the second commit **re-verified every frontier row against OpenRouter's live API** and corrected them (these are real charges, so I verified rather than trusting the estimates):

| Model | id | in / out / cached ($/M) | context |
|---|---|---|---|
| Sonnet 5 | `anthropic/claude-sonnet-5` | 3 / 15 / 0.30 → **2 / 10 / 0.20** | 200K → **1M** |
| Codex 5.3 | ~~`openai/codex-5.3`~~ → **`openai/gpt-5.3-codex`** | 1.25 / 10 / 0.125 → **1.75 / 14 / 0.175** | 400K |
| GPT-5.5 | `openai/gpt-5.5` | 1.50 / 12 / 0.15 → **5 / 30 / 0.50** | 400K → **1.05M** |
| Fable 5 | `anthropic/claude-fable-5` | 10 / 50 / 1 (already correct) | 200K → **1M** |

**The Codex id was corrected, not merely status-flipped:** the original `openai/codex-5.3` does not exist on OpenRouter (the live id is `openai/gpt-5.3-codex`). Because that row was only ever `:assumption` (coming-soon → never selectable/billable/GA), nothing persisted or referenced it — a repo-wide grep finds zero uses of the old slug outside the catalog — so there is no migration. And `gateway_model` already remaps any unknown *requested* id to the plan default, so the non-existent slug could never have reached OpenRouter regardless. No alias layer is needed.

The corrected costs re-order the catalog, so it's re-sorted ascending by multiplier to hold the monotonic-multiplier invariant (Sonnet 5 → 2.67×, Codex 5.3 → 3.10×, … GPT-5.5 → 7.40×, Fable 5 → 13.3×).

## Billing safety

The ledger **meters actual response cost**, so a price only drives the *displayed* multiplier — a wrong price never mis-charges a turn. The one real side effect is in the safe direction: `max_confirmed_rate` (the fallback that bills unknown/off-catalog ids so they can never under-bill) is Fable's `$10/$50`; the fallback spec asserts `10_550_000`.

## Tests

- `model_catalog_spec` + `plans_spec`: **49 examples, 0 failures** — derived multipliers, monotonic ordering, `orbits_pro` `allowed_models` (incl. the 3 Pro frontier rows), off-catalog fallback.
- ⚠️ The account **request** spec has a **pre-existing, unrelated** failure on develop — a mailer-view `NoMethodError` (`User ID: <%= @user.id %>`) at setup, which reproduces with this change reverted. Not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
