### PR TITLE
P1 fix(levelcode): Google sign-up rejected every new account

### DIFF
--- a/app/services/levelcode/provider_oauth.rb
+++ b/app/services/levelcode/provider_oauth.rb
@@ -69,7 +69,19 @@ module Levelcode
       payload = verify_google_id_token(id_token)
       return nil unless payload
 
-      User.from_google(payload)
+      # `terms_accepted: true` is REQUIRED, not decorative. User has
+      # `validates :terms_accepted, acceptance: { accept: true }, on: :create`; `from_google`
+      # defaults the flag to FALSE, so omitting it made `create` return an UNSAVED record.
+      # The callers only ask `user&.persisted?`, so that surfaced as a bare
+      # `?error=oauth_failed` and broke EVERY new Google signup — web and editor — while
+      # existing users kept working, because they take the `find_by` branch and never validate
+      # on :create. That asymmetry is why it read as a browser or provider flake.
+      #
+      # `true` is the honest value, and the same one the GitHub sibling below has always passed:
+      # /ai/login states "By continuing you agree to the Terms of Service and Privacy Policy"
+      # directly above both provider buttons, and `stamp_terms_acceptance` records the version
+      # and timestamp so the acceptance is auditable.
+      persisted_or_logged(User.from_google(payload, terms_accepted: true), provider: "google")
     end
 
     # Build the provider `authorize` URL the browser is redirected to. `state` is
@@ -204,14 +216,36 @@ module Levelcode
         user.update(provider: provider, uid: uid) if user.uid.blank?
         user
       else
-        User.create(
-          provider: provider,
-          uid: uid,
-          email: email,
-          password: Devise.friendly_token[0, 20],
-          terms_accepted: true
+        persisted_or_logged(
+          User.create(
+            provider: provider,
+            uid: uid,
+            email: email,
+            password: Devise.friendly_token[0, 20],
+            terms_accepted: true
+          ),
+          provider: provider
         )
       end
+    end
+
+    # A rejected signup must never leave the logs silent again.
+    #
+    # `User.create` returns an UNSAVED record when validation fails, and every caller here
+    # collapses that to `user&.persisted?` — so a validation error and a network failure at the
+    # provider produced the byte-identical `?error=oauth_failed`, with nothing anywhere naming
+    # the attribute at fault. That is how a total signup outage stayed invisible: the requests
+    # were 302s, the error rate looked normal, and only the conversion rate moved.
+    #
+    # Returns the record unchanged; this is a logging seam, not a control-flow one.
+    def persisted_or_logged(user, provider:)
+      return user if user.nil? || user.persisted?
+
+      Rails.logger.error(
+        "[Levelcode OAuth] #{provider} sign-up rejected by validation: " \
+        "#{user.errors.full_messages.join('; ').presence || 'no error messages'}"
+      )
+      user
     end
 
     # --- HTTP helpers --------------------------------------------------------

--- a/spec/services/levelcode/provider_oauth_spec.rb
+++ b/spec/services/levelcode/provider_oauth_spec.rb
@@ -44,4 +44,76 @@ RSpec.describe Levelcode::ProviderOAuth do
       expect(url).to include(CGI.escape("https://levelcode.ai/ai/auth/callback"))
     end
   end
+
+  # The outage this file previously could not have caught.
+  #
+  # Everything above tests the URL we send the browser TO. Nothing tested what happens when it
+  # comes BACK, so a Google sign-in that never produced a user still passed the whole suite.
+  # These start one step later — at a verified id_token payload — and assert the only outcome
+  # that matters: a person who has never signed in before ends up with an account.
+  describe "signing in a brand-new person" do
+    let(:payload) do
+      { "sub" => "google-uid-1", "email" => "brand-new@example.com", "email_verified" => true }
+    end
+
+    # Stub only the two steps that leave the process — the token exchange and Google's signature
+    # check — so the assertions run through the REAL google_user, including the terms flag and
+    # the logging seam. Stubbing User.from_google instead would test nothing: that is precisely
+    # the call whose arguments were wrong.
+    def sign_in_with_google
+      allow(described_class).to receive(:google_exchange_code).and_return("id.token.stub")
+      allow(described_class).to receive(:verify_google_id_token).and_return(payload)
+      described_class.google_user(code: "auth-code", redirect_uri: "https://levelcode.ai/ai/auth/callback")
+    end
+
+    before { allow(Stripe::Customer).to receive(:create).and_return(double(id: "cus_spec")) }
+
+    it "GOOGLE creates the account (regression: every new signup was rejected)" do
+      user = sign_in_with_google
+
+      expect(user.persisted?).to be(true),
+        "new Google signup rejected: #{user.errors.full_messages.inspect}"
+      expect(user.email).to eq("brand-new@example.com")
+      expect(user.provider).to eq(User::GOOGLE_PROVIDER)
+    end
+
+    it "records the acceptance shown on /ai/login, rather than merely passing validation" do
+      # `acceptance:` validators are satisfied by a virtual attribute, so "it saved" is not proof
+      # the acceptance was actually written down. The audit trail is the point.
+      user = sign_in_with_google
+
+      expect(user.terms_accepted).to be(true)
+      expect(user.terms_accepted_at).to be_present
+      expect(user.terms_accepted_version).to eq(User::TERMS_VERSION)
+    end
+
+    it "GITHUB creates the account too — the control that stayed green throughout" do
+      user = described_class.send(:find_or_create_oauth_user,
+                                  provider: "github", uid: "gh-1", email: "gh-new@example.com")
+
+      expect(user.persisted?).to be(true), user.errors.full_messages.inspect
+      expect(user.terms_accepted_at).to be_present
+    end
+
+    it "an EXISTING person signs in unchanged — the asymmetry that hid the outage" do
+      # Validation is `on: :create`, so returning users never hit it. Chrome, Firefox and mobile
+      # all "worked" for anyone with an account, which is why this looked like a browser bug.
+      existing = User.create!(provider: User::GOOGLE_PROVIDER, uid: "google-uid-1",
+                              email: "brand-new@example.com", password: "password123",
+                              terms_accepted: true)
+
+      expect(sign_in_with_google.id).to eq(existing.id)
+    end
+
+    it "names the failing attribute in the log instead of failing silently" do
+      # The outage was invisible because a validation rejection and a provider outage produced
+      # the identical `?error=oauth_failed`. Anything that stops a signup must say so.
+      allow(Rails.logger).to receive(:error)
+      allow(User).to receive(:from_google).and_return(User.new.tap(&:validate))
+
+      sign_in_with_google
+
+      expect(Rails.logger).to have_received(:error).with(/google sign-up rejected by validation/i)
+    end
+  end
 end


### PR DESCRIPTION
## What is broken

**Signing in with Google on levelcode.ai cannot create an account.** Every brand-new person is bounced to `/ai/login?error=oauth_failed`. This is the reason for no new signups.

Two corrections to the report, both from the attached logs:

- **It is not Firefox-specific.** `18:37:58` in the same log is a **Chrome** callback that fails identically. What actually predicts the outcome is whether the Google account already has a user.
- **It is not only the website.** `ProviderOAuth.google_user` is also called by `api/levelcode/v1/auth_controller.rb:39`, so **editor Google sign-in is broken the same way**. GitHub is unaffected on both surfaces.

## Root cause

```ruby
# app/services/levelcode/provider_oauth.rb:72
User.from_google(payload)     # terms_accepted defaults to nil -> false
```

`User` carries `validates :terms_accepted, acceptance: { accept: true }, on: :create`. With the flag false, `create` returns an **unsaved** record. `google_user` hands that back to callers that only ask `user&.persisted?` — so a validation rejection becomes a bare `?error=oauth_failed`.

Reproduced before touching anything:

```
persisted? false   errors=["Terms accepted must be accepted"]   terms_accepted=false
```

**`on: :create` is the entire asymmetry.** Returning users take the `find_by` branch and never validate, so they kept signing in from every browser while no new account could be created in any of them. That is why it looked like a browser bug.

The GitHub sibling twelve lines below has always passed `terms_accepted: true`. Google never did.

## The fix

Google now passes it too. `true` is the honest value, not a rubber stamp: `/ai/login` states *"By continuing you agree to the Terms of Service and Privacy Policy"* directly above both provider buttons ([LoginPage.tsx:139](https://github.com/systemu-net/onetime/blob/develop/src/levelcode/pages/LoginPage.tsx#L139)), and `stamp_terms_acceptance` writes the version and timestamp so acceptance stays auditable.

## Why nobody saw it

A rejected sign-up logged **nothing**. A validation failure and a network failure at Google produced byte-identical output: a 302, a normal error rate, no attribute named anywhere. Only the conversion rate moved. `persisted_or_logged` now names the failing attribute on the way past.

## Tests

The existing spec covered only the authorize URL we send the browser **to** — never what happens when it comes **back** — so a Google sign-in that produced no user passed the entire suite. Five specs now start at a verified id_token and assert the outcome that matters.

They stub only the two steps that leave the process (token exchange, signature check) and run through the real `google_user`. Stubbing `User.from_google` would have tested nothing — that call *is* the defect.

| bypass | result |
| --- | --- |
| revert `terms_accepted: true` | **2 fail** — new-account + audit-trail specs |
| remove the logging seam | **1 fail** — silent-failure spec |

151 examples green across `services/levelcode`, `models/user_spec.rb`, `requests/levelcode`. Rubocop clean.

## Follow-up, not in this PR

`before_validation :create_stripe_customer, on: :create` runs **before** validation, so **every failed signup since this shipped created an orphan Stripe customer** with no user behind it. Those need reconciling, and the callback belongs on `before_create`. Filed separately to keep this deploy small.