### PR TITLE
chore(db): drop the phantom levelcode_stripe_id column

### DIFF
--- a/STRIPE_ORPHAN_CUSTOMER_CLEANUP.md
+++ b/STRIPE_ORPHAN_CUSTOMER_CLEANUP.md
@@ -49,10 +49,10 @@ since  = Time.zone.parse("2026-07-22")
 cutoff = 1.hour.ago   # ignore in-flight signups: they have a customer, not yet a committed row
 
 # Which columns actually hold a Stripe customer id, asked of the database rather than
-# assumed. `levelcode_stripe_id` is in db/schema.rb but NOT in production — it was added
-# to the schema by an annotate run with no migration behind it, so databases built by
-# `db:schema:load` (development, test) have it and production does not. Asking
-# `column_names` makes this block correct on both.
+# assumed. `levelcode_stripe_id` used to be in db/schema.rb but never in production, so this
+# had to tolerate both shapes; RemoveLevelcodeStripeIdFromUsers has since dropped it
+# everywhere. Kept as an intersection anyway — it costs nothing and stays correct against
+# an older database.
 id_cols = User.column_names & %w[stripe_id levelcode_stripe_id]
 puts "matching on: #{id_cols.join(', ')}"
 
@@ -144,12 +144,12 @@ Two limits no amount of classification fixes:
   equally orphaned, but they are not this outage.
 - The `auth_events` failure rows carry **no email** (the OAuth callback has no user by then), so
   they corroborate the count and time span, not which customers are which.
-- `levelcode_stripe_id` is in `db/schema.rb` and in the model annotations but **does not exist in
-  the production database**. It was introduced by an annotate run (`b7b2cfc`) with no migration
-  behind it, so databases built by `db:schema:load` have it while production, built by migrations,
-  never did — and `db:migrate` will not create it, because nothing defines it. Step 1 asks
-  `User.column_names` instead of assuming, and prints which columns it matched on. Worth fixing
-  separately: either add a real migration or drop it from the schema.
+- `levelcode_stripe_id` was in `db/schema.rb` and the model annotations but **never existed in the
+  production database** — introduced by an annotate run (`b7b2cfc`) with no migration behind it, so
+  databases built by `db:schema:load` had it while production, built by migrations, did not. This
+  broke the first production run of step 1 with `PG::UndefinedColumn`.
+  `RemoveLevelcodeStripeIdFromUsers` has since dropped it from the schema and from every database
+  that had it. `users.stripe_id` is, and always was, the only column holding a Stripe customer id.
 
 ## Step 3 — Delete
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,7 +21,6 @@
 #  uid                    :string
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
-#  levelcode_stripe_id    :string
 #  stripe_id              :string
 #
 # Indexes
@@ -29,7 +28,6 @@
 #  index_users_on_email                 (email) UNIQUE
 #  index_users_on_jti                   (jti) UNIQUE
 #  index_users_on_last_seen_at          (last_seen_at)
-#  index_users_on_levelcode_stripe_id   (levelcode_stripe_id) UNIQUE WHERE (levelcode_stripe_id IS NOT NULL)
 #  index_users_on_provider_and_uid      (provider,uid) UNIQUE
 #  index_users_on_reset_password_token  (reset_password_token) UNIQUE
 #

--- a/db/migrate/20260729022150_remove_levelcode_stripe_id_from_users.rb
+++ b/db/migrate/20260729022150_remove_levelcode_stripe_id_from_users.rb
@@ -1,0 +1,36 @@
+class RemoveLevelcodeStripeIdFromUsers < ActiveRecord::Migration[7.2]
+  # `users.levelcode_stripe_id` never had a migration behind it. It entered db/schema.rb in
+  # b7b2cfc ("Add annotations", 2026-07-22), a commit that touched only the schema dump and
+  # the annotation comments: an annotate run regenerated the schema from a local database
+  # where the column had been added by hand, and that snapshot was committed.
+  #
+  # So whether it exists depends on how each database was built:
+  #
+  #   db:schema:load  (development, test, CI)  -> column present, always NULL
+  #   migrations      (production)             -> column absent entirely
+  #
+  # Which is why both directions are guarded. An unconditional `remove_column` would raise
+  # PG::UndefinedColumn on production, where there is nothing to remove — the migration has
+  # to be a no-op there while still cleaning up every database that loaded the schema.
+  #
+  # Nothing reads or writes the column: every Stripe customer id the application has ever
+  # stored lives in `users.stripe_id`. Dropping it makes db/schema.rb describe production
+  # accurately again, which it has not done since 2026-07-22.
+  def up
+    return unless column_exists?(:users, :levelcode_stripe_id)
+
+    remove_column :users, :levelcode_stripe_id
+  end
+
+  # Restores the pre-migration schema. Postgres drops the dependent index along with the
+  # column, so rolling back has to recreate the index as well as the column.
+  def down
+    return if column_exists?(:users, :levelcode_stripe_id)
+
+    add_column :users, :levelcode_stripe_id, :string
+    add_index :users, :levelcode_stripe_id,
+              unique: true,
+              where: "levelcode_stripe_id IS NOT NULL",
+              name: "index_users_on_levelcode_stripe_id"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_07_22_120001) do
+ActiveRecord::Schema[7.2].define(version: 2026_07_29_022150) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -389,12 +389,10 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_22_120001) do
     t.string "role", default: "member", null: false
     t.string "last_country"
     t.datetime "last_seen_at"
-    t.string "levelcode_stripe_id"
     t.jsonb "signup_attribution"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["jti"], name: "index_users_on_jti", unique: true
     t.index ["last_seen_at"], name: "index_users_on_last_seen_at"
-    t.index ["levelcode_stripe_id"], name: "index_users_on_levelcode_stripe_id", unique: true, where: "(levelcode_stripe_id IS NOT NULL)"
     t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -21,7 +21,6 @@
 #  uid                    :string
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
-#  levelcode_stripe_id    :string
 #  stripe_id              :string
 #
 # Indexes
@@ -29,7 +28,6 @@
 #  index_users_on_email                 (email) UNIQUE
 #  index_users_on_jti                   (jti) UNIQUE
 #  index_users_on_last_seen_at          (last_seen_at)
-#  index_users_on_levelcode_stripe_id   (levelcode_stripe_id) UNIQUE WHERE (levelcode_stripe_id IS NOT NULL)
 #  index_users_on_provider_and_uid      (provider,uid) UNIQUE
 #  index_users_on_reset_password_token  (reset_password_token) UNIQUE
 #

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -21,7 +21,6 @@
 #  uid                    :string
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
-#  levelcode_stripe_id    :string
 #  stripe_id              :string
 #
 # Indexes
@@ -29,7 +28,6 @@
 #  index_users_on_email                 (email) UNIQUE
 #  index_users_on_jti                   (jti) UNIQUE
 #  index_users_on_last_seen_at          (last_seen_at)
-#  index_users_on_levelcode_stripe_id   (levelcode_stripe_id) UNIQUE WHERE (levelcode_stripe_id IS NOT NULL)
 #  index_users_on_provider_and_uid      (provider,uid) UNIQUE
 #  index_users_on_reset_password_token  (reset_password_token) UNIQUE
 #


### PR DESCRIPTION
Closes the schema drift found while reconciling orphaned Stripe customers (#404, #406, #407).

## The problem

`users.levelcode_stripe_id` **never had a migration**:

```
$ grep -rl levelcode_stripe_id db/migrate/
(nothing)
```

It entered the tree in `b7b2cfc` ("Add annotations", 2026-07-22), a commit touching only `db/schema.rb` and annotation comments — an annotate run regenerated the schema from a local database where the column had been added by hand.

So its existence depended entirely on how a given database was built:

| Built by | Column |
| --- | --- |
| `db:schema:load` (development, test, CI) | present, always `NULL` |
| migrations (production) | **absent** |

And `db:migrate` could never reconcile the two, because nothing defined it.

This was not academic. It broke the first production run of the orphan-customer reconciliation with `PG::UndefinedColumn`, and until now `app/models/user.rb` told every reader that production had a column — and a `UNIQUE` index — that it did not.

Nothing reads or writes it. `users.stripe_id` is, and always was, the only column holding a Stripe customer id.

## Why both directions are guarded

That asymmetry is the entire reason this migration isn't a one-liner:

- **`up`** skips `remove_column` when the column is absent, so it's a clean no-op on production instead of an exception during deploy.
- **`down`** re-adds the column **and** the index, because Postgres drops a dependent index along with its column.

## Verification

All three paths exercised against a real database, not reasoned about:

| Path | Result |
| --- | --- |
| With the column | dropped; `schema.rb` + all 3 annotation blocks lose it; version → `20260729022150` |
| `db:rollback` | column **and** `index_users_on_levelcode_stripe_id` both restored |
| Production shape (column dropped by hand, migration unrun) | `column_exists?` → false, `remove_column` skipped, migration records **without raising** |

That third row is the one that matters — it's exactly what production will do, and it's the case an unguarded `remove_column` would have failed.

1018 examples green, rubocop clean.

## Note on deploying

Migrations are not run automatically here — there's no `db:migrate` in `.platform/` or `.ebextensions/`, and `dump_schema_after_migration = false` in production, so running it there won't rewrite `db/schema.rb`. It needs to be run by hand after deploy, and it will report as a no-op.

The runbook's note is updated in the same commit, since this change falsifies its claim that the column is still in the schema.