### PR TITLE
fix(levelcode): /ai 301'd to itself forever on a staging host

### DIFF
--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -6,7 +6,15 @@ class StaticController < ApplicationController
   # into /ai so levelcode.ai/pricing → /ai/pricing. (Non-HTML bare paths 404, which
   # is correct — the account app has no non-HTML bare endpoints; the JSON API is
   # under /api/levelcode/v1/*.)
-  LEVELCODE_HOSTS = %w[levelcode.ai www.levelcode.ai].freeze
+  # ENV-overridable so a staging or tunnel host (ngrok, a preview deploy) can serve the account app.
+  # MUST be set together with LEVELCODE_ORIGIN: overriding the origin alone points the bounce at a host
+  # that is still not recognised as a LevelCode host, and /ai then 301s to itself forever. The
+  # self-redirect guard in #ui makes that misconfiguration render instead of loop, but set both.
+  DEFAULT_LEVELCODE_HOSTS = "levelcode.ai,www.levelcode.ai"
+  def self.parse_hosts(raw)
+    raw.to_s.split(",").map { |h| h.strip.downcase }.reject(&:empty?)
+  end
+  LEVELCODE_HOSTS = parse_hosts(ENV.fetch("LEVELCODE_HOSTS", DEFAULT_LEVELCODE_HOSTS)).freeze
   # Canonical origin LevelCode Cloud lives on. thin.ly bounces any /ai request here so the account app
   # only ever opens on a LevelCode host. ENV-overridable for staging.
   LEVELCODE_ORIGIN = ENV.fetch("LEVELCODE_ORIGIN", "https://levelcode.ai").freeze
@@ -22,6 +30,11 @@ class StaticController < ApplicationController
 
       render "static/ui_levelcode", layout: false
     else
+      # Never bounce a host to itself. If LEVELCODE_ORIGIN resolves to the host already being asked,
+      # a 301 here is an infinite loop — the browser follows it straight back to this action. That is
+      # what a half-applied staging override produces (LEVELCODE_ORIGIN set, LEVELCODE_HOSTS not), and
+      # a config mistake should degrade to "serves the app" rather than to a redirect storm.
+      return render("static/ui_levelcode", layout: false) if ai_path? && origin_is_self?
       return redirect_to("#{LEVELCODE_ORIGIN}#{request.fullpath}", allow_other_host: true, status: :moved_permanently) if ai_path?
 
       render "static/ui", layout: false
@@ -46,7 +59,14 @@ class StaticController < ApplicationController
   private
 
   def levelcode_host?
-    LEVELCODE_HOSTS.include?(request.host)
+    LEVELCODE_HOSTS.include?(request.host.to_s.downcase)
+  end
+
+  # True when the canonical origin IS this request's host — i.e. redirecting would target ourselves.
+  def origin_is_self?
+    URI.parse(LEVELCODE_ORIGIN).host.to_s.casecmp?(request.host.to_s)
+  rescue URI::InvalidURIError
+    false
   end
 
   def ai_path?

--- a/spec/requests/static_spec.rb
+++ b/spec/requests/static_spec.rb
@@ -41,4 +41,61 @@ RSpec.describe "Static host/brand isolation", type: :request do
       expect(response).to redirect_to("/ai")
     end
   end
+
+  # A half-applied staging override — LEVELCODE_ORIGIN pointed at a tunnel while LEVELCODE_HOSTS still
+  # listed only production — made /ai/login 301 to itself, forever. The browser follows the redirect
+  # straight back into this action and the log fills with identical 301s.
+  describe "when the canonical origin IS the host being asked" do
+    before do
+      stub_const("StaticController::LEVELCODE_ORIGIN", "https://thinly.ngrok.app")
+      host! "thinly.ngrok.app"
+    end
+
+    it "serves the account app instead of redirecting to itself" do
+      get "/ai/login"
+      expect(response).to have_http_status(:ok)
+      expect(response).not_to have_http_status(:moved_permanently)
+    end
+
+    it "still serves the shortener shell on a non-/ai path" do
+      get "/"
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "LEVELCODE_HOSTS from the environment" do
+    it "treats a configured tunnel host as a LevelCode host" do
+      stub_const("StaticController::LEVELCODE_HOSTS", %w[levelcode.ai www.levelcode.ai thinly.ngrok.app])
+      host! "thinly.ngrok.app"
+      get "/ai/login"
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "funnels a bare path into /ai on that host, exactly as production does" do
+      stub_const("StaticController::LEVELCODE_HOSTS", %w[levelcode.ai thinly.ngrok.app])
+      host! "thinly.ngrok.app"
+      get "/pricing"
+      expect(response).to redirect_to("/ai/pricing")
+    end
+
+    it "parses a comma list, trimming and dropping blanks" do
+      # The REAL parser, not a copy of it — asserting a re-implementation against itself proves
+      # nothing about the constant the controller actually uses.
+      expect(StaticController.parse_hosts("levelcode.ai, WWW.LevelCode.ai ,thinly.ngrok.app,"))
+        .to eq(%w[levelcode.ai www.levelcode.ai thinly.ngrok.app])
+      expect(StaticController.parse_hosts("")).to eq([])
+      expect(StaticController.parse_hosts(nil)).to eq([])
+    end
+
+    it "builds the constant from the environment, not from a literal" do
+      # Asserted against the SOURCE. The constant is frozen at class load, so nothing a spec sets in
+      # ENV can rebuild it — and comparing the value to parse_hosts(default) passes just as happily
+      # when someone hardcodes the array back, because with no override the two are identical. The
+      # only thing that actually distinguishes them is how the constant is written.
+      src = Rails.root.join("app/controllers/static_controller.rb").read
+      expect(src).to match(/LEVELCODE_HOSTS\s*=\s*parse_hosts\(ENV\.fetch\("LEVELCODE_HOSTS"/),
+                    "LEVELCODE_HOSTS must be built from ENV, or a tunnel host can never serve /ai"
+      expect(StaticController::DEFAULT_LEVELCODE_HOSTS).to include("levelcode.ai")
+    end
+  end
 end


### PR DESCRIPTION
A dev build pointed at an ngrok tunnel produced an endless redirect loop — `/ai/login` logging identical 301s to itself:

```
Started GET "/ai/login" ...
Redirected to https://thinly.ngrok.app/ai/login
Completed 301 Moved Permanently in 0ms
```

## Cause

`LEVELCODE_ORIGIN` is `ENV.fetch`-able and commented "ENV-overridable for staging". `LEVELCODE_HOSTS` was a hardcoded frozen pair.

So you can point the origin at a tunnel, but you **cannot add that tunnel to the host list**. `#ui` then takes the non-LevelCode branch and bounces any `/ai` path to `LEVELCODE_ORIGIN` — which is now the host it is already serving. The browser follows the 301 straight back into the same action.

The staging override was only ever half-usable.

## Two fixes, because either alone leaves a trap

1. **`LEVELCODE_HOSTS` parses a comma list from ENV**, so a tunnel or preview host can be declared a LevelCode host and serve the account app properly — bare-path funnelling included.
2. **`#ui` refuses to redirect a host to itself.** Worth having even when configured correctly: a config mistake should degrade to *serves the app*, not to a redirect storm that reads like an application bug.

```bash
LEVELCODE_ORIGIN=https://thinly.ngrok.app
LEVELCODE_HOSTS=levelcode.ai,www.levelcode.ai,thinly.ngrok.app
```

## Two specs that proved nothing

Worth flagging, because both passed while testing nothing:

- *"parses a comma list the way the constant is built"* re-implemented the `split/strip/reject` expression and asserted the copy matched itself. Extracted the real `parse_hosts`; the spec now calls it.
- *"builds the constant from the environment"* compared `LEVELCODE_HOSTS` to `parse_hosts(default)` — satisfied just as happily by a hardcoded array, since with no override the two values are **identical**. The constant is frozen at class load, so no spec can rebuild it from ENV. The assertion is now against the **source**, which is the only thing that distinguishes the two.

Bypass-verified: self-redirect guard removed (the reported loop), `origin_is_self?` forced false, and the hosts hardcoded again — that last one only caught *after* the spec was fixed to be capable of catching it.

12 examples, 0 failures.