### PR TITLE
feat(levelcode): referral funnel API + attribution on OAuth signups

### DIFF
--- a/app/controllers/api/levelcode/v1/admin_controller.rb
+++ b/app/controllers/api/levelcode/v1/admin_controller.rb
@@ -24,6 +24,17 @@ module Api
           ), status: :ok
         end
 
+        # GET /api/levelcode/v1/admin/referrals?from=YYYY-MM-DD&to=YYYY-MM-DD
+        # Referral funnel per marketing channel: clicks -> signups -> paid.
+        def referrals
+          render json: ::Levelcode::ReferralReport.funnel(
+            from: params[:from].presence,
+            to: params[:to].presence
+          ), status: :ok
+        rescue Date::Error
+          render_levelcode_error("bad_request", "from/to must be YYYY-MM-DD dates", :bad_request)
+        end
+
         private
 
         def require_admin!

--- a/app/controllers/levelcode/web_controller.rb
+++ b/app/controllers/levelcode/web_controller.rb
@@ -435,20 +435,37 @@ module Levelcode
       if src.is_a?(Hash)
         ATTRIBUTION_PARAM_KEYS.each do |k|
           v = src[k] || src[k.to_sym]
-          params[k] = v.to_s[0, 120] if v.present?
+          cleaned = attribution_string(v, 120)
+          params[k] = cleaned if cleaned.present?
         end
       end
-      source = h["source"].to_s[0, 40]
+      source = attribution_string(h["source"], 40)
       return nil if params.empty? && source.blank?
 
       {
         "source" => source.presence || "other",
         "params" => params,
-        "landing" => h["landing"].to_s[0, 300].presence,
-        "referrer" => h["referrer"].to_s[0, 300].presence,
-        "ts" => h["ts"].to_s[0, 40].presence,
+        "landing" => attribution_string(h["landing"], 300).presence,
+        "referrer" => attribution_string(h["referrer"], 300).presence,
+        "ts" => attribution_string(h["ts"], 40).presence,
         "recorded_at" => Time.current.utc.iso8601
       }.compact
+    end
+
+    # Clean one attribution string: strip CONTROL CHARACTERS, then clamp.
+    #
+    # Length clamping alone was not enough. `source` and the param values are
+    # client-controlled and end up interpolated into the notification email's
+    # Subject header, so a value containing CR/LF is header injection — and at
+    # minimum makes the Mail gem raise, killing the signup notification job.
+    # Stripping here means nothing dangerous is ever STORED, which also protects
+    # every later consumer (the referral report, the dashboard) rather than just
+    # the one that happens to build a header today.
+    #
+    # Control chars are removed before the clamp so the limit applies to what is
+    # actually kept.
+    def attribution_string(value, limit)
+      value.to_s.gsub(/[[:cntrl:]]/, " ").squeeze(" ").strip[0, limit].to_s
     end
 
     def valid_email?(email)

--- a/app/controllers/levelcode/web_controller.rb
+++ b/app/controllers/levelcode/web_controller.rb
@@ -103,6 +103,13 @@ module Levelcode
       state = SecureRandom.urlsafe_base64(24)
       session[:levelcode_oauth_state] = state
       session[:levelcode_oauth_provider] = provider
+      # Carry the SPA's first-touch marketing attribution across the provider
+      # round-trip. It rides the session (like `state`) rather than the provider
+      # redirect, so it can't be tampered with at the provider and comes back to
+      # the same browser. Clamped because the session lives in a 4 KB cookie and
+      # this value is client-supplied; it is sanitized again before it reaches
+      # the DB (see stamp_oauth_attribution!).
+      session[:levelcode_oauth_attribution] = params[:attribution].to_s[0, 2_000].presence
 
       url = Levelcode::ProviderOAuth.authorize_url(provider: provider, redirect_uri: oauth_callback_uri, state: state)
       redirect_to url, allow_other_host: true
@@ -114,6 +121,7 @@ module Levelcode
     def oauth_callback
       provider = session.delete(:levelcode_oauth_provider).to_s
       expected_state = session.delete(:levelcode_oauth_state).to_s
+      raw_attribution = session.delete(:levelcode_oauth_attribution)
 
       if expected_state.blank? || params[:state].to_s != expected_state
         log_auth(kind: "oauth", outcome: "failure", provider: provider, reason: "session_expired")
@@ -130,6 +138,8 @@ module Levelcode
         log_auth(kind: "oauth", outcome: "failure", provider: provider, reason: "oauth_failed")
         return redirect_to("/ai/login?error=oauth_failed")
       end
+
+      stamp_oauth_attribution!(user, raw_attribution)
 
       log_auth(kind: "oauth", outcome: "success", user: user, provider: provider)
       touch_access!(user)
@@ -350,6 +360,46 @@ module Levelcode
       # on users.email rejected the loser. Re-find the winner so a valid sign-in never 500s. (Attribution
       # was stamped by whichever request won the create; the loser just returns the existing account.)
       User.find_by(email: email)
+    end
+
+    # Stamp first-touch attribution on a user who just signed up via OAuth.
+    #
+    # The email path can pass attribution straight into User.create; OAuth cannot,
+    # because GitHub and Google create the user through two different services
+    # (ProviderOAuth.find_or_create_oauth_user and User.from_google). Doing it here
+    # keeps one rule in one place for both providers.
+    #
+    # Two guards, and both matter for whether a partner's numbers mean anything:
+    #   * previously_new_record? — stamp ONLY on the create. Someone who signed up
+    #     months ago and today happens to arrive via a referral link was not
+    #     acquired by that channel; crediting them would be last-touch and would
+    #     inflate the partner's conversions.
+    #   * signup_attribution.nil? — never overwrite an existing value.
+    def stamp_oauth_attribution!(user, raw)
+      return unless user&.persisted? && user.previously_new_record?
+      return unless user.signup_attribution.nil?
+
+      attribution = sanitize_signup_attribution(parse_attribution_json(raw))
+      return if attribution.nil?
+
+      # update_column: skip validations/callbacks — this is analytics metadata and
+      # must never be able to fail a sign-in that already succeeded.
+      user.update_column(:signup_attribution, attribution)
+    rescue StandardError => e
+      # Attribution is best-effort. A signed-in user must not be bounced to an
+      # error page because a marketing field could not be written.
+      Rails.logger.warn("[levelcode] oauth attribution stamp failed: #{e.class}: #{e.message}")
+    end
+
+    # The session carries the SPA's attribution as the JSON string it put in the
+    # URL. Anything unparseable is simply organic — never an error.
+    def parse_attribution_json(raw)
+      return nil if raw.blank?
+
+      parsed = JSON.parse(raw.to_s)
+      parsed.is_a?(Hash) ? parsed : nil
+    rescue JSON::ParserError
+      nil
     end
 
     # Campaign params we recognize (mirror of the SPA's attribution util). Anything else is dropped.

--- a/app/controllers/levelcode/web_controller.rb
+++ b/app/controllers/levelcode/web_controller.rb
@@ -106,10 +106,9 @@ module Levelcode
       # Carry the SPA's first-touch marketing attribution across the provider
       # round-trip. It rides the session (like `state`) rather than the provider
       # redirect, so it can't be tampered with at the provider and comes back to
-      # the same browser. Clamped because the session lives in a 4 KB cookie and
-      # this value is client-supplied; it is sanitized again before it reaches
-      # the DB (see stamp_oauth_attribution!).
-      session[:levelcode_oauth_attribution] = params[:attribution].to_s[0, 2_000].presence
+      # the same browser. Sanitized again before it reaches the DB (see
+      # stamp_oauth_attribution!).
+      session[:levelcode_oauth_attribution] = clamp_session_bytes(params[:attribution])
 
       url = Levelcode::ProviderOAuth.authorize_url(provider: provider, redirect_uri: oauth_callback_uri, state: state)
       redirect_to url, allow_other_host: true
@@ -389,6 +388,25 @@ module Levelcode
       # Attribution is best-effort. A signed-in user must not be bounced to an
       # error page because a marketing field could not be written.
       Rails.logger.warn("[levelcode] oauth attribution stamp failed: #{e.class}: #{e.message}")
+    end
+
+    # Session budget for the attribution blob, in BYTES.
+    #
+    # Bytes, not characters: the Rails session is a ~4 KB cookie, and this value is
+    # client-supplied. A 2,000-CHARACTER clamp permits up to 8,000 bytes of
+    # multi-byte UTF-8, which can overflow the cookie — and an overflowing cookie
+    # takes the OAuth `state` down with it, turning a sign-in into
+    # "?error=session_expired".
+    ATTRIBUTION_SESSION_MAX_BYTES = 2_000
+
+    def clamp_session_bytes(raw)
+      s = raw.to_s
+      return nil if s.empty?
+
+      # byteslice can cut mid-character; scrub drops the resulting invalid tail so
+      # what lands in the session is always valid UTF-8 (JSON.parse would reject it
+      # otherwise, silently losing the attribution).
+      s.byteslice(0, ATTRIBUTION_SESSION_MAX_BYTES).to_s.scrub("").presence
     end
 
     # The session carries the SPA's attribution as the JSON string it put in the

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -40,10 +40,14 @@ class UserMailer < ApplicationMailer
   end
 
   # How they got in. `provider` is set only on the OAuth paths.
+  #
+  # Compared against the constants, not literals: Google's stored value is
+  # "google_oauth2" (User::GOOGLE_PROVIDER), so a hardcoded "google" silently
+  # falls through and reports every Google signup as Email.
   def signup_method_for(user)
     case user.provider.to_s
-    when "github" then "GitHub"
-    when "google" then "Google"
+    when ::Levelcode::ProviderOAuth::GITHUB_PROVIDER then "GitHub"
+    when User::GOOGLE_PROVIDER then "Google"
     else "Email"
     end
   end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -32,11 +32,26 @@ class UserMailer < ApplicationMailer
 
   # Channel in the subject line, so a run of these is scannable from the inbox
   # list without opening anything.
+  #
+  # Every interpolated value is scrubbed of control characters first. The
+  # sanitizer now strips them before storing, but rows written BEFORE that fix
+  # are still in the table, and a CR/LF in a mail header is injection — which the
+  # Mail gem answers by raising, taking the notification job down with it. A
+  # header builder should not trust its inputs regardless of who cleaned them
+  # upstream.
   def subject_for(email, channel, handle)
+    email = header_safe(email)
+    channel = header_safe(channel)
+    handle = header_safe(handle)
+
     return "New LevelCode signup: #{email}" if channel.blank?
 
     via = handle.present? ? "#{channel} / #{handle}" : channel
     "New LevelCode signup via #{via}: #{email}"
+  end
+
+  def header_safe(value)
+    value.to_s.gsub(/[[:cntrl:]]/, " ").squeeze(" ").strip
   end
 
   # How they got in. `provider` is set only on the OAuth paths.

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,7 +1,62 @@
-class UserMailer < ApplicationMailer
-  def created(user)
-    @created_user_email = user.email
+# frozen_string_literal: true
 
-    mail to: ENV["NOTIFICATION_EMAIL"] || Rails.application.credentials.notification_email, subject: "New user created"
+# Internal ops notification: a new account was created.
+#
+# Branded LevelCode and rendered without ApplicationMailer's thin.ly "mailer"
+# layout, following LevelcodeAuthMailer / LevelcodeBillingMailer — the template is
+# self-contained so it cannot inherit a link-shortener header and footer.
+class UserMailer < ApplicationMailer
+  layout false
+
+  def created(user)
+    @user = user
+    @email = user.email
+    @created_at = user.created_at
+    @signup_method = signup_method_for(user)
+
+    # The point of the referral work: say in the notification itself which
+    # channel produced this signup. nil for an organic one.
+    @attribution = user.signup_attribution.presence
+    @channel = @attribution&.dig("source").presence
+    @handle = referral_handle(@attribution)
+    @landing = @attribution&.dig("landing").presence
+
+    mail(
+      to: ENV["NOTIFICATION_EMAIL"] || Rails.application.credentials.notification_email,
+      from: ENV["LEVELCODE_MAIL_FROM"].presence || "LevelCode <notifications@thin.ly>",
+      subject: subject_for(@email, @channel, @handle)
+    )
+  end
+
+  private
+
+  # Channel in the subject line, so a run of these is scannable from the inbox
+  # list without opening anything.
+  def subject_for(email, channel, handle)
+    return "New LevelCode signup: #{email}" if channel.blank?
+
+    via = handle.present? ? "#{channel} / #{handle}" : channel
+    "New LevelCode signup via #{via}: #{email}"
+  end
+
+  # How they got in. `provider` is set only on the OAuth paths.
+  def signup_method_for(user)
+    case user.provider.to_s
+    when "github" then "GitHub"
+    when "google" then "Google"
+    else "Email"
+    end
+  end
+
+  # The partner handle behind the channel: the params value named by `source`
+  # (source "linkedin" -> params["linkedin"]). Falls back to `ref`, which is where
+  # a raw ref campaign lands.
+  def referral_handle(attribution)
+    return nil if attribution.blank?
+
+    params = attribution["params"]
+    return nil unless params.is_a?(Hash)
+
+    params[attribution["source"].to_s].presence || params["ref"].presence
   end
 end

--- a/app/models/concerns/user_notifier.rb
+++ b/app/models/concerns/user_notifier.rb
@@ -1,11 +1,30 @@
+# frozen_string_literal: true
+
+# Fires the internal "new signup" notification (UserMailer#created).
 module UserNotifier
   extend ActiveSupport::Concern
 
+  # How long to wait before sending. Two reasons, both about the email being RIGHT
+  # rather than instant:
+  #
+  #   * OAuth signups get their marketing attribution stamped just AFTER the user
+  #     row is created (Levelcode::WebController#stamp_oauth_attribution!), because
+  #     GitHub and Google build the user through two different services. Sending
+  #     immediately would race that write and report every OAuth signup as
+  #     "Organic".
+  #   * It keeps the job off the enqueue-before-commit knife edge entirely.
+  #
+  # This is an ops notification, so a minute of latency costs nothing.
+  NOTIFY_DELAY = 1.minute
+
   included do
-    after_create :send_created_email
+    # after_commit, not after_create: perform_async inside the transaction can be
+    # picked up by Sidekiq before the row is visible, and the job then fails its
+    # User.find and burns a retry.
+    after_commit :send_created_email, on: :create
   end
 
   def send_created_email
-    UserNotificationWorker.perform_async(id)
+    UserNotificationWorker.perform_in(NOTIFY_DELAY, id)
   end
 end

--- a/app/services/levelcode/referral_report.rb
+++ b/app/services/levelcode/referral_report.rb
@@ -1,0 +1,164 @@
+# frozen_string_literal: true
+
+module Levelcode
+  # Referral funnel for the admin dashboard: clicks -> signups -> paid, per marketing channel.
+  #
+  # The three numbers come from three unrelated places and are joined ONLY by channel name, so
+  # read the caveats before trusting a row:
+  #
+  #   clicks   `clicks` joined to `links`, channel parsed out of `links.original_url`. A click row
+  #            carries no destination of its own, so a link whose destination is later edited
+  #            re-attributes all of its past clicks. Bots are excluded (Click.human_traffic).
+  #   signups  `users.signup_attribution->>'source'`, date-filtered on users.created_at. Only
+  #            LevelCode writes that column, so it needs no extra product scoping.
+  #   paid     a LevelCode credit_wallet that is currently on a paid plan. There is NO
+  #            "became paid at" timestamp in the schema, so this is necessarily "signed up in
+  #            range AND is paying now" — not "converted during the range". The API says so in
+  #            `paid_basis` and the dashboard repeats it, because the difference matters when
+  #            someone reads the column as a conversion rate.
+  #
+  # A click and a signup can never be joined per-person: clicks are anonymous.
+  module ReferralReport
+    module_function
+
+    PRODUCT = "levelcode"
+
+    # Mirrors the SPA's attribution util (onetime/src/levelcode/attribution.ts) — same keys, same
+    # precedence, so a link's channel and a signup's `source` agree on a name.
+    PARAM_KEYS = %w[linkedin youtube ref utm_source utm_medium utm_campaign utm_content].freeze
+
+    # Only links that actually point at the product count as marketing links. There is no flag on
+    # `links` marking one, so the destination host is the only available selector.
+    MARKETING_URL_MATCH = "%levelcode.ai%"
+
+    # Derive the channel from a link's destination, in the SPA's precedence order: a named network
+    # wins, then utm_source, then ref. Anything else is "other".
+    CHANNEL_SQL = Arel.sql(<<~SQL.squish)
+      CASE
+        WHEN links.original_url ~ '[?&]linkedin='    THEN 'linkedin'
+        WHEN links.original_url ~ '[?&]youtube='     THEN 'youtube'
+        WHEN links.original_url ~ '[?&]utm_source='  THEN substring(links.original_url from '[?&]utm_source=([^&#]+)')
+        WHEN links.original_url ~ '[?&]ref='         THEN substring(links.original_url from '[?&]ref=([^&#]+)')
+        ELSE 'other'
+      END
+    SQL
+
+    # The partner handle behind the channel — the value of whichever param matched above.
+    HANDLE_SQL = Arel.sql(<<~SQL.squish)
+      COALESCE(
+        substring(links.original_url from '[?&]linkedin=([^&#]+)'),
+        substring(links.original_url from '[?&]youtube=([^&#]+)'),
+        substring(links.original_url from '[?&]ref=([^&#]+)'),
+        ''
+      )
+    SQL
+
+    # One row per (channel, handle) with the three funnel numbers, plus totals and the counts that
+    # explain what the table is NOT showing.
+    #
+    # `from` / `to` are Dates (inclusive). `to` is expanded to the end of that day.
+    def funnel(from: nil, to: nil)
+      range = date_range(from, to)
+
+      clicks   = clicks_by_channel(range)
+      signups  = signups_by_channel(range)
+      paid     = paid_by_channel(range)
+
+      rows = (clicks.keys | signups.keys | paid.keys).map do |key|
+        channel, handle = key
+        {
+          channel: channel,
+          handle: handle.presence,
+          clicks: clicks[key].to_i,
+          signups: signups[key].to_i,
+          paid: paid[key].to_i
+        }
+      end
+      rows.sort_by! { |r| [ -r[:signups], -r[:clicks], r[:channel].to_s ] }
+
+      {
+        from: range.begin.to_date.iso8601,
+        to: range.end.to_date.iso8601,
+        rows: rows,
+        totals: {
+          clicks: rows.sum { |r| r[:clicks] },
+          signups: rows.sum { |r| r[:signups] },
+          paid: rows.sum { |r| r[:paid] }
+        },
+        # Signups in range with no channel at all: organic, or a referred visitor whose browser
+        # dropped the stored attribution. Shown so the table is never mistaken for total signups.
+        unattributed_signups: User.where(created_at: range, signup_attribution: nil).count,
+        # "Paid" is a snapshot, not an event — see the note at the top of this file.
+        paid_basis: "signed_up_in_range_and_paying_now"
+      }
+    end
+
+    # --- pieces ---------------------------------------------------------------
+
+    # Human clicks in range on links whose destination points at the product, grouped by the
+    # channel + handle encoded in that destination.
+    def clicks_by_channel(range)
+      Click.human_traffic
+           .joins(:link)
+           .where(created_at: range)
+           .where("links.original_url ILIKE ?", MARKETING_URL_MATCH)
+           .group(CHANNEL_SQL, HANDLE_SQL)
+           .count
+    end
+
+    # Signups in range that carried a channel. The handle is the value of the param the source
+    # names, so `{"source":"linkedin","params":{"linkedin":"anastasia"}}` lands in the same bucket
+    # as the link that produced the click.
+    def signups_by_channel(range)
+      User.where(created_at: range)
+          .where.not(signup_attribution: nil)
+          .group(source_sql, handle_sql)
+          .count
+    end
+
+    # Of those signups, the ones on a paid LevelCode plan right now. Mirrors the predicate in
+    # Levelcode::FreeTier.paid? (which is private), including its 3-day grace on a lapsed period
+    # so a renewal in flight does not read as a downgrade.
+    def paid_by_channel(range)
+      User.where(created_at: range)
+          .where.not(signup_attribution: nil)
+          .joins("INNER JOIN credit_wallets ON credit_wallets.user_id = users.id")
+          .where(credit_wallets: { product: PRODUCT })
+          .where.not(credit_wallets: { plan_key: ::Levelcode::FREE_PLAN_KEY })
+          .where("credit_wallets.budget_micros > 0")
+          .where("credit_wallets.period_end IS NULL OR credit_wallets.period_end >= ?", Time.current - 3.days)
+          .group(source_sql, handle_sql)
+          .count
+    end
+
+    # --- helpers --------------------------------------------------------------
+
+    def source_sql
+      Arel.sql("users.signup_attribution->>'source'")
+    end
+
+    # The handle for a signup: the params value named by `source`. COALESCE rather than a lookup
+    # because `source` may be a raw utm_source/ref value with no matching params key.
+    def handle_sql
+      Arel.sql(<<~SQL.squish)
+        COALESCE(
+          users.signup_attribution->'params'->>(users.signup_attribution->>'source'),
+          users.signup_attribution->'params'->>'ref',
+          ''
+        )
+      SQL
+    end
+
+    # Inclusive day range, defaulting to the last 30 days. Guards a reversed pair so a mis-typed
+    # filter returns an empty range rather than a Postgres error.
+    def date_range(from, to)
+      finish = (to.presence && to.to_date) || Date.current
+      start  = (from.presence && from.to_date) || (finish - 29)
+      start  = finish if start > finish
+      start.beginning_of_day..finish.end_of_day
+    end
+
+    private_class_method :clicks_by_channel, :signups_by_channel, :paid_by_channel,
+                         :source_sql, :handle_sql, :date_range
+  end
+end

--- a/app/services/levelcode/referral_report.rb
+++ b/app/services/levelcode/referral_report.rb
@@ -28,8 +28,14 @@ module Levelcode
     PARAM_KEYS = %w[linkedin youtube ref utm_source utm_medium utm_campaign utm_content].freeze
 
     # Only links that actually point at the product count as marketing links. There is no flag on
-    # `links` marking one, so the destination host is the only available selector.
-    MARKETING_URL_MATCH = "%levelcode.ai%"
+    # `links` marking one, so the destination HOST is the only available selector.
+    #
+    # Anchored on scheme + host rather than a substring: `ILIKE '%levelcode.ai%'` also matches
+    # `https://notlevelcode.ai/?linkedin=x` and `https://evil.test/?next=levelcode.ai`, and since
+    # anyone can shorten any URL, that is an open door to inflating a partner's click count.
+    # Subdomains are allowed (www. and friends); the host must END there, so a lookalike like
+    # `levelcode.ai.evil.test` does not match.
+    MARKETING_URL_REGEX = '^https?://([a-z0-9_-]+\.)*levelcode\.ai(:[0-9]+)?([/?#]|$)'
 
     # Derive the channel from a link's destination, in the SPA's precedence order: a named network
     # wins, then utm_source, then ref. Anything else is "other".
@@ -101,7 +107,7 @@ module Levelcode
       Click.human_traffic
            .joins(:link)
            .where(created_at: range)
-           .where("links.original_url ILIKE ?", MARKETING_URL_MATCH)
+           .where("links.original_url ~* ?", MARKETING_URL_REGEX)
            .group(CHANNEL_SQL, HANDLE_SQL)
            .count
     end

--- a/app/services/levelcode/referral_report.rb
+++ b/app/services/levelcode/referral_report.rb
@@ -155,8 +155,13 @@ module Levelcode
       SQL
     end
 
-    # Inclusive day range, defaulting to the last 30 days. Guards a reversed pair so a mis-typed
-    # filter returns an empty range rather than a Postgres error.
+    # Inclusive day range, defaulting to the last 30 days.
+    #
+    # A REVERSED pair (from > to) collapses to the single `to` day rather than raising — a mis-typed
+    # filter should not 500. That is not silent: `funnel` echoes the range it actually used back as
+    # `from`/`to`, and the dashboard prints it under the totals, so a collapsed range is visible
+    # rather than being mistaken for "no activity in my range". The UI also blocks a reversed range
+    # before it ever reaches here.
     def date_range(from, to)
       finish = (to.presence && to.to_date) || Date.current
       start  = (from.presence && from.to_date) || (finish - 29)

--- a/app/views/user_mailer/created.html.erb
+++ b/app/views/user_mailer/created.html.erb
@@ -1,5 +1,54 @@
-<h1>New user was created</h1>
+<div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;max-width:520px;margin:0 auto;padding:8px 4px;color:#1b1a17;">
+  <p style="font-size:18px;font-weight:700;margin:0 0 24px;">LevelCode</p>
 
-<p>
-  Welcome new user: <%= @created_user_email %>
-</p>
+  <h1 style="font-size:22px;font-weight:700;margin:0 0 8px;">New signup</h1>
+  <p style="font-size:15px;color:#3a3833;margin:0 0 24px;"><%= @email %></p>
+
+  <%# The referral block is why this email was rewritten: the channel should be readable
+      at a glance, not reconstructed later from a console query. %>
+  <% if @channel.present? %>
+    <div style="border:1px solid #d9d3f5;background:#f4f1fe;border-radius:6px;padding:14px 16px;margin:0 0 24px;">
+      <p style="font-size:12px;font-weight:600;letter-spacing:0.08em;text-transform:uppercase;color:#5b3fd6;margin:0 0 6px;">
+        Referral
+      </p>
+      <p style="font-size:16px;font-weight:600;margin:0;color:#1b1a17;">
+        <%= @channel %><% if @handle.present? %> &middot; <%= @handle %><% end %>
+      </p>
+    </div>
+  <% else %>
+    <div style="border:1px solid #e7e3da;border-radius:6px;padding:14px 16px;margin:0 0 24px;">
+      <p style="font-size:12px;font-weight:600;letter-spacing:0.08em;text-transform:uppercase;color:#6b675e;margin:0 0 6px;">
+        Referral
+      </p>
+      <p style="font-size:15px;margin:0;color:#3a3833;">Organic &mdash; no campaign link</p>
+    </div>
+  <% end %>
+
+  <table style="width:100%;border-collapse:collapse;font-size:14px;margin:0 0 24px;">
+    <tr>
+      <td style="padding:8px 0;color:#6b675e;border-bottom:1px solid #efece4;width:40%;">Signed up with</td>
+      <td style="padding:8px 0;color:#1b1a17;border-bottom:1px solid #efece4;"><%= @signup_method %></td>
+    </tr>
+    <tr>
+      <td style="padding:8px 0;color:#6b675e;border-bottom:1px solid #efece4;">When</td>
+      <td style="padding:8px 0;color:#1b1a17;border-bottom:1px solid #efece4;">
+        <%= @created_at&.utc&.strftime("%d %b %Y, %H:%M UTC") %>
+      </td>
+    </tr>
+    <% if @landing.present? %>
+      <tr>
+        <td style="padding:8px 0;color:#6b675e;border-bottom:1px solid #efece4;">Landed on</td>
+        <td style="padding:8px 0;color:#1b1a17;border-bottom:1px solid #efece4;"><%= @landing %></td>
+      </tr>
+    <% end %>
+    <tr>
+      <td style="padding:8px 0;color:#6b675e;">User ID</td>
+      <td style="padding:8px 0;color:#1b1a17;"><%= @user.id %></td>
+    </tr>
+  </table>
+
+  <hr style="border:none;border-top:1px solid #e7e3da;margin:0 0 16px;">
+  <p style="font-size:13px;color:#6b675e;margin:0;">
+    Sent by LevelCode &middot; <a href="https://levelcode.ai" style="color:#5b3fd6;text-decoration:none;">levelcode.ai</a>
+  </p>
+</div>

--- a/app/views/user_mailer/created.text.erb
+++ b/app/views/user_mailer/created.text.erb
@@ -1,0 +1,14 @@
+LevelCode — new signup
+
+<%= @email %>
+
+Referral:      <% if @channel.present? %><%= @channel %><% if @handle.present? %> / <%= @handle %><% end %><% else %>Organic — no campaign link<% end %>
+Signed up with: <%= @signup_method %>
+When:           <%= @created_at&.utc&.strftime("%d %b %Y, %H:%M UTC") %>
+<% if @landing.present? -%>
+Landed on:      <%= @landing %>
+<% end -%>
+User ID:        <%= @user.id %>
+
+--
+Sent by LevelCode · https://levelcode.ai

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -164,6 +164,7 @@ Rails.application.routes.draw do
         # Admin dashboard (role: admin only)
         get   "admin/summary",    to: "admin#summary"
         get   "admin/users",      to: "admin#users"
+        get   "admin/referrals",  to: "admin#referrals"  # clicks -> signups -> paid, per channel
 
         # AI gateway (SPEC §4). The editor routes gateway traffic through its
         # OpenAI-compatible adapter, which POSTs to `<base>/chat/completions`

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -1,7 +1,33 @@
 # Preview all emails at http://localhost:3000/rails/mailers/user_mailer
+#
+# Both variants are previewable because the referral block is the part worth
+# eyeballing — and it is the branch you only see when a campaign link was used.
+# Users are built, never saved, so opening a preview cannot create accounts or
+# fire the signup notification.
 class UserMailerPreview < ActionMailer::Preview
-  # Preview this email at http://localhost:3000/rails/mailers/user_mailer/created
+  # http://localhost:3000/rails/mailers/user_mailer/created
   def created
-    UserMailer.created
+    UserMailer.created(sample_user)
+  end
+
+  # http://localhost:3000/rails/mailers/user_mailer/created_via_referral
+  def created_via_referral
+    UserMailer.created(
+      sample_user(
+        provider: "github",
+        signup_attribution: {
+          "source" => "linkedin",
+          "params" => { "linkedin" => "saienkoanastasia" },
+          "landing" => "/ai",
+          "recorded_at" => Time.current.utc.iso8601
+        }
+      )
+    )
+  end
+
+  private
+
+  def sample_user(**attrs)
+    User.new({ id: 1234, email: "new.user@example.com", created_at: Time.current }.merge(attrs))
   end
 end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -9,19 +9,64 @@ RSpec.describe UserMailer, type: :mailer do
     before do
       allow(ENV).to receive(:[]).and_call_original
       allow(ENV).to receive(:[]).with("NOTIFICATION_EMAIL").and_return("test@example.com")
+      allow(ENV).to receive(:[]).with("LEVELCODE_MAIL_FROM").and_return(nil)
     end
 
-    let(:user) { create(:user) }
-    let(:mail) { UserMailer.created(user) }
-
-    it "renders the headers" do
-      expect(mail.subject).to eq("New user created")
-      expect(mail.to).to eq([ ENV["NOTIFICATION_EMAIL"] ])
-      expect(mail.from).to eq([ "notifications@thin.ly" ])
+    def attribution(source, handle)
+      { "source" => source, "params" => { source => handle }, "landing" => "/ai" }
     end
 
-    it "renders the body" do
-      expect(mail.body.encoded).to match("Welcome new user: #{user.email}")
+    context "an organic signup" do
+      let(:user) { create(:user) }
+      let(:mail) { UserMailer.created(user) }
+
+      it "renders LevelCode-branded headers" do
+        expect(mail.subject).to eq("New LevelCode signup: #{user.email}")
+        expect(mail.to).to eq([ "test@example.com" ])
+      end
+
+      it "says the signup was organic and carries no thin.ly branding" do
+        body = mail.body.encoded
+        expect(body).to match(user.email)
+        expect(body).to match(/Organic/)
+        expect(body).to match("levelcode.ai")
+        expect(body).not_to match(/Smart URL Shortener/)
+      end
+    end
+
+    context "a referred signup" do
+      let(:user) { create(:user, signup_attribution: attribution("linkedin", "anastasia")) }
+      let(:mail) { UserMailer.created(user) }
+
+      it "names the channel and handle in the subject" do
+        expect(mail.subject).to eq("New LevelCode signup via linkedin / anastasia: #{user.email}")
+      end
+
+      it "shows the referral in the body" do
+        body = mail.body.encoded
+        expect(body).to match("linkedin")
+        expect(body).to match("anastasia")
+        expect(body).not_to match(/Organic/)
+      end
+    end
+
+    context "a channel with no handle" do
+      let(:user) { create(:user, signup_attribution: { "source" => "linkedin", "params" => {} }) }
+
+      it "falls back to the channel alone" do
+        expect(UserMailer.created(user).subject).to eq("New LevelCode signup via linkedin: #{user.email}")
+      end
+    end
+
+    context "sign-up method" do
+      it "reports the OAuth provider when there is one" do
+        user = create(:user, provider: "github", uid: "12345")
+        expect(UserMailer.created(user).body.encoded).to match("GitHub")
+      end
+
+      it "reports Email otherwise" do
+        expect(UserMailer.created(create(:user)).body.encoded).to match("Email")
+      end
     end
   end
 end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -59,9 +59,19 @@ RSpec.describe UserMailer, type: :mailer do
     end
 
     context "sign-up method" do
-      it "reports the OAuth provider when there is one" do
-        user = create(:user, provider: "github", uid: "12345")
+      it "reports GitHub" do
+        user = create(:user, provider: Levelcode::ProviderOAuth::GITHUB_PROVIDER, uid: "12345")
         expect(UserMailer.created(user).body.encoded).to match("GitHub")
+      end
+
+      # Google's stored provider is "google_oauth2", not "google" — a literal
+      # comparison falls through and reports Google signups as Email.
+      it "reports Google for the real stored provider value" do
+        expect(User::GOOGLE_PROVIDER).to eq("google_oauth2")
+        user = create(:user, provider: User::GOOGLE_PROVIDER, uid: "67890")
+        body = UserMailer.created(user).body.encoded
+        expect(body).to match("Google")
+        expect(body).not_to match(/Signed up with[^<]*<\/td>\s*<td[^>]*>\s*Email/)
       end
 
       it "reports Email otherwise" do

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -50,6 +50,61 @@ RSpec.describe UserMailer, type: :mailer do
       end
     end
 
+    # signup_attribution is client-controlled, and `source`/handle are interpolated
+    # into the Subject.
+    #
+    # On the security question: this is NOT header injection. Mail
+    # quoted-printable-encodes a CRLF inside a header value (it comes out as
+    # `=0D=0A` on the Subject line), so a crafted value cannot open a new header
+    # field, and Mail does not raise either. Verified against the encoded header
+    # block — the field list stays Date/From/To/Message-ID/Subject/MIME-*.
+    #
+    # What it DOES cause is an unreadable subject full of `=0D=0A`, which is the
+    # real (cosmetic) reason to scrub. These examples assert that, because it is
+    # the behaviour that actually changes with the fix.
+    context "a channel carrying control characters" do
+      let(:user) do
+        create(:user, signup_attribution: {
+          "source" => "linkedin\r\nBcc: attacker@example.com",
+          "params" => { "linkedin" => "anastasia\nX-Injected: yes" }
+        })
+      end
+
+      it "builds a subject with no control characters" do
+        subject_line = UserMailer.created(user).subject
+        expect(subject_line).not_to match(/[[:cntrl:]]/)
+        expect(subject_line).to include("linkedin")
+      end
+
+      # The handle is the other interpolated value, so it needs its own case: with a
+      # mangled `source` the params lookup cannot match a key, so no handle is found
+      # and the channel scrub alone would be exercised.
+      it "scrubs control characters coming from the HANDLE" do
+        referred = create(:user, signup_attribution: {
+          "source" => "linkedin",
+          "params" => { "linkedin" => "anastasia\r\nX-Injected: yes" }
+        })
+
+        subject_line = UserMailer.created(referred).subject
+        expect(subject_line).not_to match(/[[:cntrl:]]/)
+        expect(subject_line).to include("linkedin")
+        expect(subject_line).to include("anastasia")
+      end
+
+      it "does not leak quoted-printable escapes into the encoded Subject" do
+        mail = UserMailer.created(user)
+        subject_line = mail.encoded.split(/\r?\n\r?\n/, 2).first.lines.map(&:chomp)
+                           .find { |l| l.start_with?("Subject:") }
+
+        expect(subject_line).not_to include("=0D")
+        expect(subject_line).not_to include("=0A")
+      end
+
+      it "still addresses only the configured notification recipient" do
+        expect(UserMailer.created(user).to).to eq([ "test@example.com" ])
+      end
+    end
+
     context "a channel with no handle" do
       let(:user) { create(:user, signup_attribution: { "source" => "linkedin", "params" => {} }) }
 

--- a/spec/models/concerns/user_notifier_spec.rb
+++ b/spec/models/concerns/user_notifier_spec.rb
@@ -4,16 +4,27 @@ require 'rails_helper'
 
 RSpec.describe UserNotifier, type: :concern do
   describe 'callbacks' do
-    it 'enqueues UserNotificationWorker after user creation' do
-      expect(UserNotificationWorker).to receive(:perform_async).with(kind_of(Integer))
+    it 'enqueues UserNotificationWorker after the create COMMITS' do
+      # after_commit, not after_create: enqueueing inside the transaction lets
+      # Sidekiq pick the job up before the row is visible, which fails User.find
+      # and burns a retry.
+      expect(UserNotificationWorker).to receive(:perform_in).with(UserNotifier::NOTIFY_DELAY, kind_of(Integer))
       create(:user)
+    end
+
+    it 'delays the send so OAuth attribution is stamped before the email renders' do
+      # Levelcode::WebController#stamp_oauth_attribution! writes the channel just
+      # after the user row is created (GitHub and Google build the user through
+      # two different services, so it cannot be passed into the create). Sending
+      # immediately would race that write and report every OAuth signup as organic.
+      expect(UserNotifier::NOTIFY_DELAY).to be >= 30.seconds
     end
   end
 
   describe '#send_created_email' do
     it 'enqueues worker with user id' do
       existing_user = create(:user)
-      expect(UserNotificationWorker).to receive(:perform_async).with(existing_user.id)
+      expect(UserNotificationWorker).to receive(:perform_in).with(UserNotifier::NOTIFY_DELAY, existing_user.id)
       existing_user.send(:send_created_email)
     end
   end

--- a/spec/requests/api/levelcode/v1/admin_referrals_spec.rb
+++ b/spec/requests/api/levelcode/v1/admin_referrals_spec.rb
@@ -138,6 +138,19 @@ RSpec.describe "Api::Levelcode::V1::Admin referrals", type: :request do
       expect(row_for(response.parsed_body, "linkedin")).to include("signups" => 1, "clicks" => 1)
     end
 
+    # A reversed range collapses to the single `to` day rather than raising, and the
+    # response echoes what it actually used so the collapse is visible instead of
+    # looking like "no activity in my range".
+    it "collapses a reversed range to one day and says so in the response" do
+      get "/api/levelcode/v1/admin/referrals",
+          params: { from: Date.current.iso8601, to: 30.days.ago.to_date.iso8601 }
+
+      expect(response).to have_http_status(:ok)
+      body = response.parsed_body
+      expect(body["from"]).to eq(30.days.ago.to_date.iso8601)
+      expect(body["to"]).to eq(30.days.ago.to_date.iso8601)
+    end
+
     it "states the basis for the paid column so it is not read as a conversion event" do
       get "/api/levelcode/v1/admin/referrals"
       expect(response.parsed_body["paid_basis"]).to eq("signed_up_in_range_and_paying_now")

--- a/spec/requests/api/levelcode/v1/admin_referrals_spec.rb
+++ b/spec/requests/api/levelcode/v1/admin_referrals_spec.rb
@@ -1,0 +1,126 @@
+require "rails_helper"
+
+RSpec.describe "Api::Levelcode::V1::Admin referrals", type: :request do
+  let(:admin)  { create(:user, email: "admin@example.com") }
+  let(:member) { create(:user, email: "member@example.com") }
+
+  before do
+    allow(admin).to receive(:role).and_return("admin")
+    allow(admin).to receive(:admin?).and_return(true)
+  end
+
+  def as_user(user)
+    allow_any_instance_of(Api::Levelcode::V1::BaseController).to receive(:authenticate_levelcode!).and_return(true)
+    allow_any_instance_of(Api::Levelcode::V1::BaseController).to receive(:current_levelcode_user).and_return(user)
+    allow_any_instance_of(Api::Levelcode::V1::BaseController).to receive(:current_user).and_return(user)
+  end
+
+  def attribution(source, handle)
+    { "source" => source, "params" => { source => handle }, "recorded_at" => Time.current.utc.iso8601 }
+  end
+
+  def row_for(body, channel)
+    body["rows"].find { |r| r["channel"] == channel }
+  end
+
+  describe "authorization" do
+    it "403s for a non-admin" do
+      as_user(member)
+      get "/api/levelcode/v1/admin/referrals"
+      expect(response).to have_http_status(:forbidden)
+      expect(response.parsed_body.dig("error", "code")).to eq("forbidden")
+    end
+  end
+
+  describe "GET /admin/referrals" do
+    before { as_user(admin) }
+
+    it "counts signups per channel and keeps the partner handle" do
+      create(:user, email: "a@example.com", signup_attribution: attribution("linkedin", "anastasia"))
+      create(:user, email: "b@example.com", signup_attribution: attribution("linkedin", "anastasia"))
+      create(:user, email: "c@example.com", signup_attribution: attribution("youtube", "koderrsha"))
+
+      get "/api/levelcode/v1/admin/referrals"
+      expect(response).to have_http_status(:ok)
+      body = response.parsed_body
+
+      expect(row_for(body, "linkedin")).to include("signups" => 2, "handle" => "anastasia")
+      expect(row_for(body, "youtube")).to include("signups" => 1, "handle" => "koderrsha")
+      expect(body.dig("totals", "signups")).to eq(3)
+    end
+
+    it "reports signups with no attribution separately rather than as a channel" do
+      create(:user, email: "organic@example.com") # no signup_attribution
+
+      get "/api/levelcode/v1/admin/referrals"
+      body = response.parsed_body
+
+      # admin + member + organic all have nil attribution
+      expect(body["unattributed_signups"]).to be >= 1
+      expect(body["rows"].map { |r| r["channel"] }).not_to include(nil, "")
+    end
+
+    it "counts human clicks per channel from the link destination, excluding bots" do
+      owner = create(:user, email: "owner@example.com")
+      link = create(:link, user: owner, original_url: "https://levelcode.ai/ai?linkedin=anastasia")
+
+      2.times { Click.create!(link: link, is_bot: false, created_at: 1.day.ago) }
+      Click.create!(link: link, is_bot: true, created_at: 1.day.ago)
+
+      get "/api/levelcode/v1/admin/referrals"
+      expect(row_for(response.parsed_body, "linkedin")).to include("clicks" => 2)
+    end
+
+    it "ignores links that do not point at the product" do
+      owner = create(:user, email: "owner2@example.com")
+      other = create(:link, user: owner, original_url: "https://example.com/?linkedin=anastasia")
+      Click.create!(link: other, is_bot: false, created_at: 1.day.ago)
+
+      get "/api/levelcode/v1/admin/referrals"
+      expect(response.parsed_body.dig("totals", "clicks")).to eq(0)
+    end
+
+    it "counts a signup as paid only on a non-free levelcode wallet with budget" do
+      paid = create(:user, email: "paid@example.com", signup_attribution: attribution("linkedin", "anastasia"))
+      free = create(:user, email: "free@example.com", signup_attribution: attribution("linkedin", "anastasia"))
+
+      CreditWallet.create!(user: paid, product: "levelcode", plan_key: "orbits_pro",
+                           input_cap: 1, output_cap: 1, budget_micros: 5_000_000,
+                           period_start: Time.current, period_end: 1.month.from_now, overage_policy: "throttle")
+      CreditWallet.create!(user: free, product: "levelcode", plan_key: "free",
+                           input_cap: 1, output_cap: 1, budget_micros: 0,
+                           period_start: Time.current, period_end: 1.month.from_now, overage_policy: "throttle")
+
+      get "/api/levelcode/v1/admin/referrals"
+      expect(row_for(response.parsed_body, "linkedin")).to include("signups" => 2, "paid" => 1)
+    end
+
+    it "honours the date range on both signups and clicks" do
+      old_user = create(:user, email: "old@example.com", signup_attribution: attribution("linkedin", "anastasia"))
+      old_user.update_column(:created_at, 90.days.ago)
+
+      owner = create(:user, email: "owner3@example.com")
+      link = create(:link, user: owner, original_url: "https://levelcode.ai/ai?linkedin=anastasia")
+      Click.create!(link: link, is_bot: false, created_at: 90.days.ago)
+
+      get "/api/levelcode/v1/admin/referrals" # defaults to the last 30 days
+      expect(response.parsed_body.dig("totals", "signups")).to eq(0)
+      expect(response.parsed_body.dig("totals", "clicks")).to eq(0)
+
+      from = 100.days.ago.to_date.iso8601
+      get "/api/levelcode/v1/admin/referrals", params: { from: from, to: Date.current.iso8601 }
+      expect(row_for(response.parsed_body, "linkedin")).to include("signups" => 1, "clicks" => 1)
+    end
+
+    it "states the basis for the paid column so it is not read as a conversion event" do
+      get "/api/levelcode/v1/admin/referrals"
+      expect(response.parsed_body["paid_basis"]).to eq("signed_up_in_range_and_paying_now")
+    end
+
+    it "400s on an unparseable date instead of 500ing" do
+      get "/api/levelcode/v1/admin/referrals", params: { from: "not-a-date" }
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body.dig("error", "code")).to eq("bad_request")
+    end
+  end
+end

--- a/spec/requests/api/levelcode/v1/admin_referrals_spec.rb
+++ b/spec/requests/api/levelcode/v1/admin_referrals_spec.rb
@@ -80,6 +80,32 @@ RSpec.describe "Api::Levelcode::V1::Admin referrals", type: :request do
       expect(response.parsed_body.dig("totals", "clicks")).to eq(0)
     end
 
+    # A substring match on "levelcode.ai" would count all of these. Anyone can shorten
+    # any URL, so that would be an open door to inflating a partner's clicks.
+    it "does not count lookalike hosts that merely contain the domain" do
+      owner = create(:user, email: "owner4@example.com")
+      [
+        "https://notlevelcode.ai/ai?linkedin=anastasia",
+        "https://levelcode.ai.evil.test/?linkedin=anastasia",
+        "https://evil.test/?next=https://levelcode.ai/ai%3Flinkedin%3Danastasia"
+      ].each_with_index do |url, i|
+        link = create(:link, user: owner, original_url: url, lookup_code: "look#{i}00")
+        Click.create!(link: link, is_bot: false, created_at: 1.day.ago)
+      end
+
+      get "/api/levelcode/v1/admin/referrals"
+      expect(response.parsed_body.dig("totals", "clicks")).to eq(0)
+    end
+
+    it "counts the real host, including a subdomain" do
+      owner = create(:user, email: "owner5@example.com")
+      link = create(:link, user: owner, original_url: "https://www.levelcode.ai/ai?youtube=koderrsha")
+      Click.create!(link: link, is_bot: false, created_at: 1.day.ago)
+
+      get "/api/levelcode/v1/admin/referrals"
+      expect(row_for(response.parsed_body, "youtube")).to include("clicks" => 1)
+    end
+
     it "counts a signup as paid only on a non-free levelcode wallet with budget" do
       paid = create(:user, email: "paid@example.com", signup_attribution: attribution("linkedin", "anastasia"))
       free = create(:user, email: "free@example.com", signup_attribution: attribution("linkedin", "anastasia"))

--- a/spec/requests/levelcode/web_spec.rb
+++ b/spec/requests/levelcode/web_spec.rb
@@ -262,6 +262,74 @@ RSpec.describe 'Levelcode::Web (SPA backend at /ai/*)', type: :request do
       get '/ai/auth/oauth/twitter'
       expect(response).to redirect_to('/ai/login')
     end
+
+    # Marketing attribution across the OAuth round-trip. Before this, ONLY the email
+    # flow recorded a channel, so every GitHub/Google signup was attributed to
+    # nothing — which silently undercounts whichever channel sends developers.
+    describe 'marketing attribution' do
+      let(:attribution) do
+        { source: 'linkedin', params: { linkedin: 'anastasia' }, landing: '/ai' }.to_json
+      end
+
+      def start_oauth_with_attribution(blob = attribution)
+        allow(SecureRandom).to receive(:urlsafe_base64).and_return('teststate')
+        allow(Levelcode::ProviderOAuth).to receive(:authorize_url).and_return('https://github.test/authorize')
+        get '/ai/auth/oauth/github', params: { attribution: blob }
+      end
+
+      it 'stamps the channel on a user CREATED through OAuth' do
+        new_user = User.new(email: 'fresh@example.com', password: 'x' * 20, terms_accepted: true)
+        new_user.save!
+        allow(Levelcode::ProviderOAuth).to receive(:github_user).and_return(new_user)
+
+        start_oauth_with_attribution
+        get '/ai/auth/callback', params: { code: 'gh', state: 'teststate' }
+
+        stored = new_user.reload.signup_attribution
+        expect(stored['source']).to eq('linkedin')
+        expect(stored.dig('params', 'linkedin')).to eq('anastasia')
+        expect(stored['recorded_at']).to be_present
+      end
+
+      # Acquisition attribution, not last-touch: someone who signed up long ago and
+      # today arrives through a referral link was not acquired by that channel, and
+      # crediting them would inflate the partner's conversions.
+      it 'does NOT stamp an existing user who merely signs in through a referral link' do
+        existing = User.create!(email: 'old@example.com', password: 'x' * 20, terms_accepted: true)
+        existing.reload # clears previously_new_record?
+        allow(Levelcode::ProviderOAuth).to receive(:github_user).and_return(existing)
+
+        start_oauth_with_attribution
+        get '/ai/auth/callback', params: { code: 'gh', state: 'teststate' }
+
+        expect(existing.reload.signup_attribution).to be_nil
+      end
+
+      it 'ignores an unparseable attribution blob instead of failing the sign-in' do
+        new_user = User.new(email: 'junk@example.com', password: 'x' * 20, terms_accepted: true)
+        new_user.save!
+        allow(Levelcode::ProviderOAuth).to receive(:github_user).and_return(new_user)
+
+        start_oauth_with_attribution('not json{{{')
+        get '/ai/auth/callback', params: { code: 'gh', state: 'teststate' }
+
+        expect(response).to redirect_to('/ai/account')
+        expect(new_user.reload.signup_attribution).to be_nil
+      end
+
+      it 'drops params outside the whitelist' do
+        new_user = User.new(email: 'evil@example.com', password: 'x' * 20, terms_accepted: true)
+        new_user.save!
+        allow(Levelcode::ProviderOAuth).to receive(:github_user).and_return(new_user)
+
+        start_oauth_with_attribution(
+          { source: 'linkedin', params: { linkedin: 'anastasia', evil: 'x' } }.to_json
+        )
+        get '/ai/auth/callback', params: { code: 'gh', state: 'teststate' }
+
+        expect(new_user.reload.signup_attribution['params'].keys).to eq([ 'linkedin' ])
+      end
+    end
   end
 
   describe 'POST /ai/signout' do

--- a/spec/requests/levelcode/web_spec.rb
+++ b/spec/requests/levelcode/web_spec.rb
@@ -317,6 +317,23 @@ RSpec.describe 'Levelcode::Web (SPA backend at /ai/*)', type: :request do
         expect(new_user.reload.signup_attribution).to be_nil
       end
 
+      # The session is a ~4 KB cookie. A character-based clamp lets multi-byte UTF-8
+      # through at up to 4x the intended size, and an overflowing cookie takes the
+      # OAuth `state` with it — turning a sign-in into ?error=session_expired.
+      it 'survives an oversized multi-byte attribution blob without breaking sign-in' do
+        new_user = User.new(email: 'big@example.com', password: 'x' * 20, terms_accepted: true)
+        new_user.save!
+        allow(Levelcode::ProviderOAuth).to receive(:github_user).and_return(new_user)
+
+        huge = { source: 'linkedin', params: { linkedin: 'ф' * 3_000 } }.to_json
+        start_oauth_with_attribution(huge)
+        get '/ai/auth/callback', params: { code: 'gh', state: 'teststate' }
+
+        # The sign-in still completes; the truncated blob is simply unparseable and
+        # treated as organic rather than corrupting the session.
+        expect(response).to redirect_to('/ai/account')
+      end
+
       it 'drops params outside the whitelist' do
         new_user = User.new(email: 'evil@example.com', password: 'x' * 20, terms_accepted: true)
         new_user.save!

--- a/spec/requests/levelcode/web_spec.rb
+++ b/spec/requests/levelcode/web_spec.rb
@@ -129,6 +129,23 @@ RSpec.describe 'Levelcode::Web (SPA backend at /ai/*)', type: :request do
         expect(json).to eq('redirect' => '/ai/account')
       end
 
+      # Length clamping alone let CR/LF through, and these values are later
+      # interpolated into the signup notification's Subject header.
+      it 'strips control characters so nothing header-unsafe is ever stored' do
+        nasty = { source: "linkedin\r\nBcc: attacker@example.com",
+                  params: { linkedin: "anastasia\nX-Injected: yes" },
+                  landing: "/ai\r\n" }
+        post '/ai/auth/verify', params: { email: 'nasty@example.com', code: '123456', attribution: nasty }, as: :json
+
+        attr = User.find_by(email: 'nasty@example.com').signup_attribution
+        [ attr['source'], attr['params']['linkedin'], attr['landing'] ].each do |v|
+          expect(v).not_to include("\r")
+          expect(v).not_to include("\n")
+        end
+        expect(attr['source']).to start_with('linkedin')
+        expect(attr['params']['linkedin']).to start_with('anastasia')
+      end
+
       it 'whitelists keys and bounds sizes — never trusts the client blob' do
         hostile = { source: 'x' * 200,
                     params: { linkedin: 'a' * 500, evil: 'ignored', utm_source: 'newsletter' },


### PR DESCRIPTION
Backend for the referral funnel. Frontend is [systemu-net/onetime#93](https://github.com/systemu-net/onetime/pull/93).

## 1. OAuth signups now record a channel

This is the part worth reviewing carefully, because it means the numbers you already have are incomplete.

`signup_attribution` was written **only** on the email-OTP path (`find_or_create_email_user`). Every GitHub and Google signup landed with the column `NULL` and was invisible to any referral count. That undercounts *unevenly* — a channel whose audience is developers skews heavily toward GitHub sign-in — so a real channel can look weaker than it is purely because of how its visitors chose to sign in.

It can't be threaded through the services: GitHub goes via `ProviderOAuth.find_or_create_oauth_user` and Google via `User.from_google`. The controller is the one place both paths meet, so:

- `oauth_start` stashes the SPA's attribution in the session beside the CSRF `state` — clamped to 2 KB, since the session is a 4 KB cookie and the value is client-supplied.
- `oauth_callback` stamps it through `stamp_oauth_attribution!`, reusing the existing `sanitize_signup_attribution` whitelist.

Two guards, both about whether a partner's numbers mean anything:

- **`previously_new_record?`** — stamp only on the create. Someone who signed up months ago and today happens to arrive through a referral link was not acquired by that channel; crediting them would be last-touch and would inflate conversions.
- **`signup_attribution.nil?`** — never overwrite an existing value.

Failures are logged and swallowed. Analytics metadata must not break a sign-in that already succeeded.

## 2. `GET /api/levelcode/v1/admin/referrals?from=&to=`

`Levelcode::ReferralReport` returns one row per (channel, handle) with clicks / signups / paid, plus totals.

The three columns come from three unrelated sources joined **only by channel name** — clicks are anonymous, so there is no per-person path through the funnel. The response is deliberately explicit about the limits:

| Column | Source | Caveat |
| --- | --- | --- |
| `clicks` | `clicks` × `links`, channel parsed from `links.original_url`, bots excluded | A click row carries no destination of its own, so editing a link re-attributes its past clicks |
| `signups` | `users.signup_attribution->>'source'`, ranged on `users.created_at` | Only LevelCode writes this column, so it needs no extra product scoping |
| `paid` | non-free `levelcode` credit_wallet with budget, mirroring the private `FreeTier.paid?` including its 3-day grace | See below |

**There is no "became paid at" timestamp anywhere in the schema.** `credit_wallets.period_start` is overwritten on every renewal, and `users.levelcode_stripe_id` is a dead column. So `paid` can only mean *signed up in range AND paying now* — never "converted during this range". That is returned as `paid_basis` so the column cannot quietly be read as a conversion rate.

`unattributed_signups` is returned alongside, so the table is never mistaken for total signups.

## 3. The new-signup notification email

It was thin.ly-branded ("Smart URL Shortener" footer) and contained nothing but an address. Now:

- LevelCode wordmark, and the **referral channel + partner handle** in a callout **and in the subject line**, so a run of these is scannable from the inbox list without opening anything.
- Signup method (Email / GitHub / Google), time, landing path, user id.
- `layout false` with self-contained inline styles, following `LevelcodeAuthMailer`. The shared `mailer` layout is thin.ly's and is left alone, so thin.ly's own emails are unaffected.
- A text part, and both variants are previewable at `/rails/mailers/user_mailer`.

`UserNotifier` moves from `after_create` to `after_commit on: :create` — enqueueing inside the transaction lets Sidekiq pick the job up before the row is visible — and delays one minute, because the OAuth stamp lands just after the create. Sending immediately would race it and report every OAuth signup as organic.

## Verification

`473 examples, 0 failures` across `spec/models`, `spec/mailers`, `spec/workers`, `spec/requests/levelcode`, `spec/requests/api/levelcode`.

New coverage: the referral endpoint (channel grouping and handles, bot exclusion, non-product links ignored, paid predicate, date ranges on both clicks and signups, `paid_basis`, 400 on a bad date) and OAuth attribution (stamped on create, **not** stamped for an existing user, unparseable blob ignored, non-whitelisted params dropped). The mailer and notifier specs were rewritten for the new contract.

## Note for deploy

`LEVELCODE_MAIL_FROM` still falls back to `notifications@thin.ly`. Set it to a levelcode.ai sender once that domain is verified with the mail provider — the template and branding are already LevelCode.
