### PR TITLE
feat(levelcode): per-link breakdown behind each referral channel row

### DIFF
--- a/app/services/levelcode/referral_report.rb
+++ b/app/services/levelcode/referral_report.rb
@@ -69,6 +69,7 @@ module Levelcode
       clicks   = clicks_by_channel(range)
       signups  = signups_by_channel(range)
       paid     = paid_by_channel(range)
+      links    = links_by_channel(range)
 
       rows = (clicks.keys | signups.keys | paid.keys).map do |key|
         channel, handle = key
@@ -77,7 +78,8 @@ module Levelcode
           handle: handle.presence,
           clicks: clicks[key].to_i,
           signups: signups[key].to_i,
-          paid: paid[key].to_i
+          paid: paid[key].to_i,
+          links: links[key] || []
         }
       end
       rows.sort_by! { |r| [ -r[:signups], -r[:clicks], r[:channel].to_s ] }
@@ -100,6 +102,23 @@ module Levelcode
     end
 
     # --- pieces ---------------------------------------------------------------
+
+    # Per-link breakdown of the clicks column: WHICH short links produced a channel's clicks,
+    # keyed by the same (channel, handle) as the funnel rows. Click-driven like clicks_by_channel,
+    # so a marketing link with zero clicks in range is absent and a signup-only row gets an empty
+    # list — the breakdown explains the clicks number, it does not inventory every link.
+    def links_by_channel(range)
+      counts = Click.human_traffic
+                    .joins(:link)
+                    .where(created_at: range)
+                    .where("links.original_url ~* ?", MARKETING_URL_REGEX)
+                    .group(CHANNEL_SQL, HANDLE_SQL, Arel.sql("links.lookup_code"), Arel.sql("links.original_url"))
+                    .count
+      grouped = counts.each_with_object(Hash.new { |h, k| h[k] = [] }) do |((channel, handle, code, dest), n), out|
+        out[[ channel, handle ]] << { lookup_code: code, destination: dest, clicks: n }
+      end
+      grouped.transform_values { |list| list.sort_by { |l| -l[:clicks] } }
+    end
 
     # Human clicks in range on links whose destination points at the product, grouped by the
     # channel + handle encoded in that destination.
@@ -169,7 +188,7 @@ module Levelcode
       start.beginning_of_day..finish.end_of_day
     end
 
-    private_class_method :clicks_by_channel, :signups_by_channel, :paid_by_channel,
+    private_class_method :clicks_by_channel, :signups_by_channel, :paid_by_channel, :links_by_channel,
                          :source_sql, :handle_sql, :date_range
   end
 end

--- a/spec/requests/api/levelcode/v1/admin_referrals_spec.rb
+++ b/spec/requests/api/levelcode/v1/admin_referrals_spec.rb
@@ -60,6 +60,30 @@ RSpec.describe "Api::Levelcode::V1::Admin referrals", type: :request do
       expect(body["rows"].map { |r| r["channel"] }).not_to include(nil, "")
     end
 
+    it "breaks a channel's clicks down per link, sorted by clicks, keyed like the row" do
+      owner = create(:user, email: "owner-links@example.com")
+      # lookup codes are model-generated on create — assert against the real ones
+      big   = create(:link, user: owner, original_url: "https://levelcode.ai/ai?linkedin=anastasia")
+      small = create(:link, user: owner, original_url: "https://levelcode.ai/pricing?linkedin=anastasia")
+      3.times { Click.create!(link: big, is_bot: false, created_at: 1.day.ago) }
+      Click.create!(link: small, is_bot: false, created_at: 1.day.ago)
+
+      get "/api/levelcode/v1/admin/referrals"
+      row = row_for(response.parsed_body, "linkedin")
+      expect(row["clicks"]).to eq(4)
+      expect(row["links"]).to eq([
+        { "lookup_code" => big.lookup_code, "destination" => "https://levelcode.ai/ai?linkedin=anastasia", "clicks" => 3 },
+        { "lookup_code" => small.lookup_code, "destination" => "https://levelcode.ai/pricing?linkedin=anastasia", "clicks" => 1 }
+      ])
+    end
+
+    it "gives a signup-only row an empty links list (the breakdown explains clicks, not signups)" do
+      create(:user, email: "s@example.com", signup_attribution: attribution("youtube", "koderrsha"))
+
+      get "/api/levelcode/v1/admin/referrals"
+      expect(row_for(response.parsed_body, "youtube")).to include("clicks" => 0, "links" => [])
+    end
+
     it "counts human clicks per channel from the link destination, excluding bots" do
       owner = create(:user, email: "owner@example.com")
       link = create(:link, user: owner, original_url: "https://levelcode.ai/ai?linkedin=anastasia")


### PR DESCRIPTION
Each `/admin/referrals` funnel row now carries `links` — the short links that produced its clicks (`{lookup_code, destination, clicks}`, clicks-sorted, keyed by the row's channel+handle). Click-driven like the clicks column: zero-click links are absent; signup-only rows get `[]`. This makes the **other** bucket actionable — you can see exactly which unattributed links collect clicks and fix their destinations. 14 examples green, rubocop clean. Frontend consumer lands on onetime `feat/referral-dashboard`.