### PR TITLE
fix(levelcode): bound the OAuth calls, and ship HSTS + a Secure session cookie

### DIFF
--- a/app/services/levelcode/provider_oauth.rb
+++ b/app/services/levelcode/provider_oauth.rb
@@ -23,6 +23,20 @@ module Levelcode
   module ProviderOAuth
     module_function
 
+    # Every provider call goes through perform_http, and until now NONE of them set a timeout — so each
+    # one inherited Net::HTTP's 60-second defaults. A Google sign-in makes two of these back to back
+    # (token exchange, then the id_token verification's key fetch), so one stalled provider could hold
+    # the browser on a blank spinner for around two minutes before the callback finally gave up and
+    # redirected to /ai/login?error=oauth_failed. Reported as "sign-in is stuck loading".
+    #
+    # These are sized against what the endpoints actually do — a token exchange is a single small POST
+    # to Google or GitHub, not a slow query. Failing in seconds and showing the user an error they can
+    # retry beats succeeding on the rare 30-second call, because a spinner with no end is the one
+    # outcome from which a user cannot recover on their own.
+    OPEN_TIMEOUT  = 5    # seconds to establish the TCP+TLS connection
+    READ_TIMEOUT  = 10   # seconds to wait for the response body
+    WRITE_TIMEOUT = 10   # seconds to send the request body
+
     GITHUB_PROVIDER = "github"
 
     GITHUB_AUTHORIZE_URL = "https://github.com/login/oauth/authorize"
@@ -269,6 +283,9 @@ module Levelcode
     def perform_http(uri, req)
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = (uri.scheme == "https")
+      http.open_timeout  = OPEN_TIMEOUT
+      http.read_timeout  = READ_TIMEOUT
+      http.write_timeout = WRITE_TIMEOUT
       res = http.request(req)
       res.is_a?(Net::HTTPSuccess) ? res.body : nil
     rescue StandardError => e

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,7 +22,20 @@ module Backend
   class Application < Rails::Application
     # Use cookies for session store
     config.middleware.use ActionDispatch::Cookies
-    config.middleware.use ActionDispatch::Session::CookieStore, key: "_your_app_session"
+    # `secure` at the store as well as via ssl_options in production: defence in depth, and it keeps the
+    # attribute visible here rather than only as a side effect of force_ssl three files away. Gated on
+    # the environment because an unconditional `secure: true` means the cookie is never sent over
+    # http://localhost — development and the specs would silently stop being able to hold a session.
+    #
+    # same_site MUST STAY :lax. It is the Rails default, so it is stated explicitly to stop anyone
+    # "hardening" it to :strict — the Google OAuth callback is a cross-site top-level GET, :strict
+    # withholds the cookie on exactly that request, and the sign-in then dies with `session_expired`
+    # because the `state` stashed in the session never comes back. See Levelcode::WebController.
+    config.middleware.use ActionDispatch::Session::CookieStore,
+                          key: "_your_app_session",
+                          secure: Rails.env.production?,
+                          same_site: :lax,
+                          httponly: true
 
     config.api_only = true
     # Initialize configuration defaults for originally generated Rails version.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -48,12 +48,32 @@ Rails.application.configure do
   # Can be used together with config.force_ssl for Strict-Transport-Security and secure cookies.
   config.assume_ssl = true
 
-  # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # Disabled for CloudFront - CloudFront handles SSL termination
-  config.force_ssl = false
-
-  # Skip http-to-https redirect for the default health check endpoint.
-  # config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
+  # Strict-Transport-Security + secure cookies, WITHOUT the http->https redirect.
+  #
+  # `force_ssl` turns on ActionDispatch::SSL, which does three separate jobs: redirect, HSTS, and
+  # flagging cookies `secure`. We want the last two and specifically NOT the first:
+  #
+  #   * The ALB already redirects — verified: http://thin.ly 301s and http://levelcode.ai 302s.
+  #   * The ALB health check hits `/up` over PLAIN HTTP on the instance, and .ebextensions pins
+  #     `MatcherHTTPCode: "200"`. A redirect there is a 301, every instance goes unhealthy, and the
+  #     site is down. `assume_ssl` above should make the redirect unreachable anyway (it marks every
+  #     request as SSL), but "should" is not a thing to bet an outage on, so the redirect is turned
+  #     off explicitly rather than relied upon to never fire.
+  #
+  # Until now this was `force_ssl = false`, so the session cookie shipped WITHOUT `Secure` — it went
+  # in cleartext on any plain-HTTP request — and no HSTS header was sent at all. Both verified on the
+  # wire before this change.
+  #
+  # HSTS starts deliberately SHORT. A browser honours it for the full max-age and there is no way to
+  # take it back early, so this is a week rather than the Rails default of a year. Once a week has
+  # passed with no plain-HTTP breakage, raise `expires` to 1.year — and only then consider
+  # `subdomains: true`, which would commit every present and future subdomain to HTTPS at once.
+  config.force_ssl = true
+  config.ssl_options = {
+    redirect: false,
+    secure_cookies: true,
+    hsts: { expires: 1.week, subdomains: false, preload: false }
+  }
 
   # Log to STDOUT by default
   config.logger = ActiveSupport::Logger.new(STDOUT)

--- a/spec/config/ssl_config_spec.rb
+++ b/spec/config/ssl_config_spec.rb
@@ -1,0 +1,106 @@
+require "rails_helper"
+
+# `config.force_ssl = true` switches on ActionDispatch::SSL, which does THREE separate jobs: redirect
+# http->https, send Strict-Transport-Security, and flag cookies `Secure`. This app wants the last two
+# and specifically not the first, because the ALB health check reaches the instance over plain HTTP.
+#
+# Getting that wrong is not a subtle bug: `.ebextensions/03_healthcheck.config` pins
+# `MatcherHTTPCode: "200"`, so a redirect on /up is a 301, every instance is marked unhealthy, and the
+# site goes down. These specs exist because that is a one-word mistake with an outage attached.
+RSpec.describe "production SSL configuration" do
+  PRODUCTION_RB = Rails.root.join("config/environments/production.rb").freeze
+  HEALTHCHECK_CONFIG = Rails.root.join(".ebextensions/03_healthcheck.config").freeze
+
+  let(:production_source) { File.read(PRODUCTION_RB) }
+
+  # Rack 3 downcases response header names. Looking only for "Location" would make the no-redirect
+  # assertion pass whether or not a redirect happened — it was written that way first, and the
+  # deliberately-failing companion spec below is what exposed it.
+  def location(headers)
+    headers["location"] || headers["Location"]
+  end
+
+  describe "the health check cannot be redirected" do
+    # The mechanism itself, exercised rather than assumed: with `redirect: false`, a plain-HTTP request
+    # passes straight through instead of being bounced to https.
+    it "passes a plain-HTTP /up through untouched" do
+      inner = ->(_env) { [200, { "Content-Type" => "text/plain" }, ["ok"]] }
+      ssl = ActionDispatch::SSL.new(inner, redirect: false, secure_cookies: true,
+                                           hsts: { expires: 1.week, subdomains: false, preload: false })
+
+      status, headers, _body = ssl.call(Rack::MockRequest.env_for("http://levelcode.ai/up"))
+
+      expect(status).to eq(200), "the ALB matcher pins 200; a redirect here marks every instance unhealthy"
+      expect(location(headers)).to be_nil
+    end
+
+    # …and the contrast, so the spec above is not passing for some unrelated reason: the SAME request
+    # WOULD be redirected if the option were flipped back on. This is the outage, reproduced.
+    it "WOULD redirect it if `redirect` were ever turned back on" do
+      inner = ->(_env) { [200, {}, ["ok"]] }
+      ssl = ActionDispatch::SSL.new(inner, redirect: {}, secure_cookies: true, hsts: { expires: 1.week })
+
+      status, headers, _body = ssl.call(Rack::MockRequest.env_for("http://levelcode.ai/up"))
+
+      expect(status).to eq(301)
+      expect(location(headers)).to start_with("https://")
+    end
+
+    it "still needs to care, because the ALB matcher accepts only a 200" do
+      # If the health check were ever loosened to accept 3xx, the guards above would be belt-and-braces
+      # rather than load-bearing — worth knowing, so the two files are read together.
+      health = File.read(HEALTHCHECK_CONFIG)
+      expect(health).to include('MatcherHTTPCode: "200"')
+      expect(health).to include("HealthCheckPath: /up")
+    end
+  end
+
+  describe "what production actually declares" do
+    it "keeps the redirect off" do
+      expect(production_source).to match(/redirect:\s*false/),
+                                   "ActionDispatch::SSL would redirect the plain-HTTP health check"
+    end
+
+    it "turns on the two things we DO want from force_ssl" do
+      expect(production_source).to match(/config\.force_ssl\s*=\s*true/)
+      expect(production_source).to match(/secure_cookies:\s*true/)
+      expect(production_source).to match(/hsts:\s*\{/)
+    end
+
+    it "keeps HSTS conservative until it has been proven in production" do
+      # A browser honours HSTS for the full max-age and there is no way to withdraw it early, so this
+      # ships short and narrow on purpose. Raising `expires` later is a deliberate act; discovering a
+      # year-long commitment after the fact is not.
+      expect(production_source).to match(/expires:\s*1\.week/),
+                                   "raise this deliberately once a week has passed with no breakage"
+      expect(production_source).to match(/subdomains:\s*false/),
+                                   "subdomains: true commits every present AND future subdomain to HTTPS at once"
+      expect(production_source).to match(/preload:\s*false/),
+                                   "preload is effectively permanent — it is baked into browser binaries"
+    end
+
+    it "still assumes SSL behind the load balancer" do
+      # Without this, request.ssl? is false for every proxied request and ActionDispatch::SSL would
+      # never apply HSTS or the Secure flag at all — the change would be silently inert.
+      expect(production_source).to match(/config\.assume_ssl\s*=\s*true/)
+    end
+  end
+
+  describe "the session cookie" do
+    let(:application_source) { File.read(Rails.root.join("config/application.rb")) }
+
+    it "is Secure in production and not in development" do
+      # An unconditional `secure: true` means the cookie is never sent over http://localhost, so nobody
+      # can hold a session in development or in the specs.
+      expect(application_source).to match(/secure:\s*Rails\.env\.production\?/)
+    end
+
+    it "stays SameSite=Lax, because the OAuth callback depends on it" do
+      # :strict withholds the cookie on cross-site top-level GETs — which is exactly what Google's
+      # redirect back to /ai/auth/callback is. The `state` stashed in the session would not come back
+      # and every sign-in would fail with `session_expired`.
+      expect(application_source).to match(/same_site:\s*:lax/)
+      expect(application_source).not_to match(/same_site:\s*:strict/)
+    end
+  end
+end

--- a/spec/requests/api/levelcode/v1/auth_spec.rb
+++ b/spec/requests/api/levelcode/v1/auth_spec.rb
@@ -234,6 +234,12 @@ RSpec.describe 'Api::Levelcode::V1::Auth', type: :request do
         http = instance_double(Net::HTTP)
         allow(Net::HTTP).to receive(:new).and_return(http)
         allow(http).to receive(:use_ssl=)
+        # perform_http now bounds every provider call (provider_oauth.rb: OPEN/READ/WRITE_TIMEOUT).
+        # The double has to permit the setters or it rejects the very calls that stop a stalled
+        # provider hanging the browser; the timeout VALUES are asserted in provider_oauth_spec.rb.
+        allow(http).to receive(:open_timeout=)
+        allow(http).to receive(:read_timeout=)
+        allow(http).to receive(:write_timeout=)
         allow(http).to receive(:request) do |req|
           case req.path
           when '/login/oauth/access_token' then token_res

--- a/spec/services/levelcode/provider_oauth_spec.rb
+++ b/spec/services/levelcode/provider_oauth_spec.rb
@@ -116,4 +116,51 @@ RSpec.describe Levelcode::ProviderOAuth do
       expect(Rails.logger).to have_received(:error).with(/google sign-up rejected by validation/i)
     end
   end
+  # Until this was added, perform_http set NO timeouts, so every provider call inherited Net::HTTP's
+  # 60-second defaults. A Google sign-in makes two of them back to back, so one stalled provider held
+  # the browser on a blank spinner for ~2 minutes before the callback gave up. Reported by customers as
+  # "sign-in is stuck loading".
+  describe "outbound provider HTTP is bounded" do
+    # perform_http is private and every provider call funnels through it, so pinning it here covers the
+    # Google token exchange, the id_token key fetch, and both GitHub calls at once.
+    def perform(http_double)
+      allow(Net::HTTP).to receive(:new).and_return(http_double)
+      allow(http_double).to receive(:use_ssl=)
+      described_class.send(:perform_http, URI.parse("https://oauth2.googleapis.com/token"), double("req"))
+    end
+
+    it "sets a connect, read AND write timeout on every call" do
+      http = double("http")
+      allow(http).to receive(:request).and_return(double("res"))
+      expect(http).to receive(:open_timeout=).with(described_class::OPEN_TIMEOUT)
+      expect(http).to receive(:read_timeout=).with(described_class::READ_TIMEOUT)
+      expect(http).to receive(:write_timeout=).with(described_class::WRITE_TIMEOUT)
+      perform(http)
+    end
+
+    it "keeps the timeouts short enough that a stalled provider cannot outlast a user's patience" do
+      # The failure mode being prevented is a spinner with no end, so the bound that matters is the
+      # WORST CASE for one sign-in: two sequential calls, each able to burn connect + read.
+      worst_case = 2 * (described_class::OPEN_TIMEOUT + described_class::READ_TIMEOUT)
+      expect(worst_case).to be <= 40
+      expect(described_class::OPEN_TIMEOUT).to be >= 2   # not so tight that a slow TLS handshake fails
+    end
+
+    it "turns a timeout into nil rather than an exception, so the callback can show an error" do
+      # perform_http returning nil is what makes oauth_callback redirect to /ai/login?error=oauth_failed.
+      # If a timeout escaped instead, the user would get a 500 — still broken, but now unexplained.
+      http = double("http")
+      allow(http).to receive(:use_ssl=)
+      allow(http).to receive(:open_timeout=)
+      allow(http).to receive(:read_timeout=)
+      allow(http).to receive(:write_timeout=)
+      allow(http).to receive(:request).and_raise(Net::ReadTimeout)
+      allow(Net::HTTP).to receive(:new).and_return(http)
+
+      expect {
+        expect(described_class.send(:perform_http, URI.parse("https://oauth2.googleapis.com/token"), double("req"))).to be_nil
+      }.not_to raise_error
+    end
+  end
+
 end


### PR DESCRIPTION
Three defects found while investigating customer reports of sign-in hanging on mobile. None of them is the whole story — **the leading suspect for the 5G-specific part is that `levelcode.ai` has no AAAA record while every other host in the flow does** (including our own thin.ly), and that fix is in the load balancer, not here. All three of these are real, verified, and worth fixing on their own.

## 1. No timeouts on any provider call

`ProviderOAuth.perform_http` set none, so every call inherited `Net::HTTP`'s 60-second defaults. A Google sign-in makes two back to back — token exchange, then the id_token key fetch — so **one stalled provider could hold the browser on a blank spinner for ~2 minutes** before the callback gave up and redirected to `/ai/login?error=oauth_failed`.

| | before | after |
| --- | --- | --- |
| connect | 60s (default) | **5s** |
| read | 60s (default) | **10s** |
| write | 60s (default) | **10s** |
| worst case, one sign-in | **~120s** | **~30s** |

Failing in seconds with an error the user can retry beats succeeding on the rare 30-second call — a spinner with no end is the one outcome a user cannot recover from on their own.

The existing `rescue StandardError` already covers `Net::OpenTimeout` / `Net::ReadTimeout`, so a timeout still becomes `nil` → an error page, never a 500. That's now pinned by a spec, because narrowing the rescue would silently turn every timeout into a 500.

## 2. No `Secure` on the session cookie, and no HSTS at all

Both verified on the wire before this change: `path=/; httponly; samesite=lax` — no `secure` — and no `Strict-Transport-Security` header. `config.force_ssl` was `false`.

`force_ssl` is now `true`, **with `redirect: false` — deliberately.** That middleware does three jobs and we want only two:

- The ALB **already** redirects (`http://thin.ly` 301s, `http://levelcode.ai` 302s).
- The ALB health check hits `/up` over **plain HTTP**, and `.ebextensions/03_healthcheck.config` pins `MatcherHTTPCode: "200"`. A redirect there is a 301 → every instance unhealthy → **site down**.

`assume_ssl = true` should already make the redirect unreachable, and I verified `ActionDispatch::AssumeSSL` is inserted *before* `ActionDispatch::SSL`:

```
force_ssl           : true
ssl_options         : {redirect: false, secure_cookies: true, hsts: {...}}
AssumeSSL before SSL: true
```

But that's not a thing to bet an outage on, so the redirect is disabled explicitly rather than relied upon never to fire. `spec/config/ssl_config_spec.rb` covers both halves — including one spec that **reproduces the outage** by turning the option back on, so the passing spec can't be passing for an unrelated reason.

**HSTS ships deliberately short: 1 week, no subdomains, no preload.** A browser honours it for the full max-age with no way to withdraw it early. Raise `expires` to `1.year` once a week has passed clean — and only then consider `subdomains: true`, which commits every present *and future* subdomain to HTTPS at once.

## 3. `SameSite` is now explicit, because OAuth depends on it

`same_site: :lax` was already the Rails default; it's stated so nobody "hardens" it to `:strict`. Google's redirect back to `/ai/auth/callback` is a **cross-site top-level GET** — `:strict` withholds the cookie on exactly that request, the `state` stashed in the session never comes back, and every sign-in fails with `session_expired`.

`secure:` is gated on `Rails.env.production?`. Unconditional would mean the cookie is never sent over `http://localhost`, so development and the specs could not hold a session.

## Bypasses

14, each verified by reverting the fix and confirming the failure:

| | |
| --- | --- |
| each timeout dropped individually (3) | ✓ |
| read timeout back to the 60s default | ✓ |
| rescue narrowed so a timeout escapes as a 500 | ✓ |
| `redirect` turned back on — **the outage** | ✓ |
| `force_ssl` reverted | ✓ |
| `secure_cookies` off | ✓ |
| HSTS jumped to a year / all subdomains / preload (3) | ✓ |
| `assume_ssl` off — makes the whole change inert | ✓ |
| cookie made unconditionally `secure` | ✓ |
| `SameSite` hardened to `:strict` | ✓ |

## One spec my change broke

`auth_spec`'s `instance_double(Net::HTTP)` permitted only `use_ssl=` and `request`, so it rejected the new setters. I confirmed it was mine rather than pre-existing (21/21 pass on clean develop) before touching it. The double now allows them; the timeout **values** stay asserted in `provider_oauth_spec`.

Writing these specs also caught one of my own: Rack 3 downcases response headers, so an assertion on `headers["Location"]` was passing whether or not a redirect happened. The deliberately-failing companion spec is what exposed it.

## Not fixed here

The session cookie is still named `_your_app_session`, the Rails template default. Renaming it **logs out every signed-in user**, which doesn't belong in a security patch.

**1030 examples, 0 failures.**